### PR TITLE
Support SVG transforms in generated SwiftUI paths

### DIFF
--- a/.changeset/tidy-shapes-transform.md
+++ b/.changeset/tidy-shapes-transform.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": patch
+---
+
+Apply SVG element and group transforms to generated SwiftUI paths.

--- a/packages/svg-to-swiftui-core/src/elementHandlers/groupElementHandler.ts
+++ b/packages/svg-to-swiftui-core/src/elementHandlers/groupElementHandler.ts
@@ -1,5 +1,6 @@
 import type { ElementNode, RootNode } from "svg-parser";
 import { extractStyle } from "../styleUtils";
+import { getSVGTransform, wrapWithSVGTransform } from "../transformUtils";
 import type { TranspilerOptions } from "../types";
 import { handleElement } from "./index";
 
@@ -18,8 +19,9 @@ export default function handleGroupElement(element: ElementNode | RootNode, opti
     // no style to extract
   }
 
-  // Merge this group's style into the inherited parent style chain
-  const mergedParentStyle = { ...options.parentStyle, ...ownStyle };
+  // Transform is applied to the completed group path and is not inherited as style.
+  const { transform: _transform, ...presentationStyle } = ownStyle;
+  const mergedParentStyle = { ...options.parentStyle, ...presentationStyle };
 
   // For each child run the generator, accumulate swift string and return it.
   const acc: string[] = [];
@@ -44,5 +46,5 @@ export default function handleGroupElement(element: ElementNode | RootNode, opti
     options.lastPathId = childOptions.lastPathId;
   }
 
-  return acc;
+  return wrapWithSVGTransform(acc, getSVGTransform(element), options);
 }

--- a/packages/svg-to-swiftui-core/src/elementHandlers/index.ts
+++ b/packages/svg-to-swiftui-core/src/elementHandlers/index.ts
@@ -1,5 +1,6 @@
 import type { ElementNode } from "svg-parser";
 import { extractStyle } from "../styleUtils";
+import { getSVGTransform, wrapWithSVGTransform } from "../transformUtils";
 import type { TranspilerOptions } from "../types";
 import { clampNormalisedSizeProduct } from "../utils";
 import handleCircleElement from "./circleElementHandler";
@@ -245,5 +246,5 @@ export function handleElement(element: ElementNode, options: TranspilerOptions):
     ];
   }
 
-  return resultLines;
+  return wrapWithSVGTransform(resultLines, getSVGTransform(element), options);
 }

--- a/packages/svg-to-swiftui-core/src/tests/index.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/index.test.ts
@@ -84,6 +84,20 @@ test("convert-comma-separated-viewbox", () => {
   expect(result).not.toContain("NaN");
 });
 
+test("convert-translated-group", () => {
+  const rawSVG = `
+    <svg width="150" height="167" viewBox="0 0 150 167">
+      <g transform="translate(-106, -5)">
+        <path d="M112.409713 5 L256 5 L256 172 L106 172 Z" />
+      </g>
+    </svg>
+  `;
+
+  const result = convert(rawSVG, { precision: 6 });
+
+  expect(result).toContain("CGAffineTransform(a: 1, b: 0, c: 0, d: 1, tx: -0.706667*width, ty: -0.02994*height)");
+});
+
 // evenodd → nonzero conversion: SwiftUI's Path uses non-zero winding by default,
 // so paths with fill-rule="evenodd" need nested subpaths reversed at odd depths
 // to preserve the original hole semantics.

--- a/packages/svg-to-swiftui-core/src/tests/transformUtils.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/transformUtils.test.ts
@@ -1,0 +1,21 @@
+import { parseSVGTransform } from "../transformUtils";
+
+test("parse SVG transform functions", () => {
+  expect(parseSVGTransform("translate(-106, -5)")).toEqual({ a: 1, b: 0, c: 0, d: 1, e: -106, f: -5 });
+  expect(parseSVGTransform("matrix(1 2 3 4 5 6)")).toEqual({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 });
+});
+
+test("apply SVG transform lists in declaration order", () => {
+  expect(parseSVGTransform("translate(10 20) scale(2)")).toEqual({ a: 2, b: 0, c: 0, d: 2, e: 10, f: 20 });
+});
+
+test("parse rotation around a center", () => {
+  const transform = parseSVGTransform("rotate(90 10 20)");
+
+  expect(transform.a).toBeCloseTo(0);
+  expect(transform.b).toBeCloseTo(1);
+  expect(transform.c).toBeCloseTo(-1);
+  expect(transform.d).toBeCloseTo(0);
+  expect(transform.e).toBeCloseTo(30);
+  expect(transform.f).toBeCloseTo(10);
+});

