### PR TITLE
Honor SVG fill-rule=evenodd by reversing odd-depth nested subpaths

### DIFF
--- a/packages/svg-to-swiftui-core/content/evenodd-arc-donut.svg
+++ b/packages/svg-to-swiftui-core/content/evenodd-arc-donut.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#000000" fill-rule="evenodd" d="M10,50 A40,40 0 0,1 90,50 A40,40 0 0,1 10,50 Z M30,50 A20,20 0 0,1 70,50 A20,20 0 0,1 30,50 Z"/>
+</svg>

--- a/packages/svg-to-swiftui-core/content/evenodd-arc-donut.swift
+++ b/packages/svg-to-swiftui-core/content/evenodd-arc-donut.swift
@@ -1,0 +1,20 @@
+struct EvenOddArcDonutShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let width = rect.size.width
+        let height = rect.size.height
+        path.move(to: CGPoint(x: 0.1*width, y: 0.5*height))
+        path.addCurve(to: CGPoint(x: 0.5*width, y: 0.1*height), control1: CGPoint(x: 0.1*width, y: 0.2791*height), control2: CGPoint(x: 0.2791*width, y: 0.1*height))
+        path.addCurve(to: CGPoint(x: 0.9*width, y: 0.5*height), control1: CGPoint(x: 0.7209*width, y: 0.1*height), control2: CGPoint(x: 0.9*width, y: 0.2791*height))
+        path.addCurve(to: CGPoint(x: 0.5*width, y: 0.9*height), control1: CGPoint(x: 0.9*width, y: 0.7209*height), control2: CGPoint(x: 0.7209*width, y: 0.9*height))
+        path.addCurve(to: CGPoint(x: 0.1*width, y: 0.5*height), control1: CGPoint(x: 0.2791*width, y: 0.9*height), control2: CGPoint(x: 0.1*width, y: 0.7209*height))
+        path.closeSubpath()
+        path.move(to: CGPoint(x: 0.3*width, y: 0.5*height))
+        path.addCurve(to: CGPoint(x: 0.5*width, y: 0.7*height), control1: CGPoint(x: 0.3*width, y: 0.6105*height), control2: CGPoint(x: 0.3895*width, y: 0.7*height))
+        path.addCurve(to: CGPoint(x: 0.7*width, y: 0.5*height), control1: CGPoint(x: 0.6105*width, y: 0.7*height), control2: CGPoint(x: 0.7*width, y: 0.6105*height))
+        path.addCurve(to: CGPoint(x: 0.5*width, y: 0.3*height), control1: CGPoint(x: 0.7*width, y: 0.3895*height), control2: CGPoint(x: 0.6105*width, y: 0.3*height))
+        path.addCurve(to: CGPoint(x: 0.3*width, y: 0.5*height), control1: CGPoint(x: 0.3895*width, y: 0.3*height), control2: CGPoint(x: 0.3*width, y: 0.3895*height))
+        path.closeSubpath()
+        return path
+    }
+}

--- a/packages/svg-to-swiftui-core/content/evenodd-donut.svg
+++ b/packages/svg-to-swiftui-core/content/evenodd-donut.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#000000" fill-rule="evenodd" d="M0,0 L100,0 L100,100 L0,100 Z M30,30 L70,30 L70,70 L30,70 Z"/>
+</svg>

--- a/packages/svg-to-swiftui-core/content/evenodd-donut.swift
+++ b/packages/svg-to-swiftui-core/content/evenodd-donut.swift
@@ -1,0 +1,18 @@
+struct EvenOddDonutShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let width = rect.size.width
+        let height = rect.size.height
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: width, y: 0))
+        path.addLine(to: CGPoint(x: width, y: height))
+        path.addLine(to: CGPoint(x: 0, y: height))
+        path.closeSubpath()
+        path.move(to: CGPoint(x: 0.3*width, y: 0.7*height))
+        path.addLine(to: CGPoint(x: 0.7*width, y: 0.7*height))
+        path.addLine(to: CGPoint(x: 0.7*width, y: 0.3*height))
+        path.addLine(to: CGPoint(x: 0.3*width, y: 0.3*height))
+        path.closeSubpath()
+        return path
+    }
+}

