### PR TITLE
Preserve colors in multicolor SVG output

### DIFF
--- a/.changeset/bright-icons-layer.md
+++ b/.changeset/bright-icons-layer.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Preserve solid fill and stroke colors by generating layered SwiftUI views for multicolor SVGs.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # SVG to SwiftUI Converter
 
-Tool to convert SVG to SwiftUI's Shape structure. This approach is much more memory efficient than introducing a SVG library for rendering.
+Tool to convert SVG into native SwiftUI shapes. Multicolor SVGs are emitted as layered SwiftUI views so their original solid colors are preserved.
 
 ## Disclaimer (Before you use this tool)
 

--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,7 @@
       "name": "svg-to-swiftui-core",
       "version": "0.3.5",
       "dependencies": {
+        "color-name": "^1.1.4",
         "svg-parser": "^2.0.4",
         "svg-pathdata": "^6.0.3",
       },

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -5,7 +5,9 @@
 [![Downloads/month](https://img.shields.io/npm/dm/svg-to-swiftui-core.svg)](https://npmjs.org/package/svg-to-swiftui-core)
 [![License](https://img.shields.io/npm/l/svg-to-swiftui-core.svg)](LICENSE.md)
 
-This is the core transpiler code that you can use to convert raw SVG code into SwiftUI Shape struct that you can use directly in your SwiftUI Project.
+This is the core transpiler code that you can use to convert raw SVG code into native SwiftUI structures for your project.
+
+Single-color SVGs produce a tintable `Shape`. SVGs with multiple supported solid fill or stroke colors automatically produce a layered `View` that preserves those colors and their drawing order. Set `preserveColors: false` to force the legacy single-shape output, or `preserveColors: true` to retain the original paint for a single-color SVG.
 
 ## Before we start
 
@@ -59,7 +61,7 @@ You can run the tests by running following command:
 - [x] SVG `<circle>` element
 - [x] SVG `<rect>` element
 - [x] SVG `<ellipse>` element
-- [ ] Fill/stroke styling with colours
+- [x] Solid fill/stroke styling with colours
 - [ ] SVG `<text>` element
 - [ ] SVG `<g>` element with autmatic grouping into sub-paths in SwiftUI
 - [ ] SVG `<polygon>` element

--- a/packages/svg-to-swiftui-core/package.json
+++ b/packages/svg-to-swiftui-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svg-to-swiftui-core",
   "version": "0.4.0",
-  "description": "SVG to SwiftUI Shape converter core package. Will transform the raw SVG code into SwiftUI Shape via the JavaScript API.",
+  "description": "Convert SVG code into native SwiftUI shapes and layered multicolor views.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/index.mjs",
@@ -60,6 +60,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "color-name": "^1.1.4",
     "svg-parser": "^2.0.4",
     "svg-pathdata": "^6.0.3"
   }

--- a/packages/svg-to-swiftui-core/src/color-name.d.ts
+++ b/packages/svg-to-swiftui-core/src/color-name.d.ts
@@ -1,0 +1,4 @@
+declare module "color-name" {
+  const colorNames: Record<string, [number, number, number]>;
+  export default colorNames;
+}

--- a/packages/svg-to-swiftui-core/src/colorUtils.ts
+++ b/packages/svg-to-swiftui-core/src/colorUtils.ts
@@ -1,0 +1,167 @@
+import colorNames from "color-name";
+
+interface RGBAColor {
+  red: number;
+  green: number;
+  blue: number;
+  alpha: number;
+}
+
+const clamp = (value: number) => Math.min(1, Math.max(0, value));
+
+function parseHexColor(value: string): RGBAColor | undefined {
+  const hex = value.slice(1);
+  if (![3, 4, 6, 8].includes(hex.length) || !/^[\da-f]+$/i.test(hex)) return undefined;
+
+  const expanded = hex.length <= 4 ? [...hex].map((component) => `${component}${component}`).join("") : hex;
+  const withAlpha = expanded.length === 6 ? `${expanded}ff` : expanded;
+
+  return {
+    red: parseInt(withAlpha.slice(0, 2), 16) / 255,
+    green: parseInt(withAlpha.slice(2, 4), 16) / 255,
+    blue: parseInt(withAlpha.slice(4, 6), 16) / 255,
+    alpha: parseInt(withAlpha.slice(6, 8), 16) / 255,
+  };
+}
+
+function parseChannel(value: string): number | undefined {
+  const trimmed = value.trim();
+  const number = Number(trimmed.endsWith("%") ? trimmed.slice(0, -1) : trimmed);
+  if (!Number.isFinite(number)) return undefined;
+  return clamp(trimmed.endsWith("%") ? number / 100 : number / 255);
+}
+
+function parseAlpha(value: string): number | undefined {
+  const trimmed = value.trim();
+  const number = Number(trimmed.endsWith("%") ? trimmed.slice(0, -1) : trimmed);
+  if (!Number.isFinite(number)) return undefined;
+  return clamp(trimmed.endsWith("%") ? number / 100 : number);
+}
+
+function parseRGBColor(value: string): RGBAColor | undefined {
+  const match = /^rgba?\((.*)\)$/i.exec(value);
+  if (!match) return undefined;
+
+  const body = match[1]!.trim();
+  let channels: string[];
+  let alpha = "1";
+
+  if (body.includes(",")) {
+    const parts = body.split(",").map((part) => part.trim());
+    if (parts.length !== 3 && parts.length !== 4) return undefined;
+    channels = parts.slice(0, 3);
+    alpha = parts[3] ?? alpha;
+  } else {
+    const [channelPart, alphaPart] = body.split("/").map((part) => part.trim());
+    channels = channelPart!.split(/\s+/);
+    if (channels.length !== 3) return undefined;
+    alpha = alphaPart ?? alpha;
+  }
+
+  const red = parseChannel(channels[0]!);
+  const green = parseChannel(channels[1]!);
+  const blue = parseChannel(channels[2]!);
+  const parsedAlpha = parseAlpha(alpha);
+  if (red === undefined || green === undefined || blue === undefined || parsedAlpha === undefined) return undefined;
+
+  return { red, green, blue, alpha: parsedAlpha };
+}
+
+function parseHue(value: string): number | undefined {
+  const trimmed = value.trim().toLowerCase();
+  const number = Number.parseFloat(trimmed);
+  if (!Number.isFinite(number)) return undefined;
+
+  let degrees = number;
+  if (trimmed.endsWith("turn")) degrees = number * 360;
+  else if (trimmed.endsWith("rad")) degrees = (number * 180) / Math.PI;
+  else if (trimmed.endsWith("grad")) degrees = number * 0.9;
+
+  return ((degrees % 360) + 360) % 360;
+}
+
+function parsePercentage(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed.endsWith("%")) return undefined;
+  const number = Number(trimmed.slice(0, -1));
+  return Number.isFinite(number) ? clamp(number / 100) : undefined;
+}
+
+function parseHSLColor(value: string): RGBAColor | undefined {
+  const match = /^hsla?\((.*)\)$/i.exec(value);
+  if (!match) return undefined;
+
+  const body = match[1]!.trim();
+  let channels: string[];
+  let alpha = "1";
+
+  if (body.includes(",")) {
+    const parts = body.split(",").map((part) => part.trim());
+    if (parts.length !== 3 && parts.length !== 4) return undefined;
+    channels = parts.slice(0, 3);
+    alpha = parts[3] ?? alpha;
+  } else {
+    const [channelPart, alphaPart] = body.split("/").map((part) => part.trim());
+    channels = channelPart!.split(/\s+/);
+    if (channels.length !== 3) return undefined;
+    alpha = alphaPart ?? alpha;
+  }
+
+  const hue = parseHue(channels[0]!);
+  const saturation = parsePercentage(channels[1]!);
+  const lightness = parsePercentage(channels[2]!);
+  const parsedAlpha = parseAlpha(alpha);
+  if (hue === undefined || saturation === undefined || lightness === undefined || parsedAlpha === undefined) {
+    return undefined;
+  }
+
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const section = hue / 60;
+  const secondary = chroma * (1 - Math.abs((section % 2) - 1));
+  const [red, green, blue] =
+    section < 1
+      ? [chroma, secondary, 0]
+      : section < 2
+        ? [secondary, chroma, 0]
+        : section < 3
+          ? [0, chroma, secondary]
+          : section < 4
+            ? [0, secondary, chroma]
+            : section < 5
+              ? [secondary, 0, chroma]
+              : [chroma, 0, secondary];
+  const offset = lightness - chroma / 2;
+  return { red: red + offset, green: green + offset, blue: blue + offset, alpha: parsedAlpha };
+}
+
+function formatComponent(value: number): string {
+  return String(Number(clamp(value).toFixed(4)));
+}
+
+export function parseOpacity(value: string | number | undefined): number {
+  if (value === undefined) return 1;
+  return parseAlpha(String(value)) ?? 1;
+}
+
+export function swiftUIColor(paint: string, opacity = 1): string | undefined {
+  const normalized = paint.trim().toLowerCase();
+  if (normalized === "currentcolor") {
+    const effectiveOpacity = clamp(opacity);
+    return effectiveOpacity === 1 ? "Color.primary" : `Color.primary.opacity(${formatComponent(effectiveOpacity)})`;
+  }
+
+  const namedChannels = colorNames[normalized as keyof typeof colorNames];
+  const color =
+    normalized === "transparent"
+      ? parseHexColor("#00000000")
+      : namedChannels
+        ? { red: namedChannels[0] / 255, green: namedChannels[1] / 255, blue: namedChannels[2] / 255, alpha: 1 }
+        : normalized.startsWith("#")
+          ? parseHexColor(normalized)
+          : (parseRGBColor(normalized) ?? parseHSLColor(normalized));
+  if (!color) return undefined;
+
+  const alpha = clamp(color.alpha * opacity);
+  const channels = `red: ${formatComponent(color.red)}, green: ${formatComponent(color.green)}, blue: ${formatComponent(color.blue)}`;
+  return alpha === 1 ? `Color(${channels})` : `Color(${channels}, opacity: ${formatComponent(alpha)})`;
+}

--- a/packages/svg-to-swiftui-core/src/elementHandlers/index.ts
+++ b/packages/svg-to-swiftui-core/src/elementHandlers/index.ts
@@ -91,6 +91,14 @@ function buildStrokeLines(lines: string[], style: PresentationStyle, options: Tr
   const varName = `strokePath${options.lastPathId}`;
   const strokeCall = `${varName}.strokedPath(StrokeStyle(lineWidth: ${strokeWidthStr}, lineCap: ${lineCap}, lineJoin: ${lineJoin}, miterLimit: ${style.strokeMiterlimit}))`;
 
+  if (options.separatePaintLayer) {
+    return [
+      `var ${varName} = Path()`,
+      ...lines.map((l) => l.replace(/^path\./, `${varName}.`)),
+      `path.addPath(${strokeCall})`,
+    ];
+  }
+
   if (isLightStroke) {
     // Light strokes create holes by ensuring CCW winding
     return [
@@ -236,7 +244,7 @@ export function handleElement(element: ElementNode, options: TranspilerOptions):
   let resultLines = wrapWithStroke(rawLines, style, options);
 
   // For light-fill elements, reverse winding direction to create holes
-  if (isLightFill && resultLines.length > 0) {
+  if (!options.separatePaintLayer && isLightFill && resultLines.length > 0) {
     options.lastPathId++;
     const holeVar = `_hole${options.lastPathId}`;
     resultLines = [

--- a/packages/svg-to-swiftui-core/src/index.ts
+++ b/packages/svg-to-swiftui-core/src/index.ts
@@ -2,8 +2,9 @@ import type { ElementNode } from "svg-parser";
 import { parse } from "svg-parser";
 import { DEFAULT_CONFIG } from "./constants";
 import { handleElement } from "./elementHandlers";
+import { collectPaintDescriptors, collectPaintLayers, type PaintLayer } from "./paintLayerHandler";
 import { createFunctionTemplate, createStructTemplate, createUsageCommentTemplate } from "./templates";
-import type { SwiftUIGeneratorConfig, TranspilerOptions } from "./types";
+import type { SVGElementProperties, SwiftUIGeneratorConfig, TranspilerOptions } from "./types";
 import { extractSVGProperties, getSVGElement } from "./utils";
 
 /**
@@ -51,6 +52,64 @@ function svgHasFills(node: ElementNode, inheritedFill?: string): boolean {
   return false;
 }
 
+function createRootOptions(
+  svgProperties: SVGElementProperties,
+  hasFills: boolean,
+  config?: SwiftUIGeneratorConfig,
+  separatePaintLayer = false,
+): TranspilerOptions {
+  return {
+    ...svgProperties,
+    precision: config?.precision ?? 10,
+    lastPathId: 0,
+    indentationSize: config?.indentationSize ?? 4,
+    currentIndentationLevel: 0,
+    parentStyle: {},
+    fillColors: new Set<string>(),
+    strokeExpansion: 0,
+    reverseWinding: false,
+    normalizeWindingCW: false,
+    hasFills,
+    separatePaintLayer,
+    fillRule: "nonzero",
+  };
+}
+
+function createPathBody(lines: string[]): string[] {
+  return ["var path = Path()", "let width = rect.size.width", "let height = rect.size.height", ...lines, "return path"];
+}
+
+function createMulticolorView(name: string, layers: PaintLayer[], indentationSize: number): string[] {
+  const indentation = " ".repeat(indentationSize);
+  const body: string[] = [
+    "var body: some View {",
+    `${indentation}ZStack {`,
+    ...layers.map((layer, index) => `${indentation}${indentation}Layer${index}().fill(${layer.swiftColor})`),
+    `${indentation}}`,
+    "}",
+  ];
+
+  for (const [index, layer] of layers.entries()) {
+    const pathFunction = createFunctionTemplate({
+      name: "path",
+      parameters: [["in rect", "CGRect"]],
+      returnType: "Path",
+      indent: indentationSize,
+      body: createPathBody(layer.lines),
+    });
+    const layerStruct = createStructTemplate({
+      name: `Layer${index}`,
+      indent: indentationSize,
+      returnType: "Shape",
+      body: pathFunction,
+    });
+    layerStruct[0] = `private ${layerStruct[0]}`;
+    body.push("", ...layerStruct);
+  }
+
+  return createStructTemplate({ name, indent: indentationSize, returnType: "View", body });
+}
+
 export * from "./types";
 
 /**
@@ -76,27 +135,43 @@ export function convert(rawSVGString: string, config?: SwiftUIGeneratorConfig): 
  */
 function swiftUIGenerator(svgElement: ElementNode, config?: SwiftUIGeneratorConfig): string {
   const svgProperties = extractSVGProperties(svgElement);
-
-  // The initial options passed to the first element.
-  const rootTranspilerOptions: TranspilerOptions = {
-    ...svgProperties,
-    precision: config?.precision ?? 10,
-    lastPathId: 0,
-    indentationSize: config?.indentationSize ?? 4,
-    currentIndentationLevel: 0,
-    parentStyle: {},
-    fillColors: new Set<string>(),
-    strokeExpansion: 0,
-    reverseWinding: false,
-    normalizeWindingCW: false,
-    hasFills: svgHasFills(svgElement),
-    fillRule: "nonzero",
-  };
-
   const configWithDefaults = {
     ...DEFAULT_CONFIG,
     ...config,
   };
+
+  const paintDescriptors = config?.preserveColors === false ? [] : collectPaintDescriptors(svgElement);
+  const colorsAreSupported = paintDescriptors.length > 0 && paintDescriptors.every((paint) => paint.swiftColor);
+  const distinctColors = new Set(paintDescriptors.map((paint) => paint.swiftColor));
+  const preservesColors =
+    colorsAreSupported &&
+    (config?.preserveColors === true || (config?.preserveColors === undefined && distinctColors.size > 1));
+
+  if (preservesColors) {
+    const layers = collectPaintLayers(
+      svgElement,
+      createRootOptions(svgProperties, svgHasFills(svgElement), config, true),
+    );
+    const fullSwiftUIView = createMulticolorView(
+      configWithDefaults.structName ?? "SVGView",
+      layers,
+      configWithDefaults.indentationSize ?? 4,
+    );
+
+    if (config?.usageCommentPrefix) {
+      const usageComment = createUsageCommentTemplate({
+        config: configWithDefaults,
+        viewBox: svgProperties.viewBox,
+        preservesColors,
+      });
+      return [...usageComment, "", ...fullSwiftUIView].join("\n");
+    }
+
+    return fullSwiftUIView.join("\n");
+  }
+
+  // The initial options passed to the first element.
+  const rootTranspilerOptions = createRootOptions(svgProperties, svgHasFills(svgElement), config);
 
   // Generate SwiftUI Shape body.
   const generatedBody = handleElement(svgElement, rootTranspilerOptions);
@@ -108,13 +183,7 @@ function swiftUIGenerator(svgElement: ElementNode, config?: SwiftUIGeneratorConf
       parameters: [["in rect", "CGRect"]],
       returnType: "Path",
       indent: configWithDefaults.indentationSize,
-      body: [
-        "var path = Path()",
-        "let width = rect.size.width",
-        "let height = rect.size.height",
-        ...generatedBody,
-        "return path",
-      ],
+      body: createPathBody(generatedBody),
     }),
   );
 

--- a/packages/svg-to-swiftui-core/src/paintLayerHandler.ts
+++ b/packages/svg-to-swiftui-core/src/paintLayerHandler.ts
@@ -1,0 +1,151 @@
+import type { ElementNode } from "svg-parser";
+import { parseOpacity, swiftUIColor } from "./colorUtils";
+import { handleElement } from "./elementHandlers";
+import { filterStyleProps, parseStyle } from "./styleUtils";
+import { getSVGTransform, wrapWithSVGTransform } from "./transformUtils";
+import type { TranspilerOptions } from "./types";
+
+type PresentationStyle = Record<string, string | number>;
+type PaintKind = "fill" | "stroke";
+
+export interface PaintDescriptor {
+  color: string;
+  opacity: number;
+  swiftColor?: string;
+}
+
+export interface PaintLayer extends PaintDescriptor {
+  lines: string[];
+}
+
+const FILLABLE_TAGS = new Set(["path", "circle", "ellipse", "rect", "polygon", "polyline"]);
+
+function extractOwnStyle(element: ElementNode): PresentationStyle {
+  const properties = element.properties;
+  if (!properties) return {};
+
+  const presentation = filterStyleProps(properties);
+  const inline = typeof properties.style === "string" ? parseStyle(properties.style) : {};
+  return { ...presentation, ...inline };
+}
+
+function resolvePaint(value: string, style: PresentationStyle): string {
+  if (value.trim().toLowerCase() !== "currentcolor") return value;
+  const inheritedColor = style.color;
+  return inheritedColor ? String(inheritedColor) : value;
+}
+
+function isVisiblePaint(value: string | undefined): value is string {
+  return value !== undefined && value.trim().toLowerCase() !== "none";
+}
+
+function cloneForPaint(element: ElementNode, ownStyle: PresentationStyle, kind: PaintKind): ElementNode {
+  const { style: _style, ...properties } = element.properties ?? {};
+
+  return {
+    ...element,
+    properties: {
+      ...properties,
+      ...ownStyle,
+      fill: kind === "fill" ? "black" : "none",
+      stroke: kind === "stroke" ? "black" : "none",
+    },
+  };
+}
+
+function visitPaints(
+  element: ElementNode,
+  parentStyle: PresentationStyle,
+  inheritedOpacity: number,
+  ancestorTransforms: string[],
+  visitor: (
+    element: ElementNode,
+    kind: PaintKind,
+    paint: PaintDescriptor,
+    parentStyle: PresentationStyle,
+    ownStyle: PresentationStyle,
+    ancestorTransforms: string[],
+  ) => void,
+): void {
+  const ownStyle = extractOwnStyle(element);
+  const { transform: _transform, opacity: ownOpacity, ...inheritableStyle } = ownStyle;
+  const effectiveStyle = { ...parentStyle, ...inheritableStyle };
+  const opacity = inheritedOpacity * parseOpacity(ownOpacity);
+
+  if (element.tagName === "g" || element.tagName === "svg") {
+    const transform = getSVGTransform(element);
+    const transforms = transform ? [...ancestorTransforms, transform] : ancestorTransforms;
+
+    for (const child of element.children) {
+      if (typeof child === "string" || child.type !== "element") continue;
+      visitPaints(child, effectiveStyle, opacity, transforms, visitor);
+    }
+    return;
+  }
+
+  if (!FILLABLE_TAGS.has(element.tagName ?? "") && element.tagName !== "line") return;
+
+  if (element.tagName !== "line") {
+    const fill = String(effectiveStyle.fill ?? "black");
+    if (isVisiblePaint(fill)) {
+      const color = resolvePaint(fill, effectiveStyle);
+      const paintOpacity = opacity * parseOpacity(effectiveStyle["fill-opacity"]);
+      if (paintOpacity > 0) {
+        visitor(
+          element,
+          "fill",
+          { color, opacity: paintOpacity, swiftColor: swiftUIColor(color, paintOpacity) },
+          parentStyle,
+          ownStyle,
+          ancestorTransforms,
+        );
+      }
+    }
+  }
+
+  const strokeValue = effectiveStyle.stroke;
+  const stroke = strokeValue === undefined ? undefined : String(strokeValue);
+  if (isVisiblePaint(stroke)) {
+    const color = resolvePaint(stroke, effectiveStyle);
+    const paintOpacity = opacity * parseOpacity(effectiveStyle["stroke-opacity"]);
+    if (paintOpacity > 0) {
+      visitor(
+        element,
+        "stroke",
+        { color, opacity: paintOpacity, swiftColor: swiftUIColor(color, paintOpacity) },
+        parentStyle,
+        ownStyle,
+        ancestorTransforms,
+      );
+    }
+  }
+}
+
+export function collectPaintDescriptors(svgElement: ElementNode): PaintDescriptor[] {
+  const paints: PaintDescriptor[] = [];
+  visitPaints(svgElement, {}, 1, [], (_element, _kind, paint) => paints.push(paint));
+  return paints;
+}
+
+export function collectPaintLayers(svgElement: ElementNode, options: TranspilerOptions): PaintLayer[] {
+  const layers: PaintLayer[] = [];
+
+  visitPaints(svgElement, {}, 1, [], (element, kind, paint, parentStyle, ownStyle, ancestorTransforms) => {
+    const childOptions: TranspilerOptions = {
+      ...options,
+      parentStyle,
+      separatePaintLayer: true,
+    };
+    const clone = cloneForPaint(element, ownStyle, kind);
+    let lines = handleElement(clone, childOptions);
+
+    for (let index = ancestorTransforms.length - 1; index >= 0; index--) {
+      lines = wrapWithSVGTransform(lines, ancestorTransforms[index], childOptions);
+    }
+
+    options.lastPathId = childOptions.lastPathId;
+    if (lines.length > 0) layers.push({ ...paint, lines });
+  });
+
+  return layers;
+}

--- a/packages/svg-to-swiftui-core/src/templates.ts
+++ b/packages/svg-to-swiftui-core/src/templates.ts
@@ -3,12 +3,14 @@ import type { SwiftUIGeneratorConfig, ViewBoxData } from "./types";
 export const createUsageCommentTemplate = ({
   config,
   viewBox,
+  preservesColors = false,
 }: {
   config: SwiftUIGeneratorConfig;
   viewBox: ViewBoxData;
+  preservesColors?: boolean;
 }) => [
-  "// To use this shape, just add it to your SwiftUI View:",
-  `// ${config.structName}().fill().frame(width: ${viewBox.width}, height: ${viewBox.height})`,
+  `// To use this ${preservesColors ? "view" : "shape"}, just add it to your SwiftUI View:`,
+  `// ${config.structName}()${preservesColors ? "" : ".fill()"}.frame(width: ${viewBox.width}, height: ${viewBox.height})`,
 ];
 
 type ParameterName = string;

--- a/packages/svg-to-swiftui-core/src/tests/colorUtils.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/colorUtils.test.ts
@@ -1,0 +1,19 @@
+import { parseOpacity, swiftUIColor } from "../colorUtils";
+
+test("convert SVG colors to SwiftUI colors", () => {
+  expect(swiftUIColor("#f80")).toBe("Color(red: 1, green: 0.5333, blue: 0)");
+  expect(swiftUIColor("rgba(255, 0, 128, 0.5)")).toBe("Color(red: 1, green: 0, blue: 0.502, opacity: 0.5)");
+  expect(swiftUIColor("rebeccapurple")).toBe("Color(red: 0.4, green: 0.2, blue: 0.6)");
+  expect(swiftUIColor("hsl(120 100% 50% / 25%)")).toBe("Color(red: 0, green: 1, blue: 0, opacity: 0.25)");
+  expect(swiftUIColor("currentColor", 0.25)).toBe("Color.primary.opacity(0.25)");
+});
+
+test("parse SVG opacity values", () => {
+  expect(parseOpacity("50%")).toBe(0.5);
+  expect(parseOpacity("2")).toBe(1);
+  expect(parseOpacity("invalid")).toBe(1);
+});
+
+test("leave unsupported paints for legacy conversion", () => {
+  expect(swiftUIColor("url(#gradient)")).toBeUndefined();
+});

--- a/packages/svg-to-swiftui-core/src/tests/index.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/index.test.ts
@@ -57,6 +57,7 @@ test("convert-f", () => {
   const result = convert(rawSVG, {
     precision: 6,
     structName: "FaIcon",
+    preserveColors: false,
   });
   expect(result).toBe(expectedResult);
 });
@@ -67,6 +68,7 @@ test("convert-ln", () => {
   const result = convert(rawSVG, {
     precision: 6,
     structName: "LnIcon",
+    preserveColors: false,
   });
   expect(result).toBe(expectedResult);
 });
@@ -96,6 +98,73 @@ test("convert-translated-group", () => {
   const result = convert(rawSVG, { precision: 6 });
 
   expect(result).toContain("CGAffineTransform(a: 1, b: 0, c: 0, d: 1, tx: -0.706667*width, ty: -0.02994*height)");
+});
+
+test("convert-multicolor-svg-to-layered-view", () => {
+  const rawSVG = `
+    <svg viewBox="0 0 100 100">
+      <rect width="100" height="100" fill="#ff0000" />
+      <circle cx="50" cy="50" r="25" fill="rgb(0, 128, 255)" />
+    </svg>
+  `;
+
+  const result = convert(rawSVG, {
+    structName: "MulticolorIcon",
+    precision: 3,
+    usageCommentPrefix: true,
+  });
+
+  expect(result).toContain("// MulticolorIcon().frame(width: 100, height: 100)");
+  expect(result).toContain("struct MulticolorIcon: View");
+  expect(result).toContain("Layer0().fill(Color(red: 1, green: 0, blue: 0))");
+  expect(result).toContain("Layer1().fill(Color(red: 0, green: 0.502, blue: 1))");
+  expect(result.indexOf("Layer0().fill")).toBeLessThan(result.indexOf("Layer1().fill"));
+});
+
+test("preserve inherited fill and contrasting stroke colors", () => {
+  const rawSVG = `
+    <svg viewBox="0 0 100 100">
+      <g fill="#00ff00" transform="translate(5 10)">
+        <rect x="10" y="10" width="60" height="50" stroke="#0000ff" stroke-width="4" />
+      </g>
+    </svg>
+  `;
+
+  const result = convert(rawSVG, { structName: "PaintedIcon", precision: 3 });
+
+  expect(result).toContain("Layer0().fill(Color(red: 0, green: 1, blue: 0))");
+  expect(result).toContain("Layer1().fill(Color(red: 0, green: 0, blue: 1))");
+  expect(result).toContain(".strokedPath(StrokeStyle(lineWidth: 0.04*width");
+  expect(result).toContain("tx: 0.05*width, ty: 0.1*height");
+  expect(result).not.toContain("cwStrokedPath");
+});
+
+test("preserve paint opacity and inline style precedence", () => {
+  const rawSVG = `
+    <svg viewBox="0 0 20 20" opacity="0.5">
+      <rect width="20" height="20" fill="#ff0000" style="fill-opacity: 0.5" />
+      <circle cx="10" cy="10" r="5" fill="blue" />
+    </svg>
+  `;
+
+  const result = convert(rawSVG, { structName: "TransparentIcon" });
+
+  expect(result).toContain("Layer0().fill(Color(red: 1, green: 0, blue: 0, opacity: 0.25))");
+  expect(result).toContain("Layer1().fill(Color(red: 0, green: 0, blue: 1, opacity: 0.5))");
+});
+
+test("allow callers to keep legacy single-shape output", () => {
+  const rawSVG = `
+    <svg viewBox="0 0 10 10">
+      <rect width="10" height="10" fill="red" />
+      <circle cx="5" cy="5" r="2" fill="blue" />
+    </svg>
+  `;
+
+  const result = convert(rawSVG, { structName: "TintableIcon", preserveColors: false });
+
+  expect(result).toContain("struct TintableIcon: Shape");
+  expect(result).not.toContain("Color(");
 });
 
 // evenodd → nonzero conversion: SwiftUI's Path uses non-zero winding by default,

--- a/packages/svg-to-swiftui-core/src/types.ts
+++ b/packages/svg-to-swiftui-core/src/types.ts
@@ -3,6 +3,8 @@ export interface SwiftUIGeneratorConfig {
   precision?: number;
   indentationSize?: number;
   usageCommentPrefix?: boolean;
+  /** Preserve SVG paints in a layered View. Defaults to automatic detection for multicolor SVGs. */
+  preserveColors?: boolean;
 }
 
 export interface TranspilerOptions {
@@ -19,6 +21,8 @@ export interface TranspilerOptions {
   reverseWinding: boolean;
   normalizeWindingCW: boolean;
   hasFills: boolean;
+  /** Generate an independent paint layer instead of geometry for a shared silhouette. */
+  separatePaintLayer: boolean;
   /** Active SVG fill-rule for the current path: "nonzero" | "evenodd". */
   fillRule: string;
 }

--- a/packages/svg-to-swiftui-core/visual-tests/run-visual-tests.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/run-visual-tests.ts
@@ -116,6 +116,9 @@ async function main() {
       const swiftCode = convert(svgString, {
         structName: `S${items.length}`,
         precision: 5,
+        // This CoreGraphics harness tests shared silhouette geometry. Multicolor
+        // View output is covered separately because it has no single path(in:).
+        preserveColors: false,
       });
 
       items.push({

--- a/packages/svg-to-swiftui-core/visual-tests/test-all-react-icons.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/test-all-react-icons.ts
@@ -154,7 +154,11 @@ async function main() {
         const svg = iconDataToSvg(iconData);
 
         try {
-          const swiftCode = convert(svg, { structName: `S${visualItems.length}`, precision: 5 });
+          const swiftCode = convert(svg, {
+            structName: `S${visualItems.length}`,
+            precision: 5,
+            preserveColors: false,
+          });
 
           const testName = `${id}-${iconName}`.replace(/[^a-z0-9-]/g, "-");
           const resvg = new Resvg(svg, {


### PR DESCRIPTION
## Summary

- automatically emit a layered SwiftUI `View` when an SVG contains multiple supported solid paints
- preserve element order, inherited fills, strokes, opacity, and transforms
- keep single-color SVGs as tintable `Shape`s
- add `preserveColors` to force layered or legacy output
- support hex, RGB/HSL, `currentColor`, transparency, and CSS named colors

## Root cause

A single SwiftUI `Shape` receives one external fill, so combining every SVG element into one `Path` necessarily discarded per-element colors. Multicolor output now uses ordered private shape layers, each with its original paint.

## Validation

- `bun run test` — all monorepo tests passed; core has 27 tests
- `bun run build` — full monorepo production build passed
- generated multicolor Swift type-checked against SwiftUI
- focused color visual match — 100.00%
- existing colored logos — 99.95% and 99.99%
- existing geometry visual regressions — 80/80 passed
- all 1,766 SVG fixtures converted with 0 errors

Fixes #30