### PR TITLE
ci: disable changesets auto-commit

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.1.0/schema.json",
   "changelog": "@changesets/cli/changelog",
-  "commit": true,
+  "commit": false,
   "fixed": [],
   "linked": [],
   "access": "public",


### PR DESCRIPTION
## Summary
- `commit: true` in `.changeset/config.json` makes `@changesets/cli` auto-commit version bumps with a body containing `[skip ci]`.
- When a Version Packages PR is squash-merged, that body becomes the merge commit's body and GitHub Actions skips **every** workflow on the resulting push to main — which is exactly what happened to the svg2swiftui@0.2.2 release: PR #44 merged cleanly but no CI or Publish workflow ran.
- Setting `commit: false` lets `changesets/action` make the commit with its own clean default message, so the publish chain fires reliably regardless of merge mode.
- Merging this PR also unblocks the pending `svg2swiftui@0.2.2` publish (the regular merge commit will trigger CI → Publish, and changesets will see 0.2.2 is unpublished).

## Test plan
- [ ] On merge, CI runs (no `[skip ci]` in the merge commit), then Publish runs via `workflow_run`.
- [ ] `npm view svg2swiftui@0.2.2 dependencies` shows `svg-to-swiftui-core: ^0.4.0`.
- [ ] Future Version Packages PRs from changesets land with a clean commit message and CI runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)