### PR TITLE
Implement SVG painter order and compositing

### DIFF
--- a/.changeset/static-svg-compositing.md
+++ b/.changeset/static-svg-compositing.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Preserve SVG painter order, display and visibility semantics, independent paint opacity, isolated element and group opacity, explicit isolation, and transformed painted bounds in generated SwiftUI views.

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -31,6 +31,14 @@ Static selectors include universal, type, class, ID, attribute, selector lists, 
 
 SVG presentation defaults include SVG 2 properties such as `paint-order`, `mix-blend-mode`, and `isolation`. The SwiftUI backend currently consumes supported paint, geometry, visibility, opacity, stroke, transform, and paint-order values; other computed properties remain inspectable for later rendering features.
 
+### Painter order and compositing
+
+Rendered children keep SVG document order. `display: none` removes a subtree, while `visibility: hidden` can be overridden by a visible descendant. Fill, stroke, and marker phases use the computed `paint-order`; marker rendering will be added by the marker feature.
+
+Element and group `opacity` are applied once after their children have been painted into an isolated SwiftUI compositing group. Fill and stroke opacity remain independent. The generator intentionally keeps zero-opacity content in its semantic render tree and uses `.compositingGroup()` instead of rasterizing with `.drawingGroup()`.
+
+The render tree also exposes shared painted-bounds queries through `__testing`. Bounds include transforms and stroke extents, exclude `display: none`, retain zero-opacity geometry, and intersect nested viewport clips. Future marker and filter tickets can extend the same query.
+
 ## Before we start
 
 This package is written for JavaScript projects, so it's only meant to be used in a Node.js projects. If you just need to convert an SVG to SwiftUI Shape you should use [this tool](https://github.com/bring-shrubbery/SVG-to-SwiftUI).

--- a/packages/svg-to-swiftui-core/src/index.ts
+++ b/packages/svg-to-swiftui-core/src/index.ts
@@ -1,6 +1,7 @@
 import type { ElementNode } from "svg-parser";
 import { parse } from "svg-parser";
 import { DEFAULT_CONFIG } from "./constants";
+import { renderDocumentBounds, renderNodeBounds, renderNodesBounds } from "./renderTree/bounds";
 import { buildRenderDocument } from "./renderTree/buildRenderTree";
 import { analyzeCapabilities } from "./renderTree/capabilities";
 import { generateShape, generateView } from "./renderTree/generateSwiftUI";
@@ -38,7 +39,14 @@ function inspectComputedStyles(rawSVGString: string, config: SwiftUIGeneratorCon
   return result;
 }
 
