### PR TITLE
Fix comma-separated SVG viewBox parsing

### DIFF
--- a/packages/svg-to-swiftui-core/src/tests/index.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/index.test.ts
@@ -71,6 +71,19 @@ test("convert-ln", () => {
   expect(result).toBe(expectedResult);
 });
 
+test("convert-comma-separated-viewbox", () => {
+  const rawSVG = `
+    <svg width="400" height="564.2679900744417" viewBox="0, 0, 400,564.2679900744417">
+      <path d="M259.712 14.780" />
+    </svg>
+  `;
+
+  const result = convert(rawSVG, { precision: 5 });
+
+  expect(result).toContain("path.move(to: CGPoint(x: 0.64928*width, y: 0.02619*height))");
+  expect(result).not.toContain("NaN");
+});
+
 // evenodd → nonzero conversion: SwiftUI's Path uses non-zero winding by default,
 // so paths with fill-rule="evenodd" need nested subpaths reversed at odd depths
 // to preserve the original hole semantics.

--- a/packages/svg-to-swiftui-core/src/utils.ts
+++ b/packages/svg-to-swiftui-core/src/utils.ts
@@ -62,12 +62,13 @@ export function extractSVGProperties(svg: ElementNode): SVGElementProperties {
     throw new Error("Width and height or viewBox must be provided on <svg> element!");
   }
 
-  // Validiate and parse view box.
+  // Validate and parse viewBox comma-wsp separators defined by the SVG spec.
   const viewBoxElements = String(viewBox)
-    .split(" ")
+    .trim()
+    .split(/[\s,]+/)
     .map((n) => parseFloat(n));
   const [vbx, vby, vbWidth, vbHeight] = viewBoxElements;
-  const viewBoxValid = viewBoxElements.every((value) => !Number.isNaN(value));
+  const viewBoxValid = viewBoxElements.length === 4 && viewBoxElements.every((value) => Number.isFinite(value));
 
   // Parse width and height with units.
   const widthUnit = convertToPixels(width ?? vbWidth ?? "100");


### PR DESCRIPTION
## Summary

- parse SVG `viewBox` values using valid comma-whitespace separators
- require exactly four finite `viewBox` values before accepting them
- add a regression test using the separator format from issue #12

## Root cause

The parser split `viewBox` only on spaces. A value such as `0, 0, 400,564.267...` became three partially parsed numbers, silently defaulting the viewBox height to `100` and producing incorrect coordinates.

## Validation

- `bun run test` — 16 tests passed
- exact SVG from #12 — no `NaN`; first Y coordinate is correctly normalized to `0.02619*height`
- `bun run build` — passed
- `bunx biome check src/utils.ts src/tests/index.test.ts` — passed

Full package lint and typecheck have unrelated failures already present on `main` (existing path-handler formatting and test `import.meta` module configuration).

Fixes #12