### PR TITLE
Render SVG linear and radial gradients

### DIFF
--- a/.changeset/static-svg-gradients.md
+++ b/.changeset/static-svg-gradients.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Render SVG linear and radial gradient paint servers with typed inheritance, CSS stops, coordinate systems, transforms, spread methods, focal circles, fallbacks, explicit color interpolation, and deterministic vector-backed SwiftUI Canvas output.

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -39,6 +39,14 @@ Element and group `opacity` are applied once after their children have been pain
 
 The render tree also exposes shared painted-bounds queries through `__testing`. Bounds include transforms and stroke extents, exclude `display: none`, retain zero-opacity geometry, and intersect nested viewport clips. Future marker and filter tickets can extend the same query.
 
+### Linear and radial gradients
+
+`linearGradient`, `radialGradient`, and `stop` definitions are resolved as typed paint resources for fills and strokes. The resolver supports `objectBoundingBox` and `userSpaceOnUse`, percentage or length coordinates, `gradientTransform`, `pad`/`reflect`/`repeat`, `href` and `xlink:href` inheritance, local stop replacement, focal circles, CSS-styled stops, `currentColor`, alpha, and fallback paints.
+
+Gradient layers remain vector output. Generated SwiftUI uses `Canvas` to clip a Core Graphics axial or radial gradient to the native generated path; it does not rasterize the SVG during conversion. Affine gradient transforms are composed before element and ancestor transforms. Degenerate object bounding boxes deterministically paint nothing, as required for a valid paint server that cannot produce paint.
+
+Color stops are sampled in unpremultiplied SVG color space before Core Graphics draws them. `color-interpolation: sRGB`/`auto` uses sRGB channel interpolation; `linearRGB` applies the standard sRGB transfer functions, interpolates linear-light channels, then encodes back to sRGB. Sampling uses 256 intervals per spread period, which keeps Core Graphics interpolation within the RGBA harness tolerance while supporting repeat and reflect without whole-image rasterization.
+
 ## Before we start
 
 This package is written for JavaScript projects, so it's only meant to be used in a Node.js projects. If you just need to convert an SVG to SwiftUI Shape you should use [this tool](https://github.com/bring-shrubbery/SVG-to-SwiftUI).
@@ -108,6 +116,7 @@ The default antialiasing allowance is 24/255 per channel, at most 3% pixels outs
 - [x] SVG lengths, nested viewports, `<view>` fragments, and `preserveAspectRatio`
 - [x] SVG transforms (`matrix`, `translate`, `scale`, `rotate`, `skewX`, `skewY`)
 - [x] Solid fill/stroke styling with colours
+- [x] Linear/radial gradient fills and strokes, stops, inheritance, transforms, and spread methods
 - [x] Embedded CSS cascade, custom properties, and computed presentation styles
 - [ ] SVG `<text>` element
 - [ ] Automatic animation support

--- a/packages/svg-to-swiftui-core/src/colorUtils.ts
+++ b/packages/svg-to-swiftui-core/src/colorUtils.ts
@@ -1,6 +1,6 @@
 import colorNames from "color-name";
 