-export const __testing = { parseRenderDocument, inspectComputedStyles, analyzeCapabilities };
+export const __testing = {
+  parseRenderDocument,
+  inspectComputedStyles,
+  analyzeCapabilities,
+  renderDocumentBounds,
+  renderNodeBounds,
+  renderNodesBounds,
+};
 
 /** Convert a complete SVG source string into a SwiftUI Shape or View declaration. */
 export function convert(rawSVGString: string, config?: SwiftUIGeneratorConfig): string {

--- a/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
@@ -1,0 +1,155 @@
+import { SVGPathData } from "svg-pathdata";
+import { type AffineTransform, IDENTITY_TRANSFORM, multiplyTransforms } from "../transformUtils";
+import type { Geometry, RenderBounds, RenderDocument, RenderNode, RenderShape } from "./types";
+
+function union(left: RenderBounds | undefined, right: RenderBounds | undefined): RenderBounds | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  const x = Math.min(left.x, right.x);
+  const y = Math.min(left.y, right.y);
+  const maxX = Math.max(left.x + left.width, right.x + right.width);
+  const maxY = Math.max(left.y + left.height, right.y + right.height);
+  return { x, y, width: maxX - x, height: maxY - y };
+}
+
+function intersect(left: RenderBounds | undefined, right: RenderBounds): RenderBounds | undefined {
+  if (!left) return undefined;
+  const x = Math.max(left.x, right.x);
+  const y = Math.max(left.y, right.y);
+  const maxX = Math.min(left.x + left.width, right.x + right.width);
+  const maxY = Math.min(left.y + left.height, right.y + right.height);
+  return maxX < x || maxY < y ? undefined : { x, y, width: maxX - x, height: maxY - y };
+}
+
+function transformedRect(x: number, y: number, width: number, height: number, matrix: AffineTransform): RenderBounds {
+  const points = [
+    [x, y],
+    [x + width, y],
+    [x, y + height],
+    [x + width, y + height],
+  ].map(([px, py]) => ({
+    x: matrix.a * px! + matrix.c * py! + matrix.e,
+    y: matrix.b * px! + matrix.d * py! + matrix.f,
+  }));
+  const xs = points.map((point) => point.x);
+  const ys = points.map((point) => point.y);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  return { x: minX, y: minY, width: Math.max(...xs) - minX, height: Math.max(...ys) - minY };
+}
+
+function pointsBounds(points: string): RenderBounds | undefined {
+  const values = points
+    .trim()
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .map(Number);
+  if (values.length < 2 || values.some((value) => !Number.isFinite(value))) return undefined;
+  const xs: number[] = [];
+  const ys: number[] = [];
+  for (let index = 0; index + 1 < values.length; index += 2) {
+    xs.push(values[index]!);
+    ys.push(values[index + 1]!);
+  }
+  const x = Math.min(...xs);
+  const y = Math.min(...ys);
+  return { x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y };
+}
+
+function geometryBounds(geometry: Geometry): RenderBounds | undefined {
+  switch (geometry.type) {
+    case "rect":
+      return { x: geometry.x, y: geometry.y, width: geometry.width, height: geometry.height };
+    case "circle":
+      return {
+        x: geometry.cx - geometry.r,
+        y: geometry.cy - geometry.r,
+        width: 2 * geometry.r,
+        height: 2 * geometry.r,
+      };
+    case "ellipse":
+      return {
+        x: geometry.cx - geometry.rx,
+        y: geometry.cy - geometry.ry,
+        width: 2 * geometry.rx,
+        height: 2 * geometry.ry,
+      };
+    case "line": {
+      const x = Math.min(geometry.x1, geometry.x2);
+      const y = Math.min(geometry.y1, geometry.y2);
+      return { x, y, width: Math.abs(geometry.x2 - geometry.x1), height: Math.abs(geometry.y2 - geometry.y1) };
+    }
+    case "polyline":
+    case "polygon":
+      return pointsBounds(geometry.points);
+    case "path": {
+      try {
+        const bounds = new SVGPathData(geometry.d).getBounds();
+        return { x: bounds.minX, y: bounds.minY, width: bounds.maxX - bounds.minX, height: bounds.maxY - bounds.minY };
+      } catch {
+        return undefined;
+      }
+    }
+  }
+}
+
+function expandForStroke(bounds: RenderBounds, shape: RenderShape): RenderBounds {
+  if (shape.style.stroke.type === "none" || shape.style.strokeStyle.width <= 0) return bounds;
+  const half = shape.style.strokeStyle.width / 2;
+  const factor =
+    (shape.geometry.type === "path" || shape.geometry.type === "polyline" || shape.geometry.type === "polygon") &&
+    shape.style.strokeStyle.lineJoin === "miter"
+      ? Math.max(1, shape.style.strokeStyle.miterLimit)
+      : 1;
+  const expansion = half * factor;
+  return {
+    x: bounds.x - expansion,
+    y: bounds.y - expansion,
+    width: bounds.width + 2 * expansion,
+    height: bounds.height + 2 * expansion,
+  };
+}
+
+function localShapeBounds(shape: RenderShape): RenderBounds | undefined {
+  if (shape.style.fill.type === "none" && shape.style.stroke.type === "none") return undefined;
+  const bounds = geometryBounds(shape.geometry);
+  return bounds ? expandForStroke(bounds, shape) : undefined;
+}
+
+function hidden(visibility: string): boolean {
+  return visibility === "hidden" || visibility === "collapse";
+}
+
+/** Painted axis-aligned bounds for a node in the generated root coordinate space. */
+export function renderNodeBounds(node: RenderNode, parent = IDENTITY_TRANSFORM): RenderBounds | undefined {
+  if (node.style.display === "none") return undefined;
+  const transform = multiplyTransforms(parent, node.transform);
+  if (node.type === "shape") {
+    if (hidden(node.style.visibility)) return undefined;
+    const bounds = localShapeBounds(node);
+    return bounds ? transformedRect(bounds.x, bounds.y, bounds.width, bounds.height, transform) : undefined;
+  }
+  if (node.type === "group") {
+    let bounds = renderNodesBounds(node.children, transform);
+    if (node.viewport?.clip) {
+      const clip = node.viewport.rect;
+      const clipTransform = multiplyTransforms(parent, node.viewport.clipTransform);
+      bounds = intersect(bounds, transformedRect(clip.x, clip.y, clip.width, clip.height, clipTransform));
+    }
+    return bounds;
+  }
+  return undefined;
+}
+
+/** Union painted bounds for sibling render nodes. */
+export function renderNodesBounds(nodes: RenderNode[], parent = IDENTITY_TRANSFORM): RenderBounds | undefined {
+  return nodes.reduce<RenderBounds | undefined>(
+    (bounds, node) => union(bounds, renderNodeBounds(node, parent)),
+    undefined,
+  );
+}
+
+/** Painted bounds for a complete SVG document, including root viewBox mapping. */
+export function renderDocumentBounds(document: RenderDocument): RenderBounds | undefined {
+  return renderNodesBounds(document.children);
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -19,6 +19,7 @@ import type {
   CSSDiagnosticContext,
   Geometry,
   Paint,
+  PaintOrderPhase,
   RenderDiagnostic,
   RenderDocument,
   RenderGroup,
@@ -183,6 +184,55 @@ function plainNumber(
   }
 }
 
+const DEFAULT_PAINT_ORDER: readonly PaintOrderPhase[] = ["fill", "stroke", "markers"];
+
+function computedPaintOrder(
+  value: unknown,
+  element: ElementNode,
+  context: BuildContext,
+  css?: CSSDiagnosticContext,
+): readonly PaintOrderPhase[] {
+  const normalized = String(value ?? "normal")
+    .trim()
+    .toLowerCase();
+  if (normalized === "normal") return DEFAULT_PAINT_ORDER;
+  const tokens = normalized.split(/\s+/);
+  const valid = tokens.length > 0 && tokens.every((token) => DEFAULT_PAINT_ORDER.includes(token as PaintOrderPhase));
+  if (!valid || new Set(tokens).size !== tokens.length) {
+    addDiagnostic(
+      context,
+      element,
+      "invalid-paint-order",
+      `paint-order must contain distinct fill, stroke, and markers phases; received '${normalized}'.`,
+      css,
+    );
+    return DEFAULT_PAINT_ORDER;
+  }
+  return [...(tokens as PaintOrderPhase[]), ...DEFAULT_PAINT_ORDER.filter((phase) => !tokens.includes(phase))];
+}
+
+function computedOpacity(
+  value: unknown,
+  property: "opacity" | "fill-opacity" | "stroke-opacity",
+  element: ElementNode,
+  context: BuildContext,
+  css?: CSSDiagnosticContext,
+): number {
+  const normalized = String(value ?? 1).trim();
+  const numeric = normalized.endsWith("%") ? normalized.slice(0, -1).trim() : normalized;
+  if (numeric === "" || !Number.isFinite(Number(numeric))) {
+    addDiagnostic(
+      context,
+      element,
+      `invalid-${property}`,
+      `${property} must be a number or percentage; received '${normalized}'.`,
+      css,
+    );
+    return 1;
+  }
+  return parseOpacity(normalized);
+}
+
 function computeStyle(
   effective: Presentation,
   provenance: StyleResolution["provenance"],
@@ -233,13 +283,30 @@ function computeStyle(
     fill: parsePaint(isLine ? "none" : (effective.fill ?? "black"), color),
     stroke: parsePaint(effective.stroke ?? "none", color),
     color,
-    opacity: parseOpacity(effective.opacity),
-    fillOpacity: parseOpacity(effective["fill-opacity"]),
-    strokeOpacity: parseOpacity(effective["stroke-opacity"]),
+    opacity: computedOpacity(effective.opacity, "opacity", element, context, provenance.opacity),
+    fillOpacity: computedOpacity(
+      effective["fill-opacity"],
+      "fill-opacity",
+      element,
+      context,
+      provenance["fill-opacity"],
+    ),
+    strokeOpacity: computedOpacity(
+      effective["stroke-opacity"],
+      "stroke-opacity",
+      element,
+      context,
+      provenance["stroke-opacity"],
+    ),
+    paintOrder: computedPaintOrder(effective["paint-order"], element, context, provenance["paint-order"]),
     fillRule: fillRule === "evenodd" ? "evenodd" : "nonzero",
     clipRule: clipRule === "evenodd" ? "evenodd" : "nonzero",
-    display: String(effective.display ?? "inline"),
-    visibility: String(effective.visibility ?? "visible"),
+    display: String(effective.display ?? "inline")
+      .trim()
+      .toLowerCase(),
+    visibility: String(effective.visibility ?? "visible")
+      .trim()
+      .toLowerCase(),
     strokeStyle: {
       width,
       lineCap: String(effective["stroke-linecap"] ?? "butt"),

--- a/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
@@ -7,20 +7,23 @@ interface VisiblePaint {
   opacity: number;
 }
 
-function collectVisiblePaints(nodes: RenderNode[], inheritedOpacity = 1, paints: VisiblePaint[] = []): VisiblePaint[] {
+function isHidden(visibility: string): boolean {
+  return visibility === "hidden" || visibility === "collapse";
+}
+
+function collectVisiblePaints(nodes: RenderNode[], paints: VisiblePaint[] = []): VisiblePaint[] {
   for (const node of nodes) {
-    if (node.style.display === "none" || node.style.visibility === "hidden") continue;
-    const opacity = inheritedOpacity * node.style.opacity;
+    if (node.style.display === "none") continue;
     if (node.type === "group") {
-      collectVisiblePaints(node.children, opacity, paints);
+      collectVisiblePaints(node.children, paints);
       continue;
     }
-    if (node.type !== "shape") continue;
-    if (node.style.fill.type !== "none" && opacity * node.style.fillOpacity > 0) {
-      paints.push({ paint: node.style.fill, opacity: opacity * node.style.fillOpacity });
+    if (node.type !== "shape" || isHidden(node.style.visibility)) continue;
+    if (node.style.fill.type !== "none") {
+      paints.push({ paint: node.style.fill, opacity: node.style.fillOpacity });
     }
-    if (node.style.stroke.type !== "none" && opacity * node.style.strokeOpacity > 0) {
-      paints.push({ paint: node.style.stroke, opacity: opacity * node.style.strokeOpacity });
+    if (node.style.stroke.type !== "none") {
+      paints.push({ paint: node.style.stroke, opacity: node.style.strokeOpacity });
     }
   }
   return paints;
@@ -41,9 +44,28 @@ function containsViewportClip(nodes: RenderNode[]): boolean {
   );
 }
 
+function containsIndependentCompositing(nodes: RenderNode[]): boolean {
+  return nodes.some((node) => {
+    if (node.style.display === "none") return false;
+    if (
+      node.style.opacity !== 1 ||
+      node.style.fillOpacity !== 1 ||
+      node.style.strokeOpacity !== 1 ||
+      String(node.style.presentation.isolation).trim().toLowerCase() === "isolate"
+    )
+      return true;
+    return node.type === "group" && containsIndependentCompositing(node.children);
+  });
+}
+
 function solidColor(paint: Paint, opacity: number): string | undefined {
   if (paint.type !== "solid") return undefined;
   return swiftUIColor(paint.value, opacity);
+}
+
+function hasIntrinsicAlpha(paint: Paint): boolean {
+  const color = solidColor(paint, 1);
+  return color?.includes("opacity:") === true || color?.includes(".opacity(") === true;
 }
 
 /** Explain, deterministically, why this document uses the Shape fast path or the general View backend. */
@@ -51,8 +73,15 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   const paints = collectVisiblePaints(document.children);
   const reasons: string[] = [];
   const needsViewportClip = containsViewportClip(document.children);
+  const needsIndependentCompositing =
+    containsIndependentCompositing(document.children) || paints.some(({ paint }) => hasIntrinsicAlpha(paint));
 
-  if (config.preserveColors === false && !needsViewportClip && !containsGeneralViewContent(document.children)) {
+  if (
+    config.preserveColors === false &&
+    !needsViewportClip &&
+    !needsIndependentCompositing &&
+    !containsGeneralViewContent(document.children)
+  ) {
     return {
       mode: "shape",
       reasons: ["preserveColors is false; using the tintable Shape fast path"],
@@ -62,6 +91,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
 
   if (containsGeneralViewContent(document.children)) reasons.push("document contains non-geometry view content");
   if (needsViewportClip) reasons.push("document contains a clipped nested viewport");
+  if (needsIndependentCompositing) reasons.push("document uses independent paint or group opacity");
 
   const colors = paints.map(({ paint, opacity }) => solidColor(paint, opacity));
   const allColorsSupported = colors.every((color) => color !== undefined);
@@ -75,7 +105,6 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
 
   if (config.preserveColors === true && paints.length > 0)
     reasons.push("preserveColors explicitly requests source paints");
-  if (paints.some(({ opacity }) => opacity !== 1)) reasons.push("document uses independent paint or group opacity");
   if (config.preserveColors === undefined && allColorsSupported && new Set(colors).size > 1) {
     reasons.push("document contains multiple distinct source paints");
   }

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -11,10 +11,26 @@ export interface GeneratedSwiftUI {
   preservesColors: boolean;
 }
 
-interface PaintLayer {
+interface ShapeHelper {
+  name: string;
   lines: string[];
-  swiftColor: string;
-  clips: string[][];
+}
+
+type GeneratedViewNode =
+  | { type: "paint"; helper: string; swiftColor: string }
+  | {
+      type: "group";
+      children: GeneratedViewNode[];
+      opacity: number;
+      isolated: boolean;
+      clip?: string;
+    };
+
+interface ViewBuildContext {
+  options: TranspilerOptions;
+  helpers: ShapeHelper[];
+  nextLayer: number;
+  nextClip: number;
 }
 
 function createOptions(
@@ -117,8 +133,9 @@ function renderShape(
 function renderShapeNodes(nodes: RenderNode[], options: TranspilerOptions): string[] {
   const lines: string[] = [];
   for (const node of nodes) {
-    if (node.style.display === "none" || node.style.visibility === "hidden") continue;
+    if (node.style.display === "none") continue;
     if (node.type === "shape") {
+      if (node.style.visibility === "hidden" || node.style.visibility === "collapse") continue;
       lines.push(...renderShape(node, options));
       continue;
     }
@@ -135,27 +152,21 @@ function colorForPaint(paint: Paint, opacity: number): string | undefined {
   return undefined;
 }
 
-function paintOrder(value: string | number): ("fill" | "stroke")[] {
-  const defaults = ["fill", "stroke", "markers"] as const;
-  const normalized = String(value).trim().toLowerCase();
-  const specified = normalized === "normal" ? [] : normalized.split(/\s+/);
-  const ordered = [...new Set([...specified, ...defaults])];
-  return ordered.filter((item): item is "fill" | "stroke" => item === "fill" || item === "stroke");
+function addHelper(context: ViewBuildContext, name: string, lines: string[]): string {
+  context.helpers.push({ name, lines });
+  return name;
 }
 
-function collectPaintLayers(
+function buildViewNodes(
   nodes: RenderNode[],
-  options: TranspilerOptions,
-  inheritedOpacity = 1,
+  context: ViewBuildContext,
   ancestorTransforms: RenderNode["transform"][] = [],
-  ancestorClips: string[][] = [],
-  layers: PaintLayer[] = [],
-): PaintLayer[] {
+): GeneratedViewNode[] {
+  const generated: GeneratedViewNode[] = [];
   for (const node of nodes) {
-    if (node.style.display === "none" || node.style.visibility === "hidden") continue;
-    const opacity = inheritedOpacity * node.style.opacity;
+    if (node.style.display === "none") continue;
     if (node.type === "group") {
-      let clips = ancestorClips;
+      let clip: string | undefined;
       if (node.viewport?.clip) {
         const { rect, clipTransform } = node.viewport;
         let clipLines = handleElement(
@@ -172,98 +183,117 @@ function collectPaintLayers(
             },
             children: [],
           },
-          options,
+          context.options,
         );
-        clipLines = wrapWithTransform(clipLines, clipTransform, options);
+        clipLines = wrapWithTransform(clipLines, clipTransform, context.options);
         for (let index = ancestorTransforms.length - 1; index >= 0; index--) {
-          clipLines = wrapWithTransform(clipLines, ancestorTransforms[index]!, options);
+          clipLines = wrapWithTransform(clipLines, ancestorTransforms[index]!, context.options);
         }
-        clips = [...ancestorClips, clipLines];
+        clip = addHelper(context, `Clip${context.nextClip++}`, clipLines);
       }
-      collectPaintLayers(node.children, options, opacity, [...ancestorTransforms, node.transform], clips, layers);
+      const children = buildViewNodes(node.children, context, [...ancestorTransforms, node.transform]);
+      if (children.length > 0) {
+        generated.push({
+          type: "group",
+          children,
+          opacity: node.style.opacity,
+          isolated: node.style.opacity !== 1 || String(node.style.presentation.isolation).toLowerCase() === "isolate",
+          ...(clip ? { clip } : {}),
+        });
+      }
       continue;
     }
-    if (node.type !== "shape") continue;
+    if (node.type !== "shape" || node.style.visibility === "hidden" || node.style.visibility === "collapse") continue;
+
+    const paints: GeneratedViewNode[] = [];
 
     const addLayer = (kind: "fill" | "stroke", paint: Paint, paintOpacity: number) => {
-      const swiftColor = colorForPaint(paint, opacity * paintOpacity);
+      const swiftColor = colorForPaint(paint, paintOpacity);
       if (!swiftColor) return;
       let lines = renderShape(
         node,
-        options,
+        context.options,
         kind === "fill" ? { fill: "black", stroke: "none" } : { fill: "none", stroke: "black" },
       );
       for (let index = ancestorTransforms.length - 1; index >= 0; index--) {
-        lines = wrapWithTransform(lines, ancestorTransforms[index]!, options);
+        lines = wrapWithTransform(lines, ancestorTransforms[index]!, context.options);
       }
-      if (lines.length > 0) layers.push({ lines, swiftColor, clips: ancestorClips });
+      if (lines.length > 0) {
+        const helper = addHelper(context, `Layer${context.nextLayer++}`, lines);
+        paints.push({ type: "paint", helper, swiftColor });
+      }
     };
 
-    for (const kind of paintOrder(node.style.presentation["paint-order"] ?? "normal")) {
-      if (kind === "fill" && node.style.fill.type !== "none" && opacity * node.style.fillOpacity > 0) {
+    for (const kind of node.style.paintOrder) {
+      if (kind === "fill" && node.style.fill.type !== "none") {
         addLayer("fill", node.style.fill, node.style.fillOpacity);
       }
-      if (kind === "stroke" && node.style.stroke.type !== "none" && opacity * node.style.strokeOpacity > 0) {
+      if (kind === "stroke" && node.style.stroke.type !== "none") {
         addLayer("stroke", node.style.stroke, node.style.strokeOpacity);
       }
     }
+    if (paints.length > 0) {
+      generated.push({
+        type: "group",
+        children: paints,
+        opacity: node.style.opacity,
+        isolated: node.style.opacity !== 1 || String(node.style.presentation.isolation).toLowerCase() === "isolate",
+      });
+    }
   }
-  return layers;
+  return generated;
 }
 
 function createPathBody(lines: string[]): string[] {
   return ["var path = Path()", "let width = rect.size.width", "let height = rect.size.height", ...lines, "return path"];
 }
 
-function createView(name: string, layers: PaintLayer[], indentationSize: number): string[] {
+function swiftNumber(value: number): string {
+  return String(Object.is(value, -0) ? 0 : value);
+}
+
+function renderViewNode(node: GeneratedViewNode, level: number, indentation: string): string[] {
+  const prefix = indentation.repeat(level);
+  if (node.type === "paint") return [`${prefix}${node.helper}().fill(${node.swiftColor})`];
+  const lines = [`${prefix}ZStack {`];
+  for (const child of node.children) lines.push(...renderViewNode(child, level + 1, indentation));
+  lines.push(`${prefix}}`);
+  if (node.clip) lines.push(`${prefix}.clipShape(${node.clip}())`);
+  if (node.isolated) lines.push(`${prefix}.compositingGroup()`);
+  if (node.opacity !== 1) lines.push(`${prefix}.opacity(${swiftNumber(node.opacity)})`);
+  return lines;
+}
+
+function createView(
+  name: string,
+  nodes: GeneratedViewNode[],
+  helpers: ShapeHelper[],
+  indentationSize: number,
+): string[] {
   const indentation = " ".repeat(indentationSize);
-  const layerExpression = (layer: PaintLayer, index: number) => {
-    let expression = `Layer${index}().fill(${layer.swiftColor})`;
-    for (let clipIndex = 0; clipIndex < layer.clips.length; clipIndex++) {
-      expression += `.clipShape(Layer${index}Clip${clipIndex}())`;
-    }
-    return expression;
-  };
   const body: string[] = [
     "var body: some View {",
     `${indentation}ZStack {`,
-    ...layers.map((layer, index) => `${indentation}${indentation}${layerExpression(layer, index)}`),
+    ...nodes.flatMap((node) => renderViewNode(node, 2, indentation)),
     `${indentation}}`,
     "}",
   ];
-  for (const [index, layer] of layers.entries()) {
+  for (const helper of helpers) {
     const pathFunction = createFunctionTemplate({
       name: "path",
       parameters: [["in rect", "CGRect"]],
       returnType: "Path",
       indent: indentationSize,
-      body: createPathBody(layer.lines),
+      body: createPathBody(helper.lines),
     });
     const layerStruct = createStructTemplate({
-      name: `Layer${index}`,
+      name: helper.name,
       indent: indentationSize,
       returnType: "Shape",
       body: pathFunction,
     });
     layerStruct[0] = `private ${layerStruct[0]}`;
     body.push("", ...layerStruct);
-    for (const [clipIndex, clip] of layer.clips.entries()) {
-      const clipFunction = createFunctionTemplate({
-        name: "path",
-        parameters: [["in rect", "CGRect"]],
-        returnType: "Path",
-        indent: indentationSize,
-        body: createPathBody(clip),
-      });
-      const clipStruct = createStructTemplate({
-        name: `Layer${index}Clip${clipIndex}`,
-        indent: indentationSize,
-        returnType: "Shape",
-        body: clipFunction,
-      });
-      clipStruct[0] = `private ${clipStruct[0]}`;
-      body.push("", ...clipStruct);
-    }
   }
   return createStructTemplate({ name, indent: indentationSize, returnType: "View", body });
 }
@@ -300,9 +330,10 @@ export function generateView(
 ): GeneratedSwiftUI {
   const indentationSize = config.indentationSize ?? 4;
   const options = createOptions(svgProperties, document, config, true);
-  const layers = collectPaintLayers(document.children, options);
+  const context: ViewBuildContext = { options, helpers: [], nextLayer: 0, nextClip: 0 };
+  const nodes = buildViewNodes(document.children, context);
   return {
-    lines: createView(config.structName ?? "SVGView", layers, indentationSize),
+    lines: createView(config.structName ?? "SVGView", nodes, context.helpers, indentationSize),
     preservesColors: true,
   };
 }

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -43,6 +43,8 @@ export interface StrokeStyle {
   dashOffset: number;
 }
 
+export type PaintOrderPhase = "fill" | "stroke" | "markers";
+
 /** Presentation properties after inheritance and inline-style precedence have been resolved. */
 export interface ComputedStyle {
   fill: Paint;
@@ -51,6 +53,8 @@ export interface ComputedStyle {
   opacity: number;
   fillOpacity: number;
   strokeOpacity: number;
+  /** Complete SVG paint sequence after omitted phases are appended in default order. */
+  paintOrder: readonly PaintOrderPhase[];
   fillRule: "nonzero" | "evenodd";
   clipRule: "nonzero" | "evenodd";
   display: string;
@@ -145,6 +149,14 @@ export interface RenderDocument {
   resources: ResourceRegistry;
   children: RenderNode[];
   diagnostics: RenderDiagnostic[];
+}
+
+/** Axis-aligned painted bounds in the root generated-view coordinate space. */
+export interface RenderBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 export type OutputMode = "shape" | "view";

--- a/packages/svg-to-swiftui-core/src/tests/index.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/index.test.ts
@@ -149,8 +149,9 @@ test("preserve paint opacity and inline style precedence", () => {
 
   const result = convert(rawSVG, { structName: "TransparentIcon" });
 
-  expect(result).toContain("Layer0().fill(Color(red: 1, green: 0, blue: 0, opacity: 0.25))");
-  expect(result).toContain("Layer1().fill(Color(red: 0, green: 0, blue: 1, opacity: 0.5))");
+  expect(result).toContain("Layer0().fill(Color(red: 1, green: 0, blue: 0, opacity: 0.5))");
+  expect(result).toContain("Layer1().fill(Color(red: 0, green: 0, blue: 1))");
+  expect(result).toMatch(/\.compositingGroup\(\)\s+\.opacity\(0\.5\)/);
 });
 
 test("allow callers to keep legacy single-shape output", () => {

--- a/packages/svg-to-swiftui-core/src/tests/renderTree.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/renderTree.test.ts
@@ -115,6 +115,78 @@ describe("output capability analysis", () => {
       mode: "view",
       reasons: ["document uses independent paint or group opacity"],
     });
+    expect(__testing.analyzeCapabilities(document, { preserveColors: false }).mode).toBe("view");
+  });
+
+  test("emits an explicit compositing boundary for isolation", () => {
+    const source = `<svg viewBox="0 0 10 10"><g style="isolation: isolate"><rect width="10" height="10" fill="red"/></g></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(__testing.analyzeCapabilities(document, { preserveColors: false }).mode).toBe("view");
+    expect(convert(source)).toContain(".compositingGroup()");
+    expect(convert(source)).not.toContain(".drawingGroup()");
+  });
+
+  test("keeps intrinsic transparent paint on the View backend", () => {
+    const document = __testing.parseRenderDocument(
+      `<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="rgba(255, 0, 0, 0.4)"/></svg>`,
+    );
+    expect(__testing.analyzeCapabilities(document).mode).toBe("view");
+    expect(__testing.analyzeCapabilities(document, { preserveColors: false }).mode).toBe("view");
+  });
+
+  test("keeps visible descendants of hidden groups and zero-opacity paints semantic", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20"><g visibility="hidden">
+        <rect width="20" height="20" fill="red" />
+        <circle cx="10" cy="10" r="5" fill="blue" visibility="visible" opacity="0" />
+      </g></svg>
+    `);
+    expect(__testing.analyzeCapabilities(document)).toMatchObject({ mode: "view", paintCount: 1 });
+    const result = convert(`
+      <svg viewBox="0 0 20 20"><g visibility="hidden">
+        <rect width="20" height="20" fill="red" />
+        <circle cx="10" cy="10" r="5" fill="blue" visibility="visible" opacity="0" />
+      </g></svg>
+    `);
+    expect(result).toContain("Color(red: 0, green: 0, blue: 1)");
+    expect(result).not.toContain("Color(red: 1, green: 0, blue: 0)");
+    expect(result).toContain(".opacity(0)");
+  });
+
+  test("generates fill and stroke in computed paint order", () => {
+    const source = `<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="red" stroke="blue" paint-order="stroke"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    const shape = flatten(document.children).find((node) => node.type === "shape");
+    expect(shape?.style.paintOrder).toEqual(["stroke", "fill", "markers"]);
+    const result = convert(source);
+    expect(result.indexOf("Layer0().fill(Color(red: 0, green: 0, blue: 1))")).toBeLessThan(
+      result.indexOf("Layer1().fill(Color(red: 1, green: 0, blue: 0))"),
+    );
+  });
+
+  test("reports invalid paint order and opacity with CSS provenance", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 10 10"><style>#target { paint-order: fill fill; opacity: nope }</style>
+        <rect id="target" width="10" height="10" />
+      </svg>
+    `);
+    expect(document.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "invalid-paint-order", css: expect.objectContaining({ selector: "#target" }) }),
+        expect.objectContaining({ code: "invalid-opacity", css: expect.objectContaining({ selector: "#target" }) }),
+      ]),
+    );
+  });
+
+  test("computes transformed painted bounds, skipping display but retaining zero opacity", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 100">
+        <g transform="translate(5 7)"><rect x="10" y="20" width="30" height="10" fill="red" stroke="blue" stroke-width="4"/></g>
+        <rect x="90" y="90" width="5" height="5" display="none"/>
+        <rect x="50" y="50" width="10" height="10" opacity="0"/>
+      </svg>
+    `);
+    expect(__testing.renderDocumentBounds(document)).toEqual({ x: 13, y: 25, width: 47, height: 35 });
   });
 
   test("reports future content and strict mode refuses to drop it", () => {

--- a/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
@@ -60,6 +60,64 @@
       "expectedMode": "shape",
       "tags": ["circle", "geometry", "shape"]
     },
+    "compositing-display-none": {
+      "width": 128,
+      "height": 75,
+      "expectedMode": "view",
+      "tags": ["circle", "compositing", "display", "g", "geometry", "path", "rect", "use", "view"]
+    },
+    "compositing-group-opacity-overlap": {
+      "width": 128,
+      "height": 107,
+      "expectedMode": "view",
+      "tags": ["compositing", "g", "geometry", "opacity", "rect", "view"]
+    },
+    "compositing-nested-opacity": {
+      "width": 128,
+      "height": 85,
+      "expectedMode": "view",
+      "tags": ["circle", "compositing", "g", "geometry", "opacity", "stroke", "view"]
+    },
+    "compositing-paint-order-permutations": {
+      "width": 128,
+      "height": 43,
+      "expectedMode": "view",
+      "tags": ["compositing", "g", "geometry", "paint-order", "rect", "stroke", "view"]
+    },
+    "compositing-realistic-export": {
+      "width": 128,
+      "height": 51,
+      "expectedMode": "view",
+      "tags": ["circle", "compositing", "g", "geometry", "opacity", "path", "rect", "stroke", "transform", "view"]
+    },
+    "compositing-transformed-nonsquare": {
+      "width": 128,
+      "height": 58,
+      "expectedMode": "view",
+      "tags": [
+        "compositing",
+        "ellipse",
+        "g",
+        "geometry",
+        "opacity",
+        "preserve-aspect-ratio",
+        "rect",
+        "transform",
+        "view"
+      ]
+    },
+    "compositing-transparent-zero": {
+      "width": 128,
+      "height": 75,
+      "expectedMode": "view",
+      "tags": ["circle", "compositing", "geometry", "opacity", "rect", "stroke", "view"]
+    },
+    "compositing-visibility-override": {
+      "width": 128,
+      "height": 75,
+      "expectedMode": "view",
+      "tags": ["circle", "compositing", "g", "geometry", "rect", "view", "visibility"]
+    },
     "cross": {
       "width": 128,
       "height": 128,
@@ -70,7 +128,7 @@
       "width": 128,
       "height": 43,
       "expectedMode": "view",
-      "tags": ["css", "geometry", "rect", "view"]
+      "tags": ["css", "g", "geometry", "rect", "view"]
     },
     "css-geometry": {
       "width": 128,
@@ -94,7 +152,7 @@
       "width": 128,
       "height": 43,
       "expectedMode": "view",
-      "tags": ["css", "geometry", "opacity", "rect", "view"]
+      "tags": ["css", "display", "g", "geometry", "opacity", "rect", "view", "visibility"]
     },
     "ellipse": {
       "width": 128,
@@ -112,7 +170,7 @@
       "width": 128,
       "height": 85,
       "expectedMode": "view",
-      "tags": ["circle", "geometry", "rect", "transform", "view"]
+      "tags": ["circle", "g", "geometry", "rect", "transform", "view"]
     },
     "harness-multicolor-view": {
       "width": 128,
@@ -304,7 +362,7 @@
       "width": 128,
       "height": 128,
       "expectedMode": "view",
-      "tags": ["geometry", "path", "rect", "view"]
+      "tags": ["g", "geometry", "path", "rect", "view"]
     },
     "lucide-a-arrow-down": {
       "width": 128,
@@ -10540,7 +10598,7 @@
       "width": 128,
       "height": 128,
       "expectedMode": "shape",
-      "tags": ["circle", "ellipse", "geometry", "rect", "shape"]
+      "tags": ["circle", "ellipse", "g", "geometry", "rect", "shape"]
     },
     "path-stroke-zigzag": {
       "width": 128,
@@ -10552,7 +10610,7 @@
       "width": 128,
       "height": 128,
       "expectedMode": "shape",
-      "tags": ["geometry", "path", "shape", "stroke", "units"]
+      "tags": ["g", "geometry", "path", "shape", "stroke", "units"]
     },
     "polygon-diamond": {
       "width": 128,
@@ -10636,7 +10694,7 @@
       "width": 128,
       "height": 64,
       "expectedMode": "view",
-      "tags": ["circle", "geometry", "path", "structure", "use", "view"]
+      "tags": ["circle", "g", "geometry", "path", "structure", "use", "view"]
     },
     "structure-switch-link": {
       "width": 128,
@@ -10654,7 +10712,7 @@
       "width": 128,
       "height": 85,
       "expectedMode": "view",
-      "tags": ["circle", "geometry", "polygon", "rect", "structure", "transform", "view"]
+      "tags": ["circle", "g", "geometry", "polygon", "rect", "structure", "transform", "view"]
     },
     "structure-viewbox-origin": {
       "width": 128,
@@ -10702,6 +10760,7 @@
       "expectedMode": "view",
       "tags": [
         "circle",
+        "g",
         "geometry",
         "nested-svg",
         "overflow",

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-display-none.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-display-none.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 70">
+  <defs><path id="tile" d="M0 0h24v24H0z" fill="#8b5cf6"/></defs>
+  <rect width="120" height="70" fill="#f8fafc"/>
+  <rect x="5" y="5" width="20" height="60" fill="#ef4444" display="none"/>
+  <g display="none"><circle cx="55" cy="35" r="30" fill="#f59e0b"/></g>
+  <use href="#tile" x="20" y="23"/>
+  <use href="#tile" x="76" y="23" display="none"/>
+  <circle cx="92" cy="35" r="12" fill="#14b8a6"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-group-opacity-overlap.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-group-opacity-overlap.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 100">
+  <g opacity="0.5">
+    <rect x="10" y="10" width="65" height="65" rx="8" fill="#ef4444"/>
+    <rect x="45" y="25" width="65" height="65" rx="8" fill="#2563eb"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-nested-opacity.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-nested-opacity.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80">
+  <g opacity="0.75">
+    <g opacity="0.6">
+      <circle cx="42" cy="40" r="28" fill="#f97316" fill-opacity="0.65" stroke="#7c2d12" stroke-opacity="0.4" stroke-width="10"/>
+      <circle cx="76" cy="40" r="28" fill="#22c55e" fill-opacity="0.8"/>
+    </g>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-paint-order-permutations.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-paint-order-permutations.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 60">
+  <g fill="#fde047" stroke="#1d4ed8" stroke-width="14">
+    <rect x="15" y="15" width="30" height="30" rx="5" paint-order="normal"/>
+    <rect x="75" y="15" width="30" height="30" rx="5" paint-order="stroke"/>
+    <rect x="135" y="15" width="30" height="30" rx="5" paint-order="markers stroke fill"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-realistic-export.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-realistic-export.svg
@@ -1,0 +1,16 @@
+<!-- Adapted from a Figma-style exported status badge: nested named groups and presentation attributes retained. -->
+<svg width="240" height="96" viewBox="0 0 240 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g id="Badge/Success" opacity="0.92">
+    <rect width="240" height="96" rx="24" fill="#052E16"/>
+    <g id="Glow" opacity="0.55">
+      <circle cx="62" cy="48" r="32" fill="#22C55E" fill-opacity="0.55"/>
+      <circle cx="78" cy="48" r="32" fill="#10B981" fill-opacity="0.55"/>
+    </g>
+    <g id="Check" transform="translate(43 29)">
+      <circle cx="19" cy="19" r="18" fill="#DCFCE7"/>
+      <path d="M10 19L16.5 25.5L29 12.5" stroke="#15803D" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    <rect x="112" y="30" width="94" height="14" rx="7" fill="#DCFCE7"/>
+    <rect x="112" y="54" width="66" height="10" rx="5" fill="#86EFAC" fill-opacity="0.8"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-transformed-nonsquare.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-transformed-nonsquare.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-20 -10 200 90" preserveAspectRatio="xMidYMid meet">
+  <g transform="translate(18 6) rotate(8 60 35)" opacity="0.58">
+    <rect x="0" y="0" width="100" height="55" rx="9" fill="#fb7185"/>
+    <ellipse cx="92" cy="42" rx="55" ry="25" fill="#4f46e5"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-transparent-zero.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-transparent-zero.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 70">
+  <rect x="5" y="5" width="50" height="60" fill="#dc2626" opacity="0"/>
+  <circle cx="45" cy="35" r="28" fill="rgba(37, 99, 235, 0.4)"/>
+  <circle cx="78" cy="35" r="28" fill="#22c55e" fill-opacity="0.55" stroke="#14532d" stroke-opacity="0.7" stroke-width="7"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-visibility-override.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-visibility-override.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 70">
+  <rect width="120" height="70" fill="#e2e8f0"/>
+  <g visibility="hidden">
+    <rect x="8" y="8" width="45" height="54" fill="#ef4444"/>
+    <circle cx="84" cy="35" r="27" fill="#0ea5e9" visibility="visible"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
@@ -41,6 +41,7 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   }
   if (name.startsWith("structure-")) tags.add("structure");
   if (name.startsWith("css-")) tags.add("css");
+  if (name.startsWith("compositing-")) tags.add("compositing");
   if (name.startsWith("viewport-")) tags.add("viewport");
   if (name.startsWith("viewport-realistic-")) tags.add("realistic");
   for (const element of [
@@ -51,6 +52,7 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
     "line",
     "polyline",
     "polygon",
+    "g",
     "use",
     "symbol",
     "switch",
@@ -65,6 +67,8 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   if (/\boverflow\s*=/.test(source) || /<svg\b[\s\S]*<svg\b/i.test(source)) tags.add("overflow");
   if (/\bstroke\s*(?:=|:)/.test(source)) tags.add("stroke");
   if (/\bopacity\s*(?:=|:)/.test(source)) tags.add("opacity");
+  if (/\bvisibility\s*(?:=|:)/.test(source)) tags.add("visibility");
+  if (/\bdisplay\s*(?:=|:)/.test(source)) tags.add("display");
   if (/\bpaint-order\s*(?:=|:)/.test(source)) tags.add("paint-order");
   if (/var\(\s*--|--[\w-]+\s*:/.test(source)) tags.add("css-variables");
   return [...tags].sort();


### PR DESCRIPTION
Closes #55

## What changed
- preserve SVG document painter order and computed `paint-order`
- implement `display`, overridable `visibility`, zero-opacity, and independent fill/stroke opacity semantics
- generate nested SwiftUI compositing groups so element/group opacity is applied once after children render
- support explicit `isolation: isolate` without forced rasterization
- add shared transformed painted-bounds queries with stroke and viewport clipping support
- add 8 focused RGBA fixtures, including overlap, nested opacity, references, transforms, and a realistic export
- document behavior and add a minor changeset

## Validation
- 118 unit tests
- core lint and typecheck
- core and monorepo builds
- manifest/codegen verification
- 1,804/1,804 deterministic SVG-vs-SwiftUI RGBA comparisons