### PR TITLE
fix(svg2swiftui): resolve workspace dep before publish

### DIFF
--- a/packages/svg2swiftui/CHANGELOG.md
+++ b/packages/svg2swiftui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # svg2swiftui
 
+## 0.2.2
+
+### Patch Changes
+
+- Fix broken `svg-to-swiftui-core` dependency. Previous releases (0.2.0 and 0.2.1) shipped with `"svg-to-swiftui-core": "workspace:*"` in their published manifest because `changeset publish` uses `npm publish` under the hood, which does not resolve the workspace protocol. Installing those versions failed with `EUNSUPPORTEDPROTOCOL`. The dep now uses a literal `^0.4.0` range; bun still links the local workspace package during development.
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/svg2swiftui/package.json
+++ b/packages/svg2swiftui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg2swiftui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI for converting SVG files into SwiftUI Shape structs.",
   "main": "dist/cli.js",
   "bin": {
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "commander": "^12.1.0",
-    "svg-to-swiftui-core": "workspace:*"
+    "svg-to-swiftui-core": "^0.4.0"
   },
   "devDependencies": {
     "@svg-to-swiftui/tsconfig": "workspace:*",


### PR DESCRIPTION
## Summary
- `svg2swiftui@0.2.0` and `@0.2.1` shipped to npm with `"svg-to-swiftui-core": "workspace:*"` in their published manifest. `changeset publish` uses `npm publish` under the hood, and `npm publish` does not resolve the workspace protocol (only pnpm does), so both versions are uninstallable (`EUNSUPPORTEDPROTOCOL`).
- Switch the dep to a literal `^0.4.0` range. Bun workspaces still link the local package by name, so the dev loop is unaffected. Future internal bumps will be handled by changesets' `updateInternalDependencies`.
- Bumps svg2swiftui to 0.2.2.

## Test plan
- [ ] After merge + publish, `npm view svg2swiftui@0.2.2 dependencies` shows `svg-to-swiftui-core: ^0.4.0`.
- [ ] `npx svg2swiftui@0.2.2 --help` works in a clean env.
- [ ] Deprecate the broken versions: `npm deprecate svg2swiftui@"<=0.2.1" "broken workspace:* dependency, use 0.2.2+"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)