-interface RGBAColor {
+export interface RGBAColor {
   red: number;
   green: number;
   blue: number;
@@ -143,6 +143,19 @@ export function parseOpacity(value: string | number | undefined): number {
   return parseAlpha(String(value)) ?? 1;
 }
 
+/** Parse a supported SVG/CSS color without converting it to Swift source. */
+export function parseRGBAColor(paint: string): RGBAColor | undefined {
+  const normalized = paint.trim().toLowerCase();
+  const namedChannels = colorNames[normalized as keyof typeof colorNames];
+  return normalized === "transparent"
+    ? parseHexColor("#00000000")
+    : namedChannels
+      ? { red: namedChannels[0] / 255, green: namedChannels[1] / 255, blue: namedChannels[2] / 255, alpha: 1 }
+      : normalized.startsWith("#")
+        ? parseHexColor(normalized)
+        : (parseRGBColor(normalized) ?? parseHSLColor(normalized));
+}
+
 export function swiftUIColor(paint: string, opacity = 1): string | undefined {
   const normalized = paint.trim().toLowerCase();
   if (normalized === "currentcolor") {
@@ -150,15 +163,7 @@ export function swiftUIColor(paint: string, opacity = 1): string | undefined {
     return effectiveOpacity === 1 ? "Color.primary" : `Color.primary.opacity(${formatComponent(effectiveOpacity)})`;
   }
 
-  const namedChannels = colorNames[normalized as keyof typeof colorNames];
-  const color =
-    normalized === "transparent"
-      ? parseHexColor("#00000000")
-      : namedChannels
-        ? { red: namedChannels[0] / 255, green: namedChannels[1] / 255, blue: namedChannels[2] / 255, alpha: 1 }
-        : normalized.startsWith("#")
-          ? parseHexColor(normalized)
-          : (parseRGBColor(normalized) ?? parseHSLColor(normalized));
+  const color = parseRGBAColor(normalized);
   if (!color) return undefined;
 
   const alpha = clamp(color.alpha * opacity);

--- a/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
@@ -56,7 +56,8 @@ function pointsBounds(points: string): RenderBounds | undefined {
   return { x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y };
 }
 
-function geometryBounds(geometry: Geometry): RenderBounds | undefined {
+/** Untransformed geometry bounds, excluding stroke expansion and paint effects. */
+export function geometryBounds(geometry: Geometry): RenderBounds | undefined {
   switch (geometry.type) {
     case "rect":
       return { x: geometry.x, y: geometry.y, width: geometry.width, height: geometry.height };

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -14,6 +14,7 @@ import { type Presentation, type StyleResolution, SVGStyleResolver } from "../st
 import { type AffineTransform, IDENTITY_TRANSFORM, multiplyTransforms, parseTransform } from "../transformUtils";
 import type { SVGElementProperties, ViewBoxData } from "../types";
 import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio, parseViewBox, viewBoxTransform } from "../viewports";
+import { resolvePaintServers } from "./gradients";
 import type {
   ComputedStyle,
   CSSDiagnosticContext,
@@ -89,7 +90,12 @@ function parsePaint(value: unknown, currentColor: string): Paint {
   if (normalized.toLowerCase() === "currentcolor") return { type: "solid", value: currentColor };
   const reference = /^url\(\s*#([^\s)]+)\s*\)(?:\s+(.+))?$/i.exec(normalized);
   if (reference) {
-    return { type: "reference", id: reference[1]!, ...(reference[2] ? { fallback: reference[2].trim() } : {}) };
+    const fallback = reference[2]?.trim();
+    return {
+      type: "reference",
+      id: reference[1]!,
+      ...(fallback ? { fallback: fallback.toLowerCase() === "currentcolor" ? currentColor : fallback } : {}),
+    };
   }
   return { type: "solid", value: normalized };
 }
@@ -499,6 +505,7 @@ function createRegistry(root: ElementNode): ResourceRegistry {
     definitions: new Map(),
     symbols: new Map(),
     paints: new Map(),
+    paintElements: new Map(),
     clips: new Map(),
     masks: new Map(),
     markers: new Map(),
@@ -513,7 +520,7 @@ function createRegistry(root: ElementNode): ResourceRegistry {
       if (element.tagName === "symbol") registry.symbols.set(id, element);
       if (element.tagName === "view") registry.views.set(id, element);
       if (["linearGradient", "radialGradient", "pattern"].includes(element.tagName ?? ""))
-        registry.paints.set(id, element);
+        registry.paintElements.set(id, element);
       if (element.tagName === "clipPath") registry.clips.set(id, element);
       if (element.tagName === "mask") registry.masks.set(id, element);
       if (element.tagName === "marker") registry.markers.set(id, element);
@@ -799,6 +806,11 @@ function buildNode(
             style: resolved.style,
             transform,
             source: sourceLocation(element),
+            paintContext: {
+              viewport: { ...coordinate.viewport },
+              rootViewport: { ...coordinate.rootViewport },
+              fontMetrics: { ...resolved.fontMetrics },
+            },
           },
         ]
       : [];
@@ -855,6 +867,14 @@ export function buildRenderDocument(
     fontMetrics: defaultFontMetrics(),
   };
   const resolved = resolvedPresentation(svg, {}, coordinate, context, true);
+  resources.paints = resolvePaintServers(
+    svg,
+    resources.paintElements,
+    resources.definitions,
+    styleResolver,
+    resolved.effective,
+    diagnostics,
+  );
   const rootTransform = multiplyTransforms(computedTransform(svg, resolved, context), properties.viewBoxTransform);
   const childCoordinate = { ...coordinate, fontMetrics: resolved.fontMetrics };
   const root: RenderGroup = {
@@ -877,9 +897,14 @@ export function buildRenderDocument(
       if (node.type !== "shape") continue;
       for (const paint of [node.style.fill, node.style.stroke]) {
         if (paint.type !== "reference") continue;
+        const server = resources.paints.get(paint.id);
+        if (server?.type === "linearGradient" || server?.type === "radialGradient") continue;
+        const exists = resources.definitions.get(paint.id);
         diagnostics.push({
-          code: "unsupported-paint-reference",
-          message: `Paint server #${paint.id} is represented but is not implemented by the SwiftUI backend yet.`,
+          code: exists ? "wrong-paint-server-type" : "missing-paint-server",
+          message: exists
+            ? `Paint reference #${paint.id} targets <${exists.tagName}> instead of a supported gradient.`
+            : `Paint reference #${paint.id} does not resolve to a local resource.`,
           severity: "warning",
           source: node.source,
         });

--- a/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
@@ -59,8 +59,9 @@ function containsIndependentCompositing(nodes: RenderNode[]): boolean {
 }
 
 function solidColor(paint: Paint, opacity: number): string | undefined {
-  if (paint.type !== "solid") return undefined;
-  return swiftUIColor(paint.value, opacity);
+  if (paint.type === "solid") return swiftUIColor(paint.value, opacity);
+  if (paint.type === "reference" && paint.fallback) return swiftUIColor(paint.fallback, opacity);
+  return undefined;
 }
 
 function hasIntrinsicAlpha(paint: Paint): boolean {
@@ -73,12 +74,18 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   const paints = collectVisiblePaints(document.children);
   const reasons: string[] = [];
   const needsViewportClip = containsViewportClip(document.children);
+  const hasGradientPaint = paints.some(({ paint }) => {
+    if (paint.type !== "reference") return false;
+    const server = document.resources.paints.get(paint.id);
+    return server?.type === "linearGradient" || server?.type === "radialGradient";
+  });
   const needsIndependentCompositing =
     containsIndependentCompositing(document.children) || paints.some(({ paint }) => hasIntrinsicAlpha(paint));
 
   if (
     config.preserveColors === false &&
     !needsViewportClip &&
+    !hasGradientPaint &&
     !needsIndependentCompositing &&
     !containsGeneralViewContent(document.children)
   ) {
@@ -91,13 +98,23 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
 
   if (containsGeneralViewContent(document.children)) reasons.push("document contains non-geometry view content");
   if (needsViewportClip) reasons.push("document contains a clipped nested viewport");
+  if (hasGradientPaint) reasons.push("document uses an SVG gradient paint server");
   if (needsIndependentCompositing) reasons.push("document uses independent paint or group opacity");
 
-  const colors = paints.map(({ paint, opacity }) => solidColor(paint, opacity));
+  const colors = paints.map(({ paint, opacity }) => {
+    if (paint.type === "reference") {
+      const server = document.resources.paints.get(paint.id);
+      if (server?.type === "linearGradient" || server?.type === "radialGradient") return `gradient:#${paint.id}`;
+    }
+    return solidColor(paint, opacity);
+  });
   const allColorsSupported = colors.every((color) => color !== undefined);
   if (!allColorsSupported) {
     return {
-      mode: containsGeneralViewContent(document.children) ? "view" : "shape",
+      mode:
+        config.preserveColors === true || containsGeneralViewContent(document.children) || hasGradientPaint
+          ? "view"
+          : "shape",
       reasons: ["one or more source paints require a future paint backend"],
       paintCount: paints.length,
     };

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -4,7 +4,8 @@ import { handleElement } from "../elementHandlers";
 import { createFunctionTemplate, createStructTemplate } from "../templates";
 import { wrapWithTransform } from "../transformUtils";
 import type { SVGElementProperties, SwiftUIGeneratorConfig, TranspilerOptions } from "../types";
-import type { ComputedStyle, Geometry, Paint, RenderDocument, RenderNode, RenderShape } from "./types";
+import { type ResolvedGradient, resolveGradientForShape } from "./gradients";
+import type { ComputedStyle, Geometry, GradientStop, Paint, RenderDocument, RenderNode, RenderShape } from "./types";
 
 export interface GeneratedSwiftUI {
   lines: string[];
@@ -19,6 +20,14 @@ interface ShapeHelper {
 type GeneratedViewNode =
   | { type: "paint"; helper: string; swiftColor: string }
   | {
+      type: "gradient";
+      helper: string;
+      gradient: ResolvedGradient;
+      paintOpacity: number;
+      coordinateWidth: number;
+      coordinateHeight: number;
+    }
+  | {
       type: "group";
       children: GeneratedViewNode[];
       opacity: number;
@@ -31,6 +40,8 @@ interface ViewBuildContext {
   helpers: ShapeHelper[];
   nextLayer: number;
   nextClip: number;
+  document: RenderDocument;
+  precision: number;
 }
 
 function createOptions(
@@ -152,6 +163,20 @@ function colorForPaint(paint: Paint, opacity: number): string | undefined {
   return undefined;
 }
 
+function formatNumber(value: number, precision = 10): string {
+  const rounded = Number(value.toFixed(precision));
+  return String(Object.is(rounded, -0) ? 0 : rounded);
+}
+
+function colorForStop(stop: GradientStop, opacity: number, precision: number): string {
+  const { red, green, blue, alpha } = stop.color;
+  const channels = `red: ${formatNumber(red, precision)}, green: ${formatNumber(green, precision)}, blue: ${formatNumber(blue, precision)}`;
+  const effectiveAlpha = alpha * opacity;
+  return effectiveAlpha === 1
+    ? `Color(${channels})`
+    : `Color(${channels}, opacity: ${formatNumber(effectiveAlpha, precision)})`;
+}
+
 function addHelper(context: ViewBuildContext, name: string, lines: string[]): string {
   context.helpers.push({ name, lines });
   return name;
@@ -208,8 +233,6 @@ function buildViewNodes(
     const paints: GeneratedViewNode[] = [];
 
     const addLayer = (kind: "fill" | "stroke", paint: Paint, paintOpacity: number) => {
-      const swiftColor = colorForPaint(paint, paintOpacity);
-      if (!swiftColor) return;
       let lines = renderShape(
         node,
         context.options,
@@ -218,10 +241,43 @@ function buildViewNodes(
       for (let index = ancestorTransforms.length - 1; index >= 0; index--) {
         lines = wrapWithTransform(lines, ancestorTransforms[index]!, context.options);
       }
-      if (lines.length > 0) {
-        const helper = addHelper(context, `Layer${context.nextLayer++}`, lines);
-        paints.push({ type: "paint", helper, swiftColor });
+      if (lines.length === 0) return;
+      const helper = addHelper(context, `Layer${context.nextLayer++}`, lines);
+      if (paint.type === "reference") {
+        const server = context.document.resources.paints.get(paint.id);
+        if (server?.type === "linearGradient" || server?.type === "radialGradient") {
+          if (server.stops.length === 0) return;
+          if (server.stops.length === 1) {
+            paints.push({
+              type: "paint",
+              helper,
+              swiftColor: colorForStop(server.stops[0]!, paintOpacity, context.precision),
+            });
+            return;
+          }
+          const gradient = resolveGradientForShape(server, node, ancestorTransforms);
+          if (gradient.type === "solid") {
+            paints.push({
+              type: "paint",
+              helper,
+              swiftColor: colorForStop(gradient.stop, paintOpacity, context.precision),
+            });
+            return;
+          }
+          if (gradient.type === "none") return;
+          paints.push({
+            type: "gradient",
+            helper,
+            gradient,
+            paintOpacity,
+            coordinateWidth: context.document.viewport.coordinateSpace.width,
+            coordinateHeight: context.document.viewport.coordinateSpace.height,
+          });
+          return;
+        }
       }
+      const swiftColor = colorForPaint(paint, paintOpacity);
+      if (swiftColor) paints.push({ type: "paint", helper, swiftColor });
     };
 
     for (const kind of node.style.paintOrder) {
@@ -252,9 +308,60 @@ function swiftNumber(value: number): string {
   return String(Object.is(value, -0) ? 0 : value);
 }
 
+function gradientStopLiteral(stop: GradientStop, opacity: number): string {
+  return `SVGGradientStop(offset: ${formatNumber(stop.offset)}, red: ${formatNumber(stop.color.red)}, green: ${formatNumber(stop.color.green)}, blue: ${formatNumber(stop.color.blue)}, alpha: ${formatNumber(stop.color.alpha * opacity)})`;
+}
+
+function renderGradientNode(
+  node: Extract<GeneratedViewNode, { type: "gradient" }>,
+  level: number,
+  indentation: string,
+): string[] {
+  const prefix = indentation.repeat(level);
+  const inner = indentation.repeat(level + 1);
+  const nested = indentation.repeat(level + 2);
+  const deep = indentation.repeat(level + 3);
+  const gradient = node.gradient;
+  const matrix = gradient.matrix;
+  const stops = gradient.stops.map((stop) => gradientStopLiteral(stop, node.paintOpacity)).join(", ");
+  const transform = `CGAffineTransform(a: ${formatNumber(matrix.a)} * size.width / ${formatNumber(node.coordinateWidth)}, b: ${formatNumber(matrix.b)} * size.height / ${formatNumber(node.coordinateHeight)}, c: ${formatNumber(matrix.c)} * size.width / ${formatNumber(node.coordinateWidth)}, d: ${formatNumber(matrix.d)} * size.height / ${formatNumber(node.coordinateHeight)}, tx: ${formatNumber(matrix.e)} * size.width / ${formatNumber(node.coordinateWidth)}, ty: ${formatNumber(matrix.f)} * size.height / ${formatNumber(node.coordinateHeight)})`;
+  const lines = [
+    `${prefix}Canvas { context, size in`,
+    `${inner}let clipPath = ${node.helper}().path(in: CGRect(origin: .zero, size: size))`,
+    `${inner}let stops = [${stops}]`,
+    `${inner}if let gradient = svgGradient(stops: stops, spread: .${gradient.spreadMethod === "repeat" ? "repeating" : gradient.spreadMethod}, startT: ${formatNumber(gradient.startT)}, endT: ${formatNumber(gradient.endT)}, linearRGB: ${gradient.colorInterpolation === "linearRGB"}) {`,
+    `${nested}context.withCGContext { graphics in`,
+    `${deep}graphics.saveGState()`,
+    `${deep}graphics.addPath(clipPath.cgPath)`,
+    `${deep}graphics.clip()`,
+    `${deep}graphics.concatenate(${transform})`,
+  ];
+  if (gradient.type === "linearGradient") {
+    const dx = gradient.x2 - gradient.x1;
+    const dy = gradient.y2 - gradient.y1;
+    const startX = gradient.x1 + dx * gradient.startT;
+    const startY = gradient.y1 + dy * gradient.startT;
+    const endX = gradient.x1 + dx * gradient.endT;
+    const endY = gradient.y1 + dy * gradient.endT;
+    lines.push(
+      `${deep}graphics.drawLinearGradient(gradient, start: CGPoint(x: ${formatNumber(startX)}, y: ${formatNumber(startY)}), end: CGPoint(x: ${formatNumber(endX)}, y: ${formatNumber(endY)}), options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
+    );
+  } else {
+    const dx = gradient.cx - gradient.fx;
+    const dy = gradient.cy - gradient.fy;
+    const dr = gradient.r - gradient.fr;
+    lines.push(
+      `${deep}graphics.drawRadialGradient(gradient, startCenter: CGPoint(x: ${formatNumber(gradient.fx + dx * gradient.startT)}, y: ${formatNumber(gradient.fy + dy * gradient.startT)}), startRadius: ${formatNumber(gradient.fr + dr * gradient.startT)}, endCenter: CGPoint(x: ${formatNumber(gradient.fx + dx * gradient.endT)}, y: ${formatNumber(gradient.fy + dy * gradient.endT)}), endRadius: ${formatNumber(gradient.fr + dr * gradient.endT)}, options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
+    );
+  }
+  lines.push(`${deep}graphics.restoreGState()`, `${nested}}`, `${inner}}`, `${prefix}}`);
+  return lines;
+}
+
 function renderViewNode(node: GeneratedViewNode, level: number, indentation: string): string[] {
   const prefix = indentation.repeat(level);
   if (node.type === "paint") return [`${prefix}${node.helper}().fill(${node.swiftColor})`];
+  if (node.type === "gradient") return renderGradientNode(node, level, indentation);
   const lines = [`${prefix}ZStack {`];
   for (const child of node.children) lines.push(...renderViewNode(child, level + 1, indentation));
   lines.push(`${prefix}}`);
@@ -262,6 +369,92 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
   if (node.isolated) lines.push(`${prefix}.compositingGroup()`);
   if (node.opacity !== 1) lines.push(`${prefix}.opacity(${swiftNumber(node.opacity)})`);
   return lines;
+}
+
+function containsGradientNode(nodes: GeneratedViewNode[]): boolean {
+  return nodes.some(
+    (node) => node.type === "gradient" || (node.type === "group" && containsGradientNode(node.children)),
+  );
+}
+
+function gradientSupport(indentationSize: number): string[] {
+  const indentation = " ".repeat(indentationSize);
+  return [
+    "private struct SVGGradientStop {",
+    `${indentation}let offset: CGFloat`,
+    `${indentation}let red: CGFloat`,
+    `${indentation}let green: CGFloat`,
+    `${indentation}let blue: CGFloat`,
+    `${indentation}let alpha: CGFloat`,
+    "}",
+    "",
+    "private enum SVGGradientSpread {",
+    `${indentation}case pad, reflect, repeating`,
+    "}",
+    "",
+    "private func svgLinearComponent(_ value: CGFloat) -> CGFloat {",
+    `${indentation}value <= 0.04045 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)`,
+    "}",
+    "",
+    "private func svgEncodedComponent(_ value: CGFloat) -> CGFloat {",
+    `${indentation}value <= 0.0031308 ? value * 12.92 : 1.055 * pow(value, 1 / 2.4) - 0.055`,
+    "}",
+    "",
+    "private func svgGradientPosition(_ value: CGFloat, spread: SVGGradientSpread) -> CGFloat {",
+    `${indentation}switch spread {`,
+    `${indentation}case .pad:`,
+    `${indentation}${indentation}return min(1, max(0, value))`,
+    `${indentation}case .repeating:`,
+    `${indentation}${indentation}return value - floor(value)`,
+    `${indentation}case .reflect:`,
+    `${indentation}${indentation}let period = value - floor(value / 2) * 2`,
+    `${indentation}${indentation}return period <= 1 ? period : 2 - period`,
+    `${indentation}}`,
+    "}",
+    "",
+    "private func svgGradient(stops: [SVGGradientStop], spread: SVGGradientSpread, startT: CGFloat, endT: CGFloat, linearRGB: Bool) -> CGGradient? {",
+    `${indentation}guard stops.count >= 2, endT > startT else { return nil }`,
+    `${indentation}let sampleCount = max(256, Int(ceil(abs(endT - startT) * 256)))`,
+    `${indentation}var components: [CGFloat] = []`,
+    `${indentation}var locations: [CGFloat] = []`,
+    `${indentation}components.reserveCapacity((sampleCount + 1) * 4)`,
+    `${indentation}locations.reserveCapacity(sampleCount + 1)`,
+    `${indentation}for index in 0...sampleCount {`,
+    `${indentation}${indentation}let location = CGFloat(index) / CGFloat(sampleCount)`,
+    `${indentation}${indentation}let source = startT + (endT - startT) * location`,
+    `${indentation}${indentation}let position = svgGradientPosition(source, spread: spread)`,
+    `${indentation}${indentation}var lower = stops[0]`,
+    `${indentation}${indentation}var upper = stops[stops.count - 1]`,
+    `${indentation}${indentation}for stop in stops {`,
+    `${indentation}${indentation}${indentation}if stop.offset <= position { lower = stop } else { upper = stop; break }`,
+    `${indentation}${indentation}}`,
+    `${indentation}${indentation}let distance = upper.offset - lower.offset`,
+    `${indentation}${indentation}let ratio = distance == 0 ? 0 : (position - lower.offset) / distance`,
+    `${indentation}${indentation}let lowerRed = linearRGB ? svgLinearComponent(lower.red) : lower.red`,
+    `${indentation}${indentation}let lowerGreen = linearRGB ? svgLinearComponent(lower.green) : lower.green`,
+    `${indentation}${indentation}let lowerBlue = linearRGB ? svgLinearComponent(lower.blue) : lower.blue`,
+    `${indentation}${indentation}let upperRed = linearRGB ? svgLinearComponent(upper.red) : upper.red`,
+    `${indentation}${indentation}let upperGreen = linearRGB ? svgLinearComponent(upper.green) : upper.green`,
+    `${indentation}${indentation}let upperBlue = linearRGB ? svgLinearComponent(upper.blue) : upper.blue`,
+    `${indentation}${indentation}var red = lowerRed + (upperRed - lowerRed) * ratio`,
+    `${indentation}${indentation}var green = lowerGreen + (upperGreen - lowerGreen) * ratio`,
+    `${indentation}${indentation}var blue = lowerBlue + (upperBlue - lowerBlue) * ratio`,
+    `${indentation}${indentation}if linearRGB {`,
+    `${indentation}${indentation}${indentation}red = svgEncodedComponent(red)`,
+    `${indentation}${indentation}${indentation}green = svgEncodedComponent(green)`,
+    `${indentation}${indentation}${indentation}blue = svgEncodedComponent(blue)`,
+    `${indentation}${indentation}}`,
+    `${indentation}${indentation}components.append(contentsOf: [red, green, blue, lower.alpha + (upper.alpha - lower.alpha) * ratio])`,
+    `${indentation}${indentation}locations.append(location)`,
+    `${indentation}}`,
+    `${indentation}let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!`,
+    `${indentation}return components.withUnsafeBufferPointer { componentBuffer in`,
+    `${indentation}${indentation}locations.withUnsafeBufferPointer { locationBuffer in`,
+    `${indentation}${indentation}${indentation}CGGradient(colorSpace: colorSpace, colorComponents: componentBuffer.baseAddress!, locations: locationBuffer.baseAddress!, count: locations.count)`,
+    `${indentation}${indentation}}`,
+    `${indentation}}`,
+    "}",
+  ];
 }
 
 function createView(
@@ -295,6 +488,7 @@ function createView(
     layerStruct[0] = `private ${layerStruct[0]}`;
     body.push("", ...layerStruct);
   }
+  if (containsGradientNode(nodes)) body.push("", ...gradientSupport(indentationSize));
   return createStructTemplate({ name, indent: indentationSize, returnType: "View", body });
 }
 
@@ -330,7 +524,14 @@ export function generateView(
 ): GeneratedSwiftUI {
   const indentationSize = config.indentationSize ?? 4;
   const options = createOptions(svgProperties, document, config, true);
-  const context: ViewBuildContext = { options, helpers: [], nextLayer: 0, nextClip: 0 };
+  const context: ViewBuildContext = {
+    options,
+    helpers: [],
+    nextLayer: 0,
+    nextClip: 0,
+    document,
+    precision: config.precision ?? 10,
+  };
   const nodes = buildViewNodes(document.children, context);
   return {
     lines: createView(config.structName ?? "SVGView", nodes, context.helpers, indentationSize),

--- a/packages/svg-to-swiftui-core/src/renderTree/gradients.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/gradients.ts
@@ -1,0 +1,522 @@
+import type { ElementNode } from "svg-parser";
+import { parseOpacity, parseRGBAColor } from "../colorUtils";
+import { lengthContext, type ParsedSVGLength, parseSVGLength, resolveSVGLength, SVGLengthError } from "../lengths";
+import type { Presentation, SVGStyleResolver } from "../styleCascade";
+import { type AffineTransform, IDENTITY_TRANSFORM, multiplyTransforms, parseTransform } from "../transformUtils";
+import { geometryBounds } from "./bounds";
+import type {
+  GradientColorInterpolation,
+  GradientPaint,
+  GradientSpreadMethod,
+  GradientStop,
+  GradientUnits,
+  InvalidPaintServer,
+  PaintServer,
+  RenderBounds,
+  RenderDiagnostic,
+  RenderShape,
+  SourceLocation,
+} from "./types";
+
+export interface ResolvedLinearGradient {
+  type: "linearGradient";
+  matrix: AffineTransform;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  startT: number;
+  endT: number;
+  stops: GradientStop[];
+  spreadMethod: GradientSpreadMethod;
+  colorInterpolation: GradientColorInterpolation;
+}
+
+export interface ResolvedRadialGradient {
+  type: "radialGradient";
+  matrix: AffineTransform;
+  cx: number;
+  cy: number;
+  r: number;
+  fx: number;
+  fy: number;
+  fr: number;
+  startT: number;
+  endT: number;
+  stops: GradientStop[];
+  spreadMethod: GradientSpreadMethod;
+  colorInterpolation: GradientColorInterpolation;
+}
+
+export type ResolvedGradient = ResolvedLinearGradient | ResolvedRadialGradient;
+export type ResolvedGradientPaint = ResolvedGradient | { type: "solid"; stop: GradientStop } | { type: "none" };
+
+function sourceLocation(element: ElementNode): SourceLocation {
+  const id = element.properties?.id;
+  return { element: element.tagName ?? "unknown", ...(id === undefined ? {} : { id: String(id) }) };
+}
+
+function diagnostic(diagnostics: RenderDiagnostic[], element: ElementNode, code: string, message: string): void {
+  diagnostics.push({ code, message, severity: "warning", source: sourceLocation(element) });
+}
+
+function children(element: ElementNode): ElementNode[] {
+  return element.children.filter(
+    (child): child is ElementNode => typeof child !== "string" && child.type === "element",
+  );
+}
+
+function containsGradient(element: ElementNode): boolean {
+  return (
+    element.tagName === "linearGradient" ||
+    element.tagName === "radialGradient" ||
+    children(element).some(containsGradient)
+  );
+}
+
+function href(element: ElementNode): string | undefined {
+  const raw =
+    element.properties?.href ??
+    element.properties?.["xlink:href"] ??
+    element.properties?.xlinkHref ??
+    element.properties?.xLinkHref;
+  if (raw === undefined || String(raw).trim() === "") return undefined;
+  return String(raw).trim();
+}
+
+function invalidServer(element: ElementNode, type: InvalidPaintServer["type"]): InvalidPaintServer {
+  return {
+    type,
+    id: String(element.properties?.id ?? ""),
+    element: element.tagName ?? "unknown",
+    source: sourceLocation(element),
+  };
+}
+
+function parsedLength(
+  raw: unknown,
+  fallback: string,
+  label: string,
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+): ParsedSVGLength {
+  try {
+    const parsed = parseSVGLength(raw ?? fallback);
+    if (parsed.kind !== "length") throw new SVGLengthError("invalid-gradient-length", `${label} requires a length.`);
+    return parsed;
+  } catch (error) {
+    diagnostic(
+      diagnostics,
+      element,
+      error instanceof SVGLengthError ? error.code : "invalid-gradient-length",
+      `Invalid ${label}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return parseSVGLength(fallback) as ParsedSVGLength;
+  }
+}
+
+function stopOffset(raw: unknown, previous: number, element: ElementNode, diagnostics: RenderDiagnostic[]): number {
+  const source = String(raw ?? 0).trim();
+  const match = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)(%)?$/.exec(source);
+  if (!match) {
+    diagnostic(diagnostics, element, "invalid-stop-offset", `Invalid gradient stop offset '${source}'.`);
+    return previous;
+  }
+  const numeric = Number(match[1]);
+  const normalized = match[2] ? numeric / 100 : numeric;
+  return Math.max(previous, Math.min(1, Math.max(0, normalized)));
+}
+
+function stopsFor(
+  element: ElementNode,
+  presentations: Map<ElementNode, Presentation>,
+  diagnostics: RenderDiagnostic[],
+): GradientStop[] {
+  const result: GradientStop[] = [];
+  let previous = 0;
+  for (const stop of children(element).filter((child) => child.tagName === "stop")) {
+    const style = presentations.get(stop) ?? {};
+    const offset = stopOffset(stop.properties?.offset, previous, stop, diagnostics);
+    previous = offset;
+    const colorSource = String(style["stop-color"] ?? "black");
+    const parsed = parseRGBAColor(colorSource);
+    if (!parsed) {
+      diagnostic(diagnostics, stop, "invalid-stop-color", `Unsupported gradient stop color '${colorSource}'.`);
+    }
+    const opacitySource = String(style["stop-opacity"] ?? 1).trim();
+    if (!/^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?%?$/.test(opacitySource)) {
+      diagnostic(diagnostics, stop, "invalid-stop-opacity", `Invalid stop-opacity '${opacitySource}'.`);
+    }
+    const color = parsed ?? { red: 0, green: 0, blue: 0, alpha: 1 };
+    result.push({
+      offset,
+      color: { ...color, alpha: color.alpha * parseOpacity(opacitySource) },
+      source: sourceLocation(stop),
+    });
+  }
+  return result;
+}
+
+function property(chain: ElementNode[], name: string): unknown {
+  for (const element of chain) {
+    const value = element.properties?.[name];
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+/** Resolve typed gradient resources, including href attribute and stop inheritance. */
+export function resolvePaintServers(
+  root: ElementNode,
+  paintElements: Map<string, ElementNode>,
+  definitions: Map<string, ElementNode>,
+  styleResolver: SVGStyleResolver,
+  rootPresentation: Presentation,
+  diagnostics: RenderDiagnostic[],
+): Map<string, PaintServer> {
+  const presentations = new Map<ElementNode, Presentation>();
+
+  const walk = (element: ElementNode, inherited: Presentation): void => {
+    for (const child of children(element)) {
+      const isStop = child.tagName === "stop" && ["linearGradient", "radialGradient"].includes(element.tagName ?? "");
+      if (!containsGradient(child) && !isStop) continue;
+      const resolved = styleResolver.resolve(child, inherited);
+      presentations.set(child, resolved.values);
+      if (!isStop) walk(child, resolved.values);
+    }
+  };
+  walk(root, rootPresentation);
+
+  const chains = new Map<string, ElementNode[] | undefined>();
+  const chainFor = (id: string, stack: string[] = []): ElementNode[] | undefined => {
+    if (chains.has(id)) return chains.get(id);
+    const element = paintElements.get(id);
+    if (!element || !["linearGradient", "radialGradient"].includes(element.tagName ?? "")) return undefined;
+    if (stack.includes(id)) {
+      diagnostic(
+        diagnostics,
+        element,
+        "cyclic-gradient-reference",
+        `Gradient reference cycle detected: ${[...stack.slice(stack.indexOf(id)), id].map((item) => `#${item}`).join(" -> ")}.`,
+      );
+      for (const cycleId of stack.slice(stack.indexOf(id))) chains.set(cycleId, undefined);
+      chains.set(id, undefined);
+      return undefined;
+    }
+    const reference = href(element);
+    if (!reference) {
+      const chain = [element];
+      chains.set(id, chain);
+      return chain;
+    }
+    if (!reference.startsWith("#")) {
+      diagnostic(
+        diagnostics,
+        element,
+        "external-gradient-reference",
+        `Only local gradient href references are supported.`,
+      );
+      chains.set(id, undefined);
+      return undefined;
+    }
+    const parentId = reference.slice(1);
+    const referenced = definitions.get(parentId);
+    if (!referenced) {
+      diagnostic(
+        diagnostics,
+        element,
+        "missing-gradient-template",
+        `Gradient #${id} references missing template #${parentId}.`,
+      );
+      chains.set(id, undefined);
+      return undefined;
+    }
+    if (!["linearGradient", "radialGradient"].includes(referenced.tagName ?? "")) {
+      diagnostic(
+        diagnostics,
+        element,
+        "wrong-gradient-template-type",
+        `Gradient #${id} references <${referenced.tagName}> instead of a gradient.`,
+      );
+      chains.set(id, undefined);
+      return undefined;
+    }
+    const parent = chainFor(parentId, [...stack, id]);
+    if (!parent) {
+      chains.set(id, undefined);
+      return undefined;
+    }
+    const chain = [element, ...parent];
+    chains.set(id, chain);
+    return chain;
+  };
+
+  const result = new Map<string, PaintServer>();
+  for (const [id, element] of paintElements) {
+    if (element.tagName === "pattern") {
+      result.set(id, invalidServer(element, "unsupported"));
+      continue;
+    }
+    const chain = chainFor(id);
+    if (!chain) {
+      result.set(id, invalidServer(element, "invalid"));
+      continue;
+    }
+
+    const unitsSource = String(property(chain, "gradientUnits") ?? "objectBoundingBox");
+    const units: GradientUnits = unitsSource === "userSpaceOnUse" ? "userSpaceOnUse" : "objectBoundingBox";
+    if (!["userSpaceOnUse", "objectBoundingBox"].includes(unitsSource)) {
+      diagnostic(diagnostics, element, "invalid-gradient-units", `Invalid gradientUnits '${unitsSource}'.`);
+    }
+
+    const spreadSource = String(property(chain, "spreadMethod") ?? "pad").toLowerCase();
+    const spreadMethod: GradientSpreadMethod = ["pad", "reflect", "repeat"].includes(spreadSource)
+      ? (spreadSource as GradientSpreadMethod)
+      : "pad";
+    if (spreadMethod !== spreadSource) {
+      diagnostic(diagnostics, element, "invalid-gradient-spread", `Invalid spreadMethod '${spreadSource}'.`);
+    }
+
+    let transform = IDENTITY_TRANSFORM;
+    const transformSource = property(chain, "gradientTransform");
+    if (transformSource !== undefined) {
+      try {
+        transform = parseTransform(transformSource);
+      } catch (error) {
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-gradient-transform",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+
+    const interpolationSource = String(presentations.get(element)?.["color-interpolation"] ?? "sRGB");
+    const colorInterpolation: GradientColorInterpolation =
+      interpolationSource.toLowerCase() === "linearrgb" ? "linearRGB" : "sRGB";
+    if (!["srgb", "linearrgb", "auto"].includes(interpolationSource.toLowerCase())) {
+      diagnostic(
+        diagnostics,
+        element,
+        "invalid-color-interpolation",
+        `Invalid color-interpolation '${interpolationSource}'.`,
+      );
+    }
+
+    const stopOwner = chain.find((candidate) => children(candidate).some((child) => child.tagName === "stop"));
+    const stops = stopOwner ? stopsFor(stopOwner, presentations, diagnostics) : [];
+    const base = {
+      id,
+      units,
+      transform,
+      spreadMethod,
+      stops,
+      colorInterpolation,
+      ...(href(element)?.startsWith("#") ? { href: href(element)!.slice(1) } : {}),
+      source: sourceLocation(element),
+    };
+
+    let paint: GradientPaint;
+    if (element.tagName === "linearGradient") {
+      paint = {
+        ...base,
+        type: "linearGradient",
+        x1: parsedLength(property(chain, "x1"), "0%", "linear gradient x1", element, diagnostics),
+        y1: parsedLength(property(chain, "y1"), "0%", "linear gradient y1", element, diagnostics),
+        x2: parsedLength(property(chain, "x2"), "100%", "linear gradient x2", element, diagnostics),
+        y2: parsedLength(property(chain, "y2"), "0%", "linear gradient y2", element, diagnostics),
+      };
+    } else {
+      const cx = parsedLength(property(chain, "cx"), "50%", "radial gradient cx", element, diagnostics);
+      const cy = parsedLength(property(chain, "cy"), "50%", "radial gradient cy", element, diagnostics);
+      const r = parsedLength(property(chain, "r"), "50%", "radial gradient r", element, diagnostics);
+      const fxSource = property(chain, "fx");
+      const fySource = property(chain, "fy");
+      const fr = parsedLength(property(chain, "fr"), "0%", "radial gradient fr", element, diagnostics);
+      if (r.value < 0)
+        diagnostic(diagnostics, element, "negative-gradient-radius", "Radial gradient r cannot be negative.");
+      if (fr.value < 0)
+        diagnostic(diagnostics, element, "negative-gradient-focal-radius", "Radial gradient fr cannot be negative.");
+      paint = {
+        ...base,
+        type: "radialGradient",
+        cx,
+        cy,
+        r: r.value < 0 ? { ...r, value: 0 } : r,
+        fx: fxSource === undefined ? cx : parsedLength(fxSource, "50%", "radial gradient fx", element, diagnostics),
+        fy: fySource === undefined ? cy : parsedLength(fySource, "50%", "radial gradient fy", element, diagnostics),
+        fr: fr.value < 0 ? { ...fr, value: 0 } : fr,
+      };
+    }
+    result.set(id, paint);
+  }
+  return result;
+}
+
+function invert(matrix: AffineTransform): AffineTransform | undefined {
+  const determinant = matrix.a * matrix.d - matrix.b * matrix.c;
+  if (Math.abs(determinant) < 1e-12) return undefined;
+  return {
+    a: matrix.d / determinant,
+    b: -matrix.b / determinant,
+    c: -matrix.c / determinant,
+    d: matrix.a / determinant,
+    e: (matrix.c * matrix.f - matrix.d * matrix.e) / determinant,
+    f: (matrix.b * matrix.e - matrix.a * matrix.f) / determinant,
+  };
+}
+
+function point(matrix: AffineTransform, x: number, y: number): { x: number; y: number } {
+  return { x: matrix.a * x + matrix.c * y + matrix.e, y: matrix.b * x + matrix.d * y + matrix.f };
+}
+
+function boundsPoints(bounds: RenderBounds): Array<{ x: number; y: number }> {
+  const centerX = bounds.x + bounds.width / 2;
+  const centerY = bounds.y + bounds.height / 2;
+  return [
+    { x: bounds.x, y: bounds.y },
+    { x: bounds.x + bounds.width, y: bounds.y },
+    { x: bounds.x, y: bounds.y + bounds.height },
+    { x: bounds.x + bounds.width, y: bounds.y + bounds.height },
+    { x: centerX, y: bounds.y },
+    { x: centerX, y: bounds.y + bounds.height },
+    { x: bounds.x, y: centerY },
+    { x: bounds.x + bounds.width, y: centerY },
+  ];
+}
+
+function localToRoot(shape: RenderShape, ancestors: AffineTransform[]): AffineTransform {
+  return [...ancestors, shape.transform].reduce(
+    (matrix, transform) => multiplyTransforms(matrix, transform),
+    IDENTITY_TRANSFORM,
+  );
+}
+
+function resolveCoordinate(
+  value: ParsedSVGLength,
+  axis: "horizontal" | "vertical" | "other",
+  units: GradientUnits,
+  shape: RenderShape,
+): number {
+  const viewport = units === "objectBoundingBox" ? { width: 1, height: 1 } : shape.paintContext.viewport;
+  const percentageBasis =
+    axis === "horizontal" ? "viewport-width" : axis === "vertical" ? "viewport-height" : "viewport-diagonal";
+  const resolved = resolveSVGLength(
+    value,
+    lengthContext(viewport, shape.paintContext.rootViewport, percentageBasis, axis, shape.paintContext.fontMetrics),
+  );
+  return typeof resolved === "number" ? resolved : 0;
+}
+
+function spreadRange(values: number[], spreadMethod: GradientSpreadMethod): { startT: number; endT: number } {
+  if (spreadMethod === "pad") return { startT: 0, endT: 1 };
+  const minimum = Math.min(...values);
+  const maximum = Math.max(...values);
+  return { startT: Math.floor(Math.min(0, minimum)), endT: Math.ceil(Math.max(1, maximum)) };
+}
+
+function radialParameter(
+  x: number,
+  y: number,
+  fx: number,
+  fy: number,
+  fr: number,
+  cx: number,
+  cy: number,
+  r: number,
+): number | undefined {
+  const centerX = cx - fx;
+  const centerY = cy - fy;
+  const radius = r - fr;
+  const px = x - fx;
+  const py = y - fy;
+  const a = centerX * centerX + centerY * centerY - radius * radius;
+  const b = -2 * (px * centerX + py * centerY + fr * radius);
+  const c = px * px + py * py - fr * fr;
+  if (Math.abs(a) < 1e-12) {
+    if (Math.abs(b) < 1e-12) return undefined;
+    const value = -c / b;
+    return value >= 0 ? value : undefined;
+  }
+  const discriminant = b * b - 4 * a * c;
+  if (discriminant < 0) return undefined;
+  const root = Math.sqrt(discriminant);
+  const values = [(-b - root) / (2 * a), (-b + root) / (2 * a)].filter((value) => value >= 0);
+  return values.length > 0 ? Math.max(...values) : undefined;
+}
+
+/** Resolve one typed gradient against a specific shape's pre-paint bounds and coordinate context. */
+export function resolveGradientForShape(
+  gradient: GradientPaint,
+  shape: RenderShape,
+  ancestors: AffineTransform[] = [],
+): ResolvedGradientPaint {
+  if (gradient.stops.length === 0) return { type: "none" };
+  const bounds = geometryBounds(shape.geometry);
+  if (!bounds) return { type: "none" };
+  if (gradient.units === "objectBoundingBox" && (bounds.width === 0 || bounds.height === 0)) return { type: "none" };
+
+  const unitsMatrix: AffineTransform =
+    gradient.units === "objectBoundingBox"
+      ? { a: bounds.width, b: 0, c: 0, d: bounds.height, e: bounds.x, f: bounds.y }
+      : IDENTITY_TRANSFORM;
+  const gradientToLocal = multiplyTransforms(unitsMatrix, gradient.transform);
+  const matrix = multiplyTransforms(localToRoot(shape, ancestors), gradientToLocal);
+  const localToGradient = invert(gradientToLocal);
+  if (!localToGradient) return { type: "none" };
+  const targetPoints = boundsPoints(bounds).map((item) => point(localToGradient, item.x, item.y));
+
+  if (gradient.type === "linearGradient") {
+    const x1 = resolveCoordinate(gradient.x1, "horizontal", gradient.units, shape);
+    const y1 = resolveCoordinate(gradient.y1, "vertical", gradient.units, shape);
+    const x2 = resolveCoordinate(gradient.x2, "horizontal", gradient.units, shape);
+    const y2 = resolveCoordinate(gradient.y2, "vertical", gradient.units, shape);
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const lengthSquared = dx * dx + dy * dy;
+    if (lengthSquared < 1e-18) return { type: "solid", stop: gradient.stops[gradient.stops.length - 1]! };
+    const parameters = targetPoints.map((item) => ((item.x - x1) * dx + (item.y - y1) * dy) / lengthSquared);
+    return {
+      type: "linearGradient",
+      matrix,
+      x1,
+      y1,
+      x2,
+      y2,
+      ...spreadRange(parameters, gradient.spreadMethod),
+      stops: gradient.stops,
+      spreadMethod: gradient.spreadMethod,
+      colorInterpolation: gradient.colorInterpolation,
+    };
+  }
+
+  const cx = resolveCoordinate(gradient.cx, "horizontal", gradient.units, shape);
+  const cy = resolveCoordinate(gradient.cy, "vertical", gradient.units, shape);
+  const r = resolveCoordinate(gradient.r, "other", gradient.units, shape);
+  const fx = resolveCoordinate(gradient.fx, "horizontal", gradient.units, shape);
+  const fy = resolveCoordinate(gradient.fy, "vertical", gradient.units, shape);
+  const fr = resolveCoordinate(gradient.fr, "other", gradient.units, shape);
+  if (r === fr && cx === fx && cy === fy) return { type: "none" };
+  const parameters = targetPoints
+    .map((item) => radialParameter(item.x, item.y, fx, fy, fr, cx, cy, r))
+    .filter((value): value is number => value !== undefined);
+  const range =
+    gradient.spreadMethod === "pad"
+      ? { startT: 0, endT: 1 }
+      : { startT: 0, endT: Math.max(1, Math.ceil(parameters.length > 0 ? Math.max(...parameters) : 64)) };
+  return {
+    type: "radialGradient",
+    matrix,
+    cx,
+    cy,
+    r,
+    fx,
+    fy,
+    fr,
+    ...range,
+    stops: gradient.stops,
+    spreadMethod: gradient.spreadMethod,
+    colorInterpolation: gradient.colorInterpolation,
+  };
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -1,4 +1,6 @@
 import type { ElementNode } from "svg-parser";
+import type { RGBAColor } from "../colorUtils";
+import type { FontMetrics, ParsedSVGLength } from "../lengths";
 import type { AffineTransform } from "../transformUtils";
 import type { ViewBoxData } from "../types";
 import type { PreserveAspectRatio } from "../viewports";
@@ -33,6 +35,55 @@ export type Paint =
   | { type: "none" }
   | { type: "solid"; value: string }
   | { type: "reference"; id: string; fallback?: string };
+
+export type GradientUnits = "objectBoundingBox" | "userSpaceOnUse";
+export type GradientSpreadMethod = "pad" | "reflect" | "repeat";
+export type GradientColorInterpolation = "sRGB" | "linearRGB";
+
+export interface GradientStop {
+  offset: number;
+  color: RGBAColor;
+  source: SourceLocation;
+}
+
+interface GradientPaintBase {
+  id: string;
+  units: GradientUnits;
+  transform: AffineTransform;
+  spreadMethod: GradientSpreadMethod;
+  stops: GradientStop[];
+  colorInterpolation: GradientColorInterpolation;
+  href?: string;
+  source: SourceLocation;
+}
+
+export interface LinearGradientPaint extends GradientPaintBase {
+  type: "linearGradient";
+  x1: ParsedSVGLength;
+  y1: ParsedSVGLength;
+  x2: ParsedSVGLength;
+  y2: ParsedSVGLength;
+}
+
+export interface RadialGradientPaint extends GradientPaintBase {
+  type: "radialGradient";
+  cx: ParsedSVGLength;
+  cy: ParsedSVGLength;
+  r: ParsedSVGLength;
+  fx: ParsedSVGLength;
+  fy: ParsedSVGLength;
+  fr: ParsedSVGLength;
+}
+
+export interface InvalidPaintServer {
+  type: "invalid" | "unsupported";
+  id: string;
+  element: string;
+  source: SourceLocation;
+}
+
+export type GradientPaint = LinearGradientPaint | RadialGradientPaint;
+export type PaintServer = GradientPaint | InvalidPaintServer;
 
 export interface StrokeStyle {
   width: number;
@@ -81,6 +132,12 @@ export interface RenderShape {
   style: ComputedStyle;
   transform: AffineTransform;
   source: SourceLocation;
+  /** Coordinate context at the referencing element, retained for user-space paint percentages. */
+  paintContext: {
+    viewport: { width: number; height: number };
+    rootViewport: { width: number; height: number };
+    fontMetrics: FontMetrics;
+  };
 }
 
 export interface RenderGroup {
@@ -128,7 +185,10 @@ export type RenderNode = RenderGroup | RenderShape | RenderText | RenderImage;
 export interface ResourceRegistry {
   definitions: Map<string, ElementNode>;
   symbols: Map<string, ElementNode>;
-  paints: Map<string, ElementNode>;
+  /** Typed paint resources consumed by the renderer. */
+  paints: Map<string, PaintServer>;
+  /** Original paint elements retained for future pattern/resource resolvers. */
+  paintElements: Map<string, ElementNode>;
   clips: Map<string, ElementNode>;
   masks: Map<string, ElementNode>;
   markers: Map<string, ElementNode>;

--- a/packages/svg-to-swiftui-core/src/tests/gradients.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/gradients.test.ts
@@ -1,0 +1,178 @@
+import { __testing, convert } from "../index";
+import { resolveGradientForShape } from "../renderTree/gradients";
+import type { GradientPaint, RenderNode, RenderShape } from "../renderTree/types";
+
+function flatten(nodes: RenderNode[]): RenderNode[] {
+  return nodes.flatMap((node) => (node.type === "group" ? [node, ...flatten(node.children)] : [node]));
+}
+
+function gradient(source: string, id: string): GradientPaint {
+  const server = __testing.parseRenderDocument(source).resources.paints.get(id);
+  if (server?.type !== "linearGradient" && server?.type !== "radialGradient") throw new Error(`Missing #${id}`);
+  return server;
+}
+
+describe("typed SVG gradient resources", () => {
+  test("retains defaults, coordinate units, transforms, spread, and ordered stops", () => {
+    const server = gradient(
+      `<svg viewBox="0 0 100 50"><defs><linearGradient id="g" x1="10%" y1="2" x2="90%" gradientTransform="skewX(12)" spreadMethod="reflect">
+        <stop offset="-20%" stop-color="red"/><stop offset="70%" stop-color="green"/><stop offset="40%" stop-color="blue"/><stop offset="140%" stop-color="white"/>
+      </linearGradient></defs></svg>`,
+      "g",
+    );
+    expect(server).toMatchObject({
+      type: "linearGradient",
+      units: "objectBoundingBox",
+      spreadMethod: "reflect",
+      x1: { value: 10, unit: "%" },
+      y1: { value: 2, unit: "" },
+      x2: { value: 90, unit: "%" },
+      y2: { value: 0, unit: "%" },
+    });
+    expect(server.stops.map((stop) => stop.offset)).toEqual([0, 0.7, 0.7, 1]);
+    expect(server.transform.c).not.toBe(0);
+  });
+
+  test("computes stop CSS, currentColor, intrinsic alpha, and stop opacity", () => {
+    const server = gradient(
+      `<svg viewBox="0 0 10 10"><style>.hot { stop-color: currentColor; stop-opacity: 50% }</style><defs>
+        <linearGradient id="g" color="#336699"><stop class="hot" offset="0"/><stop offset="1" stop-color="rgba(255,0,0,.4)" stop-opacity=".5"/>
+      </linearGradient></defs></svg>`,
+      "g",
+    );
+    expect(server.stops[0]?.color).toEqual({ red: 0.2, green: 0.4, blue: 0.6, alpha: 0.5 });
+    expect(server.stops[1]?.color.alpha).toBeCloseTo(0.2);
+  });
+
+  test("inherits href attributes and stops, while local stops replace the template", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 100"><defs>
+        <linearGradient id="base" x1="10%" x2="80%" spreadMethod="repeat"><stop offset="0" stop-color="red"/><stop offset="1" stop-color="blue"/></linearGradient>
+        <linearGradient id="inherited" href="#base" y2="100%"/>
+        <radialGradient id="override" href="#inherited"><stop offset=".25" stop-color="green"/></radialGradient>
+      </defs></svg>
+    `);
+    const inherited = document.resources.paints.get("inherited");
+    const override = document.resources.paints.get("override");
+    expect(inherited).toMatchObject({ type: "linearGradient", href: "base", spreadMethod: "repeat" });
+    if (inherited?.type !== "linearGradient") throw new Error("missing inherited gradient");
+    expect(inherited.x1).toMatchObject({ value: 10, unit: "%" });
+    expect(inherited.y2).toMatchObject({ value: 100, unit: "%" });
+    expect(inherited.stops).toHaveLength(2);
+    expect(override).toMatchObject({ type: "radialGradient", href: "inherited", stops: [{ offset: 0.25 }] });
+  });
+
+  test("diagnoses missing, wrong-type, cyclic, and malformed gradient resources", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20"><defs>
+        <rect id="shape" width="2" height="2"/>
+        <linearGradient id="wrong" href="#shape"/>
+        <linearGradient id="missing" href="#nope"/>
+        <linearGradient id="a" href="#b"/><radialGradient id="b" href="#a"/>
+        <linearGradient id="bad" gradientUnits="space" spreadMethod="mirror" gradientTransform="wat(1)"><stop offset="wat" stop-color="no-color"/></linearGradient>
+      </defs><rect width="20" height="20" fill="url(#not-there) #f00"/></svg>
+    `);
+    expect(document.diagnostics.map(({ code }) => code)).toEqual(
+      expect.arrayContaining([
+        "wrong-gradient-template-type",
+        "missing-gradient-template",
+        "cyclic-gradient-reference",
+        "invalid-gradient-units",
+        "invalid-gradient-spread",
+        "invalid-gradient-transform",
+        "invalid-stop-offset",
+        "invalid-stop-color",
+        "missing-paint-server",
+      ]),
+    );
+    expect(
+      convert(`<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="url(#missing) red"/></svg>`, {
+        preserveColors: true,
+      }),
+    ).toContain("Color(red: 1, green: 0, blue: 0)");
+    const current = __testing.parseRenderDocument(
+      `<svg viewBox="0 0 10 10" color="#123456"><rect width="10" height="10" fill="url(#missing) currentColor"/></svg>`,
+    );
+    const currentShape = flatten(current.children).find((node): node is RenderShape => node.type === "shape")!;
+    expect(currentShape.style.fill).toEqual({ type: "reference", id: "missing", fallback: "#123456" });
+  });
+
+  test("resolves object-bounding-box and user-space coordinates against the referencing shape", () => {
+    const source = `<svg viewBox="10 20 200 100"><defs>
+      <linearGradient id="box"><stop/><stop offset="1" stop-color="white"/></linearGradient>
+      <linearGradient id="user" gradientUnits="userSpaceOnUse" x1="25%" y1="50%" x2="75%" y2="50%"><stop/><stop offset="1" stop-color="white"/></linearGradient>
+    </defs><rect id="target" x="30" y="40" width="80" height="20" fill="url(#box)"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    const shape = flatten(document.children).find((node): node is RenderShape => node.type === "shape")!;
+    const box = document.resources.paints.get("box") as GradientPaint;
+    const user = document.resources.paints.get("user") as GradientPaint;
+    expect(resolveGradientForShape(box, shape)).toMatchObject({
+      type: "linearGradient",
+      matrix: { a: 80, d: 20, e: 30, f: 40 },
+      x1: 0,
+      x2: 1,
+    });
+    expect(resolveGradientForShape(user, shape)).toMatchObject({ x1: 50, y1: 50, x2: 150, y2: 50 });
+
+    const flatDocument = __testing.parseRenderDocument(
+      `<svg viewBox="0 0 100 100"><defs><linearGradient id="g"><stop/><stop offset="1" stop-color="white"/></linearGradient></defs><rect id="flat" width="80" height="0" fill="url(#g) red"/></svg>`,
+    );
+    const flatShape = flatten(flatDocument.children).find(
+      (node): node is RenderShape => node.type === "shape" && node.source.id === "flat",
+    )!;
+    expect(resolveGradientForShape(flatDocument.resources.paints.get("g") as GradientPaint, flatShape)).toEqual({
+      type: "none",
+    });
+  });
+
+  test("forces gradient fills and strokes through the View backend even when tinting was requested", () => {
+    const source = `<svg viewBox="0 0 20 20"><defs><linearGradient id="g"><stop stop-color="red"/><stop offset="1" stop-color="blue"/></linearGradient></defs><circle cx="10" cy="10" r="8" fill="url(#g)" stroke="url(#g)"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(__testing.analyzeCapabilities(document, { preserveColors: false })).toMatchObject({
+      mode: "view",
+      reasons: expect.arrayContaining(["document uses an SVG gradient paint server"]),
+    });
+    const output = convert(source);
+    expect(output).toContain("Canvas { context, size in");
+    expect(output).toContain("drawLinearGradient");
+  });
+
+  test("selects explicit linearRGB sampling and retains radial focal radius", () => {
+    const source = `<svg viewBox="0 0 100 100"><defs>
+      <linearGradient id="linear" color-interpolation="linearRGB"><stop stop-color="red"/><stop offset="1" stop-color="green"/></linearGradient>
+      <radialGradient id="radial" cx="50" cy="50" r="40" fx="35" fy="30" fr="5"><stop/><stop offset="1" stop-color="white"/></radialGradient>
+    </defs><rect width="100" height="100" fill="url(#linear)"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(document.resources.paints.get("linear")).toMatchObject({ colorInterpolation: "linearRGB" });
+    expect(document.resources.paints.get("radial")).toMatchObject({
+      type: "radialGradient",
+      fx: { value: 35 },
+      fy: { value: 30 },
+      fr: { value: 5 },
+    });
+    const output = convert(source);
+    expect(output).toContain("linearRGB: true");
+    expect(output).toContain("pow((value + 0.055) / 1.055, 2.4)");
+  });
+
+  test("keeps SVG 2 focal circles outside the end circle instead of applying SVG 1.1 clamping", () => {
+    const source = `<svg viewBox="0 0 100 100"><defs><radialGradient id="g" gradientUnits="userSpaceOnUse" cx="50" cy="50" r="20" fx="90" fy="50" fr="5"><stop/><stop offset="1" stop-color="white"/></radialGradient></defs><rect width="100" height="100" fill="url(#g)"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    const shape = flatten(document.children).find((node): node is RenderShape => node.type === "shape")!;
+    const resolved = resolveGradientForShape(document.resources.paints.get("g") as GradientPaint, shape);
+    expect(resolved).toMatchObject({ type: "radialGradient", fx: 90, fy: 50, fr: 5, cx: 50, cy: 50, r: 20 });
+  });
+
+  test("handles zero-stop and degenerate gradients deterministically", () => {
+    const linear = `<svg viewBox="0 0 10 10"><defs><linearGradient id="g" x1="50%" y1="50%" x2="50%" y2="50%"><stop stop-color="red"/><stop offset="1" stop-color="blue"/></linearGradient></defs><rect width="10" height="10" fill="url(#g)"/></svg>`;
+    const linearOutput = convert(linear);
+    expect(linearOutput).toContain("Color(red: 0, green: 0, blue: 1)");
+    expect(linearOutput).not.toContain("drawLinearGradient");
+
+    const radial = `<svg viewBox="0 0 10 10"><defs><radialGradient id="g" cx="50%" cy="50%" r="25%" fx="50%" fy="50%" fr="25%"><stop stop-color="red"/><stop offset="1" stop-color="blue"/></radialGradient></defs><rect width="10" height="10" fill="url(#g)"/></svg>`;
+    expect(convert(radial)).not.toContain("drawRadialGradient");
+
+    const noStops = `<svg viewBox="0 0 10 10"><defs><linearGradient id="g"/></defs><rect width="10" height="10" fill="url(#g) red"/></svg>`;
+    expect(convert(noStops, { preserveColors: true })).not.toContain("Color(red: 1, green: 0, blue: 0)");
+  });
+});

--- a/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
@@ -166,6 +166,136 @@
       "expectedMode": "view",
       "tags": ["geometry", "path", "rect", "view"]
     },
+    "gradient-coordinate-units": {
+      "width": 128,
+      "height": 58,
+      "expectedMode": "view",
+      "tags": ["geometry", "gradient", "gradient-units", "linearGradient", "rect", "stop", "units", "view"]
+    },
+    "gradient-fallbacks": {
+      "width": 128,
+      "height": 50,
+      "expectedMode": "view",
+      "tags": ["geometry", "gradient", "gradient-href", "linearGradient", "radialGradient", "rect", "view"]
+    },
+    "gradient-fill-stroke": {
+      "width": 128,
+      "height": 71,
+      "expectedMode": "view",
+      "tags": ["geometry", "gradient", "gradient-units", "linearGradient", "rect", "stop", "stroke", "view"]
+    },
+    "gradient-href-inheritance": {
+      "width": 128,
+      "height": 51,
+      "expectedMode": "view",
+      "tags": [
+        "geometry",
+        "gradient",
+        "gradient-href",
+        "gradient-spread",
+        "gradient-transform",
+        "linearGradient",
+        "rect",
+        "stop",
+        "view"
+      ]
+    },
+    "gradient-linear-basic": {
+      "width": 128,
+      "height": 75,
+      "expectedMode": "view",
+      "tags": ["geometry", "gradient", "linearGradient", "rect", "stop", "view"]
+    },
+    "gradient-linear-directions": {
+      "width": 128,
+      "height": 50,
+      "expectedMode": "view",
+      "tags": ["geometry", "gradient", "linearGradient", "rect", "stop", "view"]
+    },
+    "gradient-nonzero-viewbox": {
+      "width": 128,
+      "height": 48,
+      "expectedMode": "view",
+      "tags": [
+        "ellipse",
+        "geometry",
+        "gradient",
+        "gradient-units",
+        "linearGradient",
+        "radialGradient",
+        "rect",
+        "stop",
+        "view"
+      ]
+    },
+    "gradient-radial-focal": {
+      "width": 128,
+      "height": 57,
+      "expectedMode": "view",
+      "tags": ["circle", "geometry", "gradient", "gradient-units", "radialGradient", "stop", "view"]
+    },
+    "gradient-radial-spread": {
+      "width": 128,
+      "height": 57,
+      "expectedMode": "view",
+      "tags": ["circle", "geometry", "gradient", "gradient-spread", "gradient-units", "radialGradient", "stop", "view"]
+    },
+    "gradient-radial-transform": {
+      "width": 128,
+      "height": 58,
+      "expectedMode": "view",
+      "tags": ["geometry", "gradient", "gradient-transform", "radialGradient", "rect", "stop", "transform", "view"]
+    },
+    "gradient-realistic-export": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "geometry",
+        "gradient",
+        "gradient-href",
+        "gradient-units",
+        "linearGradient",
+        "opacity",
+        "path",
+        "radialGradient",
+        "rect",
+        "stop",
+        "stroke",
+        "view"
+      ]
+    },
+    "gradient-spread-methods": {
+      "width": 128,
+      "height": 55,
+      "expectedMode": "view",
+      "tags": ["geometry", "gradient", "gradient-spread", "linearGradient", "rect", "stop", "view"]
+    },
+    "gradient-stop-alpha-css": {
+      "width": 128,
+      "height": 82,
+      "expectedMode": "view",
+      "tags": ["circle", "geometry", "gradient", "linearGradient", "opacity", "stop", "units", "view"]
+    },
+    "gradient-stop-counts": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": ["geometry", "gradient", "linearGradient", "opacity", "radialGradient", "rect", "stop", "view"]
+    },
+    "gradient-stop-normalization": {
+      "width": 128,
+      "height": 56,
+      "expectedMode": "view",
+      "tags": ["geometry", "gradient", "linearGradient", "rect", "stop", "units", "view"]
+    },
+    "gradient-transforms": {
+      "width": 128,
+      "height": 61,
+      "expectedMode": "view",
+      "tags": ["geometry", "gradient", "gradient-transform", "linearGradient", "rect", "stop", "transform", "view"]
+    },
     "group-transform": {
       "width": 128,
       "height": 85,

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-coordinate-units.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-coordinate-units.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 90">
+  <defs>
+    <linearGradient id="bbox" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#ec4899"/><stop offset="1" stop-color="#4f46e5"/></linearGradient>
+    <linearGradient id="user" gradientUnits="userSpaceOnUse" x1="50%" y1="10%" x2="50%" y2="90%"><stop stop-color="#ec4899"/><stop offset="1" stop-color="#4f46e5"/></linearGradient>
+  </defs>
+  <rect x="8" y="12" width="78" height="66" fill="url(#bbox)"/>
+  <rect x="114" y="12" width="78" height="66" fill="url(#user)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-fallbacks.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-fallbacks.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 70">
+  <defs>
+    <rect id="wrong" width="2" height="2"/>
+    <linearGradient id="cycle-a" href="#cycle-b"/>
+    <radialGradient id="cycle-b" href="#cycle-a"/>
+  </defs>
+  <rect x="5" y="5" width="50" height="60" fill="url(#missing) #ef4444"/>
+  <rect x="65" y="5" width="50" height="60" fill="url(#wrong)"/>
+  <rect x="125" y="5" width="50" height="60" fill="url(#cycle-a) #3b82f6"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-fill-stroke.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-fill-stroke.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 100">
+  <defs>
+    <linearGradient id="fill"><stop stop-color="#fde047"/><stop offset="1" stop-color="#f97316"/></linearGradient>
+    <linearGradient id="stroke" gradientUnits="userSpaceOnUse" x1="10" y1="10" x2="170" y2="90"><stop stop-color="#06b6d4"/><stop offset=".5" stop-color="#4f46e5"/><stop offset="1" stop-color="#db2777"/></linearGradient>
+  </defs>
+  <rect x="20" y="20" width="140" height="60" rx="18" fill="url(#fill)" stroke="url(#stroke)" stroke-width="12"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-href-inheritance.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-href-inheritance.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 80" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="base" x1="0" y1="0" x2="1" y2="1" spreadMethod="reflect">
+      <stop stop-color="#14b8a6"/><stop offset="1" stop-color="#312e81"/>
+    </linearGradient>
+    <linearGradient id="inherited" href="#base" gradientTransform="rotate(12 .5 .5)"/>
+    <linearGradient id="overridden" xlink:href="#base"><stop stop-color="#fef3c7"/><stop offset="1" stop-color="#b91c1c"/></linearGradient>
+  </defs>
+  <rect x="8" y="8" width="84" height="64" fill="url(#inherited)"/>
+  <rect x="108" y="8" width="84" height="64" fill="url(#overridden)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-linear-basic.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-linear-basic.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 70">
+  <defs>
+    <linearGradient id="horizontal">
+      <stop offset="0" stop-color="#ef4444"/>
+      <stop offset="0.5" stop-color="#facc15"/>
+      <stop offset="1" stop-color="#2563eb"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="104" height="54" rx="9" fill="url(#horizontal)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-linear-directions.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-linear-directions.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 70">
+  <defs>
+    <linearGradient id="h"><stop stop-color="#f43f5e"/><stop offset="1" stop-color="#2563eb"/></linearGradient>
+    <linearGradient id="v" x2="0" y2="1"><stop stop-color="#f43f5e"/><stop offset="1" stop-color="#2563eb"/></linearGradient>
+    <linearGradient id="d" x2="1" y2="1"><stop stop-color="#f43f5e"/><stop offset="1" stop-color="#2563eb"/></linearGradient>
+  </defs>
+  <rect x="5" y="5" width="50" height="60" fill="url(#h)"/>
+  <rect x="65" y="5" width="50" height="60" fill="url(#v)"/>
+  <rect x="125" y="5" width="50" height="60" fill="url(#d)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-nonzero-viewbox.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-nonzero-viewbox.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 20 240 90">
+  <defs>
+    <linearGradient id="user" gradientUnits="userSpaceOnUse" x1="-40" y1="20" x2="200" y2="110"><stop stop-color="#a7f3d0"/><stop offset="1" stop-color="#0f766e"/></linearGradient>
+    <radialGradient id="box"><stop stop-color="#fdf4ff"/><stop offset="1" stop-color="#a21caf"/></radialGradient>
+  </defs>
+  <rect x="-30" y="28" width="125" height="74" fill="url(#user)"/>
+  <ellipse cx="150" cy="65" rx="42" ry="34" fill="url(#box)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-radial-focal.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-radial-focal.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 80">
+  <defs>
+    <radialGradient id="default"><stop stop-color="#fef08a"/><stop offset=".55" stop-color="#f97316"/><stop offset="1" stop-color="#7c2d12"/></radialGradient>
+    <radialGradient id="focal" gradientUnits="userSpaceOnUse" cx="135" cy="40" r="34" fx="119" fy="24" fr="0">
+      <stop stop-color="#fff"/><stop offset=".35" stop-color="#38bdf8"/><stop offset="1" stop-color="#1e3a8a"/>
+    </radialGradient>
+  </defs>
+  <circle cx="42" cy="40" r="34" fill="url(#default)"/>
+  <circle cx="135" cy="40" r="34" fill="url(#focal)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-radial-spread.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-radial-spread.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 80">
+  <defs>
+    <radialGradient id="reflect" gradientUnits="userSpaceOnUse" cx="45" cy="40" r="15" spreadMethod="reflect"><stop stop-color="#fef08a"/><stop offset="1" stop-color="#dc2626"/></radialGradient>
+    <radialGradient id="repeat" gradientUnits="userSpaceOnUse" cx="135" cy="40" r="15" spreadMethod="repeat"><stop stop-color="#bae6fd"/><stop offset="1" stop-color="#1d4ed8"/></radialGradient>
+  </defs>
+  <circle cx="45" cy="40" r="36" fill="url(#reflect)"/>
+  <circle cx="135" cy="40" r="36" fill="url(#repeat)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-radial-transform.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-radial-transform.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 90">
+  <defs>
+    <radialGradient id="ellipse" gradientTransform="rotate(22 .5 .5) translate(.08 -.05)" fx=".3" fy=".25">
+      <stop stop-color="#fff"/><stop offset=".3" stop-color="#fb7185"/><stop offset="1" stop-color="#881337"/>
+    </radialGradient>
+  </defs>
+  <rect x="12" y="12" width="176" height="66" rx="12" fill="url(#ellipse)" transform="skewX(-5)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-realistic-export.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-realistic-export.svg
@@ -1,0 +1,14 @@
+<!-- Adapted from a design-tool export with reusable gradient templates and translucent overlays. -->
+<svg width="240" height="120" viewBox="0 0 240 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#172554"/><stop offset=".55" stop-color="#3730A3"/><stop offset="1" stop-color="#7E22CE"/></linearGradient>
+    <radialGradient id="glow" gradientUnits="userSpaceOnUse" cx="174" cy="25" r="95" fx="192" fy="8"><stop stop-color="#F0ABFC" stop-opacity=".9"/><stop offset="1" stop-color="#A855F7" stop-opacity="0"/></radialGradient>
+    <linearGradient id="shine" href="#card" x1="0" y1="0" x2="1" y2="0"><stop stop-color="white" stop-opacity=".72"/><stop offset="1" stop-color="white" stop-opacity=".08"/></linearGradient>
+  </defs>
+  <rect x="4" y="4" width="232" height="112" rx="24" fill="url(#card)"/>
+  <rect x="4" y="4" width="232" height="112" rx="24" fill="url(#glow)" opacity=".72"/>
+  <circle cx="54" cy="60" r="31" fill="url(#shine)"/>
+  <path d="M40 60L50 70L70 48" stroke="white" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="108" y="43" width="92" height="13" rx="6.5" fill="white" fill-opacity=".92"/>
+  <rect x="108" y="66" width="64" height="9" rx="4.5" fill="white" fill-opacity=".52"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-spread-methods.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-spread-methods.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 210 90">
+  <defs>
+    <linearGradient id="pad" x1=".25" x2=".75" spreadMethod="pad"><stop stop-color="#0ea5e9"/><stop offset="1" stop-color="#f97316"/></linearGradient>
+    <linearGradient id="reflect" x1=".25" x2=".75" spreadMethod="reflect"><stop stop-color="#0ea5e9"/><stop offset="1" stop-color="#f97316"/></linearGradient>
+    <linearGradient id="repeat" x1=".25" x2=".75" spreadMethod="repeat"><stop stop-color="#0ea5e9"/><stop offset="1" stop-color="#f97316"/></linearGradient>
+  </defs>
+  <rect x="5" y="8" width="60" height="74" fill="url(#pad)"/>
+  <rect x="75" y="8" width="60" height="74" fill="url(#reflect)"/>
+  <rect x="145" y="8" width="60" height="74" fill="url(#repeat)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-stop-alpha-css.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-stop-alpha-css.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 90">
+  <style>
+    .alpha-start { stop-color: currentColor; stop-opacity: .2 }
+    .alpha-middle { stop-color: #8b5cf6; stop-opacity: 70% }
+    .alpha-end { stop-color: rgba(239, 68, 68, .35) }
+  </style>
+  <defs>
+    <linearGradient id="alpha" color="#0ea5e9" x2="1" y2="1">
+      <stop class="alpha-start" offset="0"/><stop class="alpha-middle" offset=".5"/><stop class="alpha-end" offset="1"/>
+    </linearGradient>
+  </defs>
+  <circle cx="48" cy="45" r="38" fill="url(#alpha)"/>
+  <circle cx="92" cy="45" r="38" fill="url(#alpha)" opacity=".7"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-stop-counts.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-stop-counts.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 70">
+  <defs>
+    <linearGradient id="one"><stop offset=".4" stop-color="#22c55e" stop-opacity=".65"/></linearGradient>
+    <radialGradient id="zero"/>
+  </defs>
+  <rect width="140" height="70" fill="#e2e8f0"/>
+  <rect x="8" y="8" width="54" height="54" fill="url(#one)"/>
+  <rect x="78" y="8" width="54" height="54" fill="url(#zero)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-stop-normalization.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-stop-normalization.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 70">
+  <defs>
+    <linearGradient id="normalized">
+      <stop offset="-20%" stop-color="#111827"/>
+      <stop offset="55%" stop-color="#22c55e"/>
+      <stop offset="25%" stop-color="#facc15"/>
+      <stop offset="55%" stop-color="#ef4444"/>
+      <stop offset="140%" stop-color="#f8fafc"/>
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="150" height="60" fill="url(#normalized)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-transforms.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-transforms.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 210 100">
+  <defs>
+    <linearGradient id="plain"><stop stop-color="#facc15"/><stop offset="1" stop-color="#dc2626"/></linearGradient>
+    <linearGradient id="skewed" gradientTransform="rotate(35 .5 .5) skewX(18)"><stop stop-color="#facc15"/><stop offset="1" stop-color="#dc2626"/></linearGradient>
+  </defs>
+  <rect x="12" y="16" width="78" height="58" rx="8" fill="url(#plain)" transform="rotate(-8 51 45)"/>
+  <rect x="118" y="16" width="78" height="58" rx="8" fill="url(#skewed)" transform="translate(2 8) rotate(8 157 45)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
@@ -42,6 +42,7 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   if (name.startsWith("structure-")) tags.add("structure");
   if (name.startsWith("css-")) tags.add("css");
   if (name.startsWith("compositing-")) tags.add("compositing");
+  if (name.startsWith("gradient-")) tags.add("gradient");
   if (name.startsWith("viewport-")) tags.add("viewport");
   if (name.startsWith("viewport-realistic-")) tags.add("realistic");
   for (const element of [
@@ -53,6 +54,9 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
     "polyline",
     "polygon",
     "g",
+    "linearGradient",
+    "radialGradient",
+    "stop",
     "use",
     "symbol",
     "switch",
@@ -70,6 +74,10 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   if (/\bvisibility\s*(?:=|:)/.test(source)) tags.add("visibility");
   if (/\bdisplay\s*(?:=|:)/.test(source)) tags.add("display");
   if (/\bpaint-order\s*(?:=|:)/.test(source)) tags.add("paint-order");
+  if (/\bgradientUnits\s*=/.test(source)) tags.add("gradient-units");
+  if (/\bgradientTransform\s*=/.test(source)) tags.add("gradient-transform");
+  if (/\bspreadMethod\s*=/.test(source)) tags.add("gradient-spread");
+  if (/<(?:linearGradient|radialGradient)\b[^>]*(?:href|xlink:href)\s*=/.test(source)) tags.add("gradient-href");
   if (/var\(\s*--|--[\w-]+\s*:/.test(source)) tags.add("css-variables");
   return [...tags].sort();
 }


### PR DESCRIPTION
Closes #56.

## What changed

- parse `linearGradient`, `radialGradient`, and `stop` into typed paint resources
- implement local `href`/`xlink:href` inheritance, local stop replacement, CSS/currentColor stops, alpha, diagnostics, and paint fallbacks
- resolve `objectBoundingBox` and `userSpaceOnUse` coordinates, transforms, focal circles, and pad/reflect/repeat spread
- generate vector SwiftUI `Canvas` + Core Graphics axial/radial drawing for fills and strokes
- sample unpremultiplied sRGB or linearRGB stops without conversion-time rasterization
- add 16 deterministic full-RGBA fixtures, focused tests, docs, and a minor changeset

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test -- --runInBand` — 127 tests passed
- `bun run visual-test -- --tag gradient --fresh` — 16/16 passed
- `bun run visual-test -- --fresh` — 1,820/1,820 passed
- `bun run build` — monorepo build passed