--- a/packages/svg-to-swiftui-core/src/transformUtils.ts
+++ b/packages/svg-to-swiftui-core/src/transformUtils.ts
@@ -1,0 +1,172 @@
+import type { ElementNode, RootNode } from "svg-parser";
+import type { TranspilerOptions } from "./types";
+import { clampNormalisedSizeProduct } from "./utils";
+
+export interface AffineTransform {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+  e: number;
+  f: number;
+}
+
+const IDENTITY: AffineTransform = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+
+function multiply(left: AffineTransform, right: AffineTransform): AffineTransform {
+  return {
+    a: left.a * right.a + left.c * right.b,
+    b: left.b * right.a + left.d * right.b,
+    c: left.a * right.c + left.c * right.d,
+    d: left.b * right.c + left.d * right.d,
+    e: left.a * right.e + left.c * right.f + left.e,
+    f: left.b * right.e + left.d * right.f + left.f,
+  };
+}
+
+function translate(tx: number, ty = 0): AffineTransform {
+  return { a: 1, b: 0, c: 0, d: 1, e: tx, f: ty };
+}
+
+function scale(sx: number, sy = sx): AffineTransform {
+  return { a: sx, b: 0, c: 0, d: sy, e: 0, f: 0 };
+}
+
+function rotate(angle: number, cx = 0, cy = 0): AffineTransform {
+  const radians = (angle * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  return {
+    a: cos,
+    b: sin,
+    c: -sin,
+    d: cos,
+    e: cx - cx * cos + cy * sin,
+    f: cy - cx * sin - cy * cos,
+  };
+}
+
+function parseNumbers(value: string): number[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+
+  const numbers = trimmed.split(/[\s,]+/).map(Number);
+  if (numbers.some((number) => !Number.isFinite(number))) {
+    throw new Error(`Invalid SVG transform parameters: ${value}`);
+  }
+  return numbers;
+}
+
+function requireArity(name: string, values: number[], allowed: number[]): void {
+  if (!allowed.includes(values.length)) {
+    throw new Error(`SVG ${name}() expects ${allowed.join(" or ")} parameters, received ${values.length}`);
+  }
+}
+
+function transformFunction(name: string, values: number[]): AffineTransform {
+  switch (name.toLowerCase()) {
+    case "matrix":
+      requireArity(name, values, [6]);
+      return { a: values[0]!, b: values[1]!, c: values[2]!, d: values[3]!, e: values[4]!, f: values[5]! };
+    case "translate":
+      requireArity(name, values, [1, 2]);
+      return translate(values[0]!, values[1]);
+    case "scale":
+      requireArity(name, values, [1, 2]);
+      return scale(values[0]!, values[1]);
+    case "rotate":
+      requireArity(name, values, [1, 3]);
+      return rotate(values[0]!, values[1], values[2]);
+    case "skewx":
+      requireArity(name, values, [1]);
+      return { a: 1, b: 0, c: Math.tan((values[0]! * Math.PI) / 180), d: 1, e: 0, f: 0 };
+    case "skewy":
+      requireArity(name, values, [1]);
+      return { a: 1, b: Math.tan((values[0]! * Math.PI) / 180), c: 0, d: 1, e: 0, f: 0 };
+    default:
+      throw new Error(`Unsupported SVG transform function: ${name}`);
+  }
+}
+
+/** Parse an SVG transform list and apply its functions in the declared order. */
+export function parseSVGTransform(value: string): AffineTransform {
+  const functionPattern = /([a-zA-Z]+)\s*\(([^)]*)\)/g;
+  let matrix = IDENTITY;
+  let lastIndex = 0;
+  let matched = false;
+
+  for (const match of value.matchAll(functionPattern)) {
+    const separator = value.slice(lastIndex, match.index);
+    if (!/^[\s,]*$/.test(separator)) {
+      throw new Error(`Invalid SVG transform list: ${value}`);
+    }
+
+    matrix = multiply(matrix, transformFunction(match[1]!, parseNumbers(match[2]!)));
+    lastIndex = (match.index ?? 0) + match[0].length;
+    matched = true;
+  }
+
+  if (!matched || !/^[\s,]*$/.test(value.slice(lastIndex))) {
+    throw new Error(`Invalid SVG transform list: ${value}`);
+  }
+
+  return matrix;
+}
+
+export function getSVGTransform(element: ElementNode | RootNode): string | undefined {
+  if (element.type !== "element") return undefined;
+
+  const attribute = element.properties?.transform;
+  if (attribute !== undefined && String(attribute).trim()) return String(attribute).trim();
+
+  const style = element.properties?.style;
+  if (typeof style === "string") {
+    const match = /(?:^|;)\s*transform\s*:\s*([^;]+)/i.exec(style);
+    if (match?.[1]?.trim()) return match[1].trim();
+  }
+
+  return undefined;
+}
+
+function formatNumber(value: number, precision: number): string {
+  const rounded = Number(value.toFixed(precision));
+  return String(Object.is(rounded, -0) ? 0 : rounded);
+}
+
+function scaledRuntimeValue(value: number, suffix: "height/width" | "width/height", precision: number): string {
+  const formatted = formatNumber(value, precision);
+  if (formatted === "0") return "0";
+  if (formatted === "1") return suffix;
+  if (formatted === "-1") return `-${suffix}`;
+  return `${formatted}*${suffix}`;
+}
+
+function swiftTransform(matrix: AffineTransform, options: TranspilerOptions): string {
+  const { viewBox, precision } = options;
+  const a = formatNumber(matrix.a, precision);
+  const b = scaledRuntimeValue(matrix.b * (viewBox.width / viewBox.height), "height/width", precision);
+  const c = scaledRuntimeValue(matrix.c * (viewBox.height / viewBox.width), "width/height", precision);
+  const d = formatNumber(matrix.d, precision);
+  const tx = clampNormalisedSizeProduct(formatNumber(matrix.e / viewBox.width, precision), "width");
+  const ty = clampNormalisedSizeProduct(formatNumber(matrix.f / viewBox.height, precision), "height");
+
+  return `CGAffineTransform(a: ${a}, b: ${b}, c: ${c}, d: ${d}, tx: ${tx}, ty: ${ty})`;
+}
+
+export function wrapWithSVGTransform(
+  lines: string[],
+  transform: string | undefined,
+  options: TranspilerOptions,
+): string[] {
+  if (!transform || lines.length === 0) return lines;
+
+  const matrix = parseSVGTransform(transform);
+  options.lastPathId++;
+  const variable = `transformPath${options.lastPathId}`;
+
+  return [
+    `var ${variable} = Path()`,
+    ...lines.map((line) => line.replace(/^path\./, `${variable}.`)),
+    `path.addPath(${variable}.applying(${swiftTransform(matrix, options)}))`,
+  ];
+}

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/group-transform.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/group-transform.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="160" viewBox="0 0 240 160">
+  <g transform="translate(55 20) rotate(18) scale(1.15 0.8)">
+    <rect x="10" y="15" width="110" height="70" rx="12" fill="#2563eb" />
+    <circle cx="65" cy="50" r="20" fill="#2563eb" />
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/swift-template.swift
+++ b/packages/svg-to-swiftui-core/visual-tests/swift-template.swift
@@ -48,6 +48,11 @@ struct Path {
     mutating func addPath(_ other: Path) {
         _path.addPath(other.cgPath)
     }
+    func applying(_ transform: CGAffineTransform) -> Path {
+        var result = Path()
+        result._path.addPath(cgPath, transform: transform)
+        return result
+    }
     mutating func addReversedPath(_ other: Path) {
         struct Elem {
             var type: CGPathElementType


### PR DESCRIPTION
## Summary

- parse SVG `matrix`, `translate`, `scale`, `rotate`, and skew transforms
- apply element and nested group transforms to generated SwiftUI paths
- add unit and visual regression coverage
- add a patch changeset for `svg-to-swiftui-core`

## Validation

- `bun run test` — 20 passed
- `bun run build` — passed
- group transform visual regression — 99.99%
- exact issue #31 SVG visual comparison — 100.00%

Fixes #31