--- a/packages/svg-to-swiftui-core/content/evenodd-moon.svg
+++ b/packages/svg-to-swiftui-core/content/evenodd-moon.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#000000" fill-rule="evenodd" d="M10,50 L50,10 L90,50 L50,90 Z M55,35 L70,35 L70,50 L55,50 Z"/>
+</svg>

--- a/packages/svg-to-swiftui-core/content/evenodd-moon.swift
+++ b/packages/svg-to-swiftui-core/content/evenodd-moon.swift
@@ -1,0 +1,18 @@
+struct EvenOddMoonShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let width = rect.size.width
+        let height = rect.size.height
+        path.move(to: CGPoint(x: 0.1*width, y: 0.5*height))
+        path.addLine(to: CGPoint(x: 0.5*width, y: 0.1*height))
+        path.addLine(to: CGPoint(x: 0.9*width, y: 0.5*height))
+        path.addLine(to: CGPoint(x: 0.5*width, y: 0.9*height))
+        path.closeSubpath()
+        path.move(to: CGPoint(x: 0.55*width, y: 0.5*height))
+        path.addLine(to: CGPoint(x: 0.7*width, y: 0.5*height))
+        path.addLine(to: CGPoint(x: 0.7*width, y: 0.35*height))
+        path.addLine(to: CGPoint(x: 0.55*width, y: 0.35*height))
+        path.closeSubpath()
+        return path
+    }
+}

--- a/packages/svg-to-swiftui-core/content/evenodd-nested-deep.svg
+++ b/packages/svg-to-swiftui-core/content/evenodd-nested-deep.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#000000" fill-rule="evenodd" d="M0,0 L100,0 L100,100 L0,100 Z M20,20 L80,20 L80,80 L20,80 Z M40,40 L60,40 L60,60 L40,60 Z"/>
+</svg>

--- a/packages/svg-to-swiftui-core/content/evenodd-nested-deep.swift
+++ b/packages/svg-to-swiftui-core/content/evenodd-nested-deep.swift
@@ -1,0 +1,23 @@
+struct EvenOddNestedDeepShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let width = rect.size.width
+        let height = rect.size.height
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: width, y: 0))
+        path.addLine(to: CGPoint(x: width, y: height))
+        path.addLine(to: CGPoint(x: 0, y: height))
+        path.closeSubpath()
+        path.move(to: CGPoint(x: 0.2*width, y: 0.8*height))
+        path.addLine(to: CGPoint(x: 0.8*width, y: 0.8*height))
+        path.addLine(to: CGPoint(x: 0.8*width, y: 0.2*height))
+        path.addLine(to: CGPoint(x: 0.2*width, y: 0.2*height))
+        path.closeSubpath()
+        path.move(to: CGPoint(x: 0.4*width, y: 0.4*height))
+        path.addLine(to: CGPoint(x: 0.6*width, y: 0.4*height))
+        path.addLine(to: CGPoint(x: 0.6*width, y: 0.6*height))
+        path.addLine(to: CGPoint(x: 0.4*width, y: 0.6*height))
+        path.closeSubpath()
+        return path
+    }
+}

--- a/packages/svg-to-swiftui-core/content/nonzero-two-rects.svg
+++ b/packages/svg-to-swiftui-core/content/nonzero-two-rects.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#000000" fill-rule="nonzero" d="M0,0 L100,0 L100,100 L0,100 Z M30,30 L70,30 L70,70 L30,70 Z"/>
+</svg>

--- a/packages/svg-to-swiftui-core/content/nonzero-two-rects.swift
+++ b/packages/svg-to-swiftui-core/content/nonzero-two-rects.swift
@@ -1,0 +1,18 @@
+struct NonZeroTwoRectsShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let width = rect.size.width
+        let height = rect.size.height
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: width, y: 0))
+        path.addLine(to: CGPoint(x: width, y: height))
+        path.addLine(to: CGPoint(x: 0, y: height))
+        path.closeSubpath()
+        path.move(to: CGPoint(x: 0.3*width, y: 0.3*height))
+        path.addLine(to: CGPoint(x: 0.7*width, y: 0.3*height))
+        path.addLine(to: CGPoint(x: 0.7*width, y: 0.7*height))
+        path.addLine(to: CGPoint(x: 0.3*width, y: 0.7*height))
+        path.closeSubpath()
+        return path
+    }
+}

