### PR TITLE
ci: build packages before publishing

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -19,6 +19,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
 
+      - name: Build
+        run: bun run build
+
       - name: Create .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"


### PR DESCRIPTION
## Summary
- The Publish workflow ran `bun install` then `changeset publish` with no build step. Since `dist/` is gitignored, the runner had no compiled output and npm warned `No bin file found at dist/cli.js` while publishing empty contents.
- Add a `bun run build` step (mirrors what CI already does) so changesets publishes real artifacts.

## Test plan
- [ ] Merge to main, refresh `NPM_TOKEN` if needed, and re-run the Publish workflow (or push an empty commit) — `svg-to-swiftui-core@0.4.0` and `svg2swiftui@0.2.1` should publish with proper dist contents and the bin file present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)