--- a/packages/svg-to-swiftui-core/src/elementHandlers/index.ts
+++ b/packages/svg-to-swiftui-core/src/elementHandlers/index.ts
@@ -159,6 +159,12 @@ export function handleElement(element: ElementNode, options: TranspilerOptions):
   const prevNormalize = options.normalizeWindingCW;
   options.normalizeWindingCW = style.hasFill && style.fillRule !== "evenodd";
 
+  // Expose this element's fill-rule to the path handler. SwiftUI's Path uses
+  // non-zero winding by default, so evenodd paths need their nested subpaths
+  // reversed to produce holes equivalent to SVG's evenodd semantics.
+  const prevFillRule = options.fillRule;
+  options.fillRule = style.fillRule;
+
   let rawLines: string[];
 
   switch (element.tagName) {
@@ -203,6 +209,7 @@ export function handleElement(element: ElementNode, options: TranspilerOptions):
 
   options.strokeExpansion = prevExpansion;
   options.normalizeWindingCW = prevNormalize;
+  options.fillRule = prevFillRule;
 
   // Detect light fills for winding reversal (creates holes under winding fill rule)
   let fillColor = "";

--- a/packages/svg-to-swiftui-core/src/elementHandlers/pathElementHandler/index.ts
+++ b/packages/svg-to-swiftui-core/src/elementHandlers/pathElementHandler/index.ts
@@ -152,6 +152,151 @@ function reverseSubpath(commands: SVGCommand[]): SVGCommand[] {
   return result;
 }
 
+// ---------------------------------------------------------------------------
+// evenodd → nonzero conversion
+//
+// SwiftUI's `Path` renders with the non-zero winding rule by default. SVGs
+// authored with `fill-rule="evenodd"` express "holes" by drawing nested
+// subpaths in the same direction as their parent — even-odd then leaves
+// odd-depth regions unfilled. Under non-zero winding, same-direction nested
+// subpaths add up to a solid fill (no hole).
+//
+// To preserve the visual under non-zero we compute each subpath's containment
+// depth (how many other subpaths it lies inside) and reverse every subpath at
+// an odd depth. After reversal a point inside a nested subpath accumulates a
+// winding total of 0, producing the same hole evenodd would have produced.
+// ---------------------------------------------------------------------------
+
+/** Split a flat command stream into one subpath per MOVE_TO. */
+function splitSubpaths(commands: SVGCommand[]): SVGCommand[][] {
+  const subpaths: SVGCommand[][] = [];
+  let current: SVGCommand[] = [];
+  for (const cmd of commands) {
+    if (cmd.type === SVGPathData.MOVE_TO && current.length > 0) {
+      subpaths.push(current);
+      current = [];
+    }
+    current.push(cmd);
+  }
+  if (current.length > 0) subpaths.push(current);
+  return subpaths;
+}
+
+/** Sample a subpath into a polyline; beziers contribute intermediate points. */
+function sampleSubpathPoints(commands: SVGCommand[]): SimplePoint[] {
+  const points: SimplePoint[] = [];
+  let curX = 0;
+  let curY = 0;
+  for (const cmd of commands) {
+    switch (cmd.type) {
+      case SVGPathData.MOVE_TO:
+      case SVGPathData.LINE_TO:
+        curX = cmd.x;
+        curY = cmd.y;
+        points.push({ x: curX, y: curY });
+        break;
+      case SVGPathData.CURVE_TO: {
+        const x0 = curX;
+        const y0 = curY;
+        for (const t of [0.25, 0.5, 0.75]) {
+          const mt = 1 - t;
+          const px = mt * mt * mt * x0 + 3 * mt * mt * t * cmd.x1 + 3 * mt * t * t * cmd.x2 + t * t * t * cmd.x;
+          const py = mt * mt * mt * y0 + 3 * mt * mt * t * cmd.y1 + 3 * mt * t * t * cmd.y2 + t * t * t * cmd.y;
+          points.push({ x: px, y: py });
+        }
+        curX = cmd.x;
+        curY = cmd.y;
+        points.push({ x: curX, y: curY });
+        break;
+      }
+      case SVGPathData.QUAD_TO: {
+        const x0 = curX;
+        const y0 = curY;
+        for (const t of [0.25, 0.5, 0.75]) {
+          const mt = 1 - t;
+          const px = mt * mt * x0 + 2 * mt * t * cmd.x1 + t * t * cmd.x;
+          const py = mt * mt * y0 + 2 * mt * t * cmd.y1 + t * t * cmd.y;
+          points.push({ x: px, y: py });
+        }
+        curX = cmd.x;
+        curY = cmd.y;
+        points.push({ x: curX, y: curY });
+        break;
+      }
+      case SVGPathData.CLOSE_PATH:
+        break;
+    }
+  }
+  return points;
+}
+
+/** Ray-cast point-in-polygon. Polygon is implicitly closed (last → first). */
+function pointInPolygon(pt: SimplePoint, polygon: SimplePoint[]): boolean {
+  if (polygon.length < 3) return false;
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const a = polygon[i]!;
+    const b = polygon[j]!;
+    const intersects =
+      a.y > pt.y !== b.y > pt.y && pt.x < ((b.x - a.x) * (pt.y - a.y)) / (b.y - a.y || 1e-12) + a.x;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+/**
+ * For each subpath, count how many *other* subpaths contain it — that's its
+ * nesting depth. Reverse every subpath at odd depth so a non-zero fill
+ * produces the same visual that evenodd would have.
+ *
+ * Containment is tested by sampling many probe points along subpath i's
+ * boundary (edge midpoints of the sampled polyline) and checking what
+ * fraction of those probes fall inside subpath j. A single centroid is
+ * unreliable for concentric shapes (donut-style geometry), where both
+ * subpaths share a centroid; using many boundary probes keeps the test
+ * accurate for both Moon-style nesting and centered donuts.
+ */
+function evenOddToNonZero(commands: SVGCommand[]): SVGCommand[] {
+  const subpaths = splitSubpaths(commands);
+  if (subpaths.length <= 1) return commands;
+
+  const sampled = subpaths.map(sampleSubpathPoints);
+
+  // Probes: midpoints of every sampled edge of each subpath. These lie on
+  // subpath i's boundary, so checking "are most of i's probes inside j?" is
+  // a robust containment test independent of where i and j are centered.
+  const probes: SimplePoint[][] = sampled.map((pts) => {
+    if (pts.length < 2) return [];
+    const out: SimplePoint[] = [];
+    for (let k = 0; k < pts.length; k++) {
+      const a = pts[k]!;
+      const b = pts[(k + 1) % pts.length]!;
+      out.push({ x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 });
+    }
+    return out;
+  });
+
+  const result: SVGCommand[] = [];
+  for (let i = 0; i < subpaths.length; i++) {
+    let depth = 0;
+    const myProbes = probes[i]!;
+    if (myProbes.length > 0) {
+      for (let j = 0; j < subpaths.length; j++) {
+        if (i === j) continue;
+        let inside = 0;
+        for (const p of myProbes) if (pointInPolygon(p, sampled[j]!)) inside++;
+        if (inside * 2 > myProbes.length) depth++;
+      }
+    }
+    if (depth % 2 === 1) {
+      result.push(...reverseSubpath(subpaths[i]!));
+    } else {
+      result.push(...subpaths[i]!);
+    }
+  }
+  return result;
+}
+
 /**
  * Check if the first (dominant) subpath is CCW. If so, reverse ALL subpaths
  * to flip their winding while preserving relative winding between them.
@@ -209,6 +354,23 @@ export default function handlePathElement(element: ElementNode, options: Transpi
     options.lastPathId++;
 
     const pathData = new SVGPathData(props.d).toAbs();
+
+    // SwiftUI's Path uses non-zero winding by default. When the SVG declares
+    // fill-rule="evenodd", reverse odd-depth nested subpaths so that a
+    // non-zero fill of the resulting Path produces the same visual as evenodd.
+    if (options.fillRule === "evenodd") {
+      try {
+        const normalized = new SVGPathData(props.d)
+          .toAbs()
+          .normalizeHVZ(false, true, true)
+          .normalizeST()
+          .aToC();
+        const converted = evenOddToNonZero(normalized.commands);
+        return convertPathToSwift(converted, options);
+      } catch {
+        // Fall through to untransformed output on arc/normalization failure.
+      }
+    }
 
     // For filled paths, normalize winding to CW to match addRect/addEllipse
     if (options.normalizeWindingCW) {

--- a/packages/svg-to-swiftui-core/src/index.ts
+++ b/packages/svg-to-swiftui-core/src/index.ts
@@ -90,6 +90,7 @@ function swiftUIGenerator(svgElement: ElementNode, config?: SwiftUIGeneratorConf
     reverseWinding: false,
     normalizeWindingCW: false,
     hasFills: svgHasFills(svgElement),
+    fillRule: "nonzero",
   };
 
   const configWithDefaults = {

--- a/packages/svg-to-swiftui-core/src/tests/index.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/index.test.ts
@@ -70,3 +70,57 @@ test("convert-ln", () => {
   });
   expect(result).toBe(expectedResult);
 });
+
+// evenodd → nonzero conversion: SwiftUI's Path uses non-zero winding by default,
+// so paths with fill-rule="evenodd" need nested subpaths reversed at odd depths
+// to preserve the original hole semantics.
+
+test("convert-evenodd-donut", () => {
+  const rawSVG = loadContentFile("evenodd-donut.svg");
+  const expectedResult = loadContentFile("evenodd-donut.swift");
+  const result = convert(rawSVG, {
+    precision: 4,
+    structName: "EvenOddDonutShape",
+  });
+  expect(result).toBe(expectedResult);
+});
+
+test("convert-evenodd-nested-deep", () => {
+  const rawSVG = loadContentFile("evenodd-nested-deep.svg");
+  const expectedResult = loadContentFile("evenodd-nested-deep.swift");
+  const result = convert(rawSVG, {
+    precision: 4,
+    structName: "EvenOddNestedDeepShape",
+  });
+  expect(result).toBe(expectedResult);
+});
+
+test("convert-evenodd-moon", () => {
+  const rawSVG = loadContentFile("evenodd-moon.svg");
+  const expectedResult = loadContentFile("evenodd-moon.swift");
+  const result = convert(rawSVG, {
+    precision: 4,
+    structName: "EvenOddMoonShape",
+  });
+  expect(result).toBe(expectedResult);
+});
+
+test("convert-evenodd-arc-donut", () => {
+  const rawSVG = loadContentFile("evenodd-arc-donut.svg");
+  const expectedResult = loadContentFile("evenodd-arc-donut.swift");
+  const result = convert(rawSVG, {
+    precision: 4,
+    structName: "EvenOddArcDonutShape",
+  });
+  expect(result).toBe(expectedResult);
+});
+
+test("convert-nonzero-two-rects", () => {
+  const rawSVG = loadContentFile("nonzero-two-rects.svg");
+  const expectedResult = loadContentFile("nonzero-two-rects.swift");
+  const result = convert(rawSVG, {
+    precision: 4,
+    structName: "NonZeroTwoRectsShape",
+  });
+  expect(result).toBe(expectedResult);
+});

--- a/packages/svg-to-swiftui-core/src/types.ts
+++ b/packages/svg-to-swiftui-core/src/types.ts
@@ -19,6 +19,8 @@ export interface TranspilerOptions {
   reverseWinding: boolean;
   normalizeWindingCW: boolean;
   hasFills: boolean;
+  /** Active SVG fill-rule for the current path: "nonzero" | "evenodd". */
+  fillRule: string;
 }
 
 export interface ViewBoxData {


### PR DESCRIPTION
## Summary

  SwiftUI's `Path` always fills with the **non-zero winding rule**. SVGs authored with `fill-rule="evenodd"` rely on *even-odd* fill semantics — nested same-winding subpaths produce holes — so the existing converter silently dropped those holes whenever an SVG used `evenodd`. The fix detects nested subpaths in evenodd paths and reverses every subpath at **odd nesting depth**, so a non-zero fill of the emitted SwiftUI `Path` produces the same visual the SVG originally expressed.

## The bug

  An SVG file like this:

  ```xml
  <path fill-rule="evenodd"
        d="M0,0 L10,0 L10,10 L0,10 Z
           M3,3 L7,3 L7,7 L3,7 Z"/>
  ```

describes a square with a square hole. Both subpaths are CW. Under **even-odd**, the inner subpath cuts out a hole. Under **non-zero** (what SwiftUI uses), both windings sum to a solid fill.
Previously, the converter emitted both subpaths verbatim and ignored `fill-rule`. Visual result: cyan-filled square with no hole.

<img width="463" height="945" alt="IMG_0119" src="https://github.com/user-attachments/assets/47b5af25-834f-4009-9dbd-37fb89aa433b" />

## The fix

When `fill-rule="evenodd"` is set on a `<path>` (or inherited from a parent):

1. Normalize the path data (`H`/`V`/`S`/`T`/`A` resolved to `M`/`L`/`C`/`Q`/`Z`, absolute coordinates).
2. Split into subpaths at each `M`.
3. For each subpath, compute its **nesting depth** — how many other subpaths contain it.
4. Reverse every subpath at **odd depth** so that under non-zero winding the same regions become holes.

This preserves the visual exactly for any nesting depth: depth 0 stays as-is, depth 1 reverses (becomes a hole), depth 2 stays (a filled island inside the hole), depth 3 reverses, and so on.

### Why depth detection uses boundary-probe sampling, not centroids

The naïve approach — "is subpath A's centroid inside subpath B?" — breaks for two real cases:

* **Concentric shapes** (a donut, or the synthetic test in [Image #1]): both subpaths share the same centroid, so centroid-in-polygon is undefined.
* **Non-concentric nested cutouts** (Figma's moon icon, where the inner highlight is off-center inside the crescent): a single sample point can land outside, producing a false negative on one side.

Instead, we sample many probe points along subpath A's own boundary (midpoints of its polyline edges) and ask "what fraction of A's boundary lies inside B?" More than half → A is contained in B. This is robust regardless of where A and B are centered.

## Tests

Added five fixture-based tests in `packages/svg-to-swiftui-core/src/tests/index.test.ts` covering the cases the previous suite didn't exercise. 

 ### Use cases that were missing from the previous suite

Before this PR, no test case exercised:

* Any path with `fill-rule="evenodd"`
* Any path with multiple subpaths where the relationship between subpaths matters
* Containment depth > 1
* Concentric subpaths (where centroid-based heuristics would have failed silently)
* The `aToC` normalization branch in the path handler

Each is now covered.

  ## Visual proof

  Two side-by-side SwiftUI demos comparing the buggy converter output vs. the patched converter output. Both use the synthetic, copyright-clean SVGs above.

  **Synthetic donut** — outer square + concentric inner square, evenodd:

<img width="463" height="945" alt="IMG_0119" src="https://github.com/user-attachments/assets/ec1222e6-7564-465c-bdd0-0a299cea00b6" />

  **3-level nest — depth-parity check** — three concentric squares, evenodd:

<img width="467" height="956" alt="IMG_0120" src="https://github.com/user-attachments/assets/308e8b87-5b2e-4bac-8851-e1c1a197ce77" />

 The 3-level case is the most diagnostic: if odd-depth reversal were applied to *all* nested subpaths instead of just odd-depth ones, the center square would disappear. It stays filled, confirming depth 2 (even) is correctly left alone.

## Compatibility

* Non-evenodd paths are completely unaffected — the new branch is gated on `options.fillRule === "evenodd"`.
* If the path-data normalization step throws (very rare; degenerate arcs), the converter falls back to the original untransformed commands, preserving previous behavior for that path.
* No public API changes. `convert()` signature is unchanged.

## Test plan

[x] `bun install`
[x] `bun run build`
[x] `bun run test` — all suites pass, including the 5 new `convert-evenodd-*` / `convert-nonzero-two-rects` cases