### PR TITLE
Render SVG pattern paint servers

### DIFF
--- a/.changeset/static-svg-patterns.md
+++ b/.changeset/static-svg-patterns.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Render SVG pattern paint servers as typed, inherited, vector-backed SwiftUI Canvas tiles with coordinate-system, transform, viewBox, clipping, nesting, alpha, fill, stroke, and cycle-diagnostic support.

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -47,6 +47,12 @@ Gradient layers remain vector output. Generated SwiftUI uses `Canvas` to clip a 
 
 Color stops are sampled in unpremultiplied SVG color space before Core Graphics draws them. `color-interpolation: sRGB`/`auto` uses sRGB channel interpolation; `linearRGB` applies the standard sRGB transfer functions, interpolates linear-light channels, then encodes back to sRGB. Sampling uses 256 intervals per spread period, which keeps Core Graphics interpolation within the RGBA harness tolerance while supporting repeat and reflect without whole-image rasterization.
 
+### Pattern paint servers
+
+`pattern` definitions are resolved as typed fill and stroke resources. The resolver supports `patternUnits`, `patternContentUnits`, `viewBox`/`preserveAspectRatio`, `patternTransform`, `href` and `xlink:href` inheritance, local content replacement, nested patterns, groups, `use`, gradients, alpha, and diagnostics for invalid dimensions or cyclic references.
+
+Generated SwiftUI keeps pattern content vector-based in `Canvas`. It repeats compound paths without tile seams, clips overflowing content to each tile, preserves fractional origins at different display scales, and resolves object-bounding-box patterns against each painted shape.
+
 ## Before we start
 
 This package is written for JavaScript projects, so it's only meant to be used in a Node.js projects. If you just need to convert an SVG to SwiftUI Shape you should use [this tool](https://github.com/bring-shrubbery/SVG-to-SwiftUI).
@@ -117,6 +123,7 @@ The default antialiasing allowance is 24/255 per channel, at most 3% pixels outs
 - [x] SVG transforms (`matrix`, `translate`, `scale`, `rotate`, `skewX`, `skewY`)
 - [x] Solid fill/stroke styling with colours
 - [x] Linear/radial gradient fills and strokes, stops, inheritance, transforms, and spread methods
+- [x] Pattern fills and strokes, inheritance, coordinate systems, transforms, viewBox behavior, and vector tiling
 - [x] Embedded CSS cascade, custom properties, and computed presentation styles
 - [ ] SVG `<text>` element
 - [ ] Automatic animation support

--- a/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
@@ -117,6 +117,13 @@ function localShapeBounds(shape: RenderShape): RenderBounds | undefined {
   return bounds ? expandForStroke(bounds, shape) : undefined;
 }
 
+/** Local bounds for one paint phase, including stroke expansion when requested. */
+export function shapePaintBounds(shape: RenderShape, kind: "fill" | "stroke"): RenderBounds | undefined {
+  const bounds = geometryBounds(shape.geometry);
+  if (!bounds) return undefined;
+  return kind === "stroke" ? expandForStroke(bounds, shape) : bounds;
+}
+
 function hidden(visibility: string): boolean {
   return visibility === "hidden" || visibility === "collapse";
 }

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -15,16 +15,19 @@ import { type AffineTransform, IDENTITY_TRANSFORM, multiplyTransforms, parseTran
 import type { SVGElementProperties, ViewBoxData } from "../types";
 import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio, parseViewBox, viewBoxTransform } from "../viewports";
 import { resolvePaintServers } from "./gradients";
+import { resolvePatternPaintServers } from "./patterns";
 import type {
   ComputedStyle,
   CSSDiagnosticContext,
   Geometry,
   Paint,
   PaintOrderPhase,
+  PatternPaint,
   RenderDiagnostic,
   RenderDocument,
   RenderGroup,
   RenderNode,
+  RenderShape,
   ResourceRegistry,
   SourceLocation,
 } from "./types";
@@ -875,6 +878,16 @@ export function buildRenderDocument(
     resolved.effective,
     diagnostics,
   );
+  for (const [id, paint] of resolvePatternPaintServers(
+    svg,
+    resources.paintElements,
+    resources.definitions,
+    styleResolver,
+    resolved.effective,
+    diagnostics,
+  )) {
+    resources.paints.set(id, paint);
+  }
   const rootTransform = multiplyTransforms(computedTransform(svg, resolved, context), properties.viewBoxTransform);
   const childCoordinate = { ...coordinate, fontMetrics: resolved.fontMetrics };
   const root: RenderGroup = {
@@ -888,6 +901,97 @@ export function buildRenderDocument(
   };
   const children: RenderNode[] = [root];
 
+  function diagnosePatternOnce(pattern: PatternPaint, code: string, message: string): void {
+    if (diagnostics.some((item) => item.code === code && item.source.id === pattern.id && item.message === message))
+      return;
+    diagnostics.push({ code, message, severity: "warning", source: pattern.source });
+  }
+
+  function buildPatternChildren(pattern: PatternPaint, shape: RenderShape): RenderNode[] {
+    const viewport = pattern.viewBox
+      ? { width: pattern.viewBox.width, height: pattern.viewBox.height }
+      : pattern.contentUnits === "objectBoundingBox"
+        ? { width: 1, height: 1 }
+        : { ...shape.paintContext.viewport };
+    const patternCoordinate: CoordinateContext = {
+      viewport,
+      rootViewport: { ...shape.paintContext.rootViewport },
+      fontMetrics: { ...shape.paintContext.fontMetrics },
+    };
+    const patternContext: BuildContext = {
+      ...context,
+      activeReferences: new Set(context.activeReferences).add(pattern.id),
+    };
+    const built: RenderNode[] = [];
+    for (const content of pattern.contentElements) {
+      try {
+        built.push(...buildNode(content, pattern.presentation as Presentation, patternCoordinate, patternContext));
+      } catch (error) {
+        pattern.invalid = true;
+        const message = error instanceof Error ? error.message : String(error);
+        diagnosePatternOnce(
+          pattern,
+          message.toLowerCase().includes("circular")
+            ? "cyclic-pattern-use-reference"
+            : "invalid-pattern-content-reference",
+          `Pattern #${pattern.id} content could not be resolved: ${message}`,
+        );
+      }
+    }
+    return built;
+  }
+
+  function materializePattern(pattern: PatternPaint, shape: RenderShape, stack: PatternPaint[]): void {
+    const cycleIndex = stack.findIndex((candidate) => candidate.id === pattern.id);
+    if (cycleIndex >= 0) {
+      const cycle = [...stack.slice(cycleIndex), pattern];
+      for (const candidate of cycle) candidate.invalid = true;
+      diagnosePatternOnce(
+        pattern,
+        "cyclic-pattern-content-reference",
+        `Pattern paint cycle detected: ${cycle.map((candidate) => `#${candidate.id}`).join(" -> ")}.`,
+      );
+      return;
+    }
+    if (pattern.instances.has(shape)) return;
+
+    const patternChildren = buildPatternChildren(pattern, shape);
+    pattern.instances.set(shape, { children: patternChildren });
+    if (pattern.children.length === 0) pattern.children = patternChildren;
+
+    const visit = (nodes: RenderNode[]): void => {
+      for (const node of nodes) {
+        if (node.type === "group") {
+          visit(node.children);
+          continue;
+        }
+        if (node.type !== "shape") continue;
+        for (const paint of [node.style.fill, node.style.stroke]) {
+          if (paint.type !== "reference") continue;
+          const dependency = resources.paints.get(paint.id);
+          if (dependency?.type === "pattern") materializePattern(dependency, node, [...stack, pattern]);
+        }
+      }
+    };
+    visit(patternChildren);
+  }
+
+  function materializeReferencedPatterns(nodes: RenderNode[]): void {
+    for (const node of nodes) {
+      if (node.type === "group") {
+        materializeReferencedPatterns(node.children);
+        continue;
+      }
+      if (node.type !== "shape") continue;
+      for (const paint of [node.style.fill, node.style.stroke]) {
+        if (paint.type !== "reference") continue;
+        const pattern = resources.paints.get(paint.id);
+        if (pattern?.type === "pattern") materializePattern(pattern, node, []);
+      }
+    }
+  }
+  materializeReferencedPatterns(children);
+
   function diagnosePaintReferences(nodes: RenderNode[]): void {
     for (const node of nodes) {
       if (node.type === "group") {
@@ -898,13 +1002,26 @@ export function buildRenderDocument(
       for (const paint of [node.style.fill, node.style.stroke]) {
         if (paint.type !== "reference") continue;
         const server = resources.paints.get(paint.id);
-        if (server?.type === "linearGradient" || server?.type === "radialGradient") continue;
+        if (
+          server?.type === "linearGradient" ||
+          server?.type === "radialGradient" ||
+          (server?.type === "pattern" && !server.invalid)
+        )
+          continue;
         const exists = resources.definitions.get(paint.id);
         diagnostics.push({
-          code: exists ? "wrong-paint-server-type" : "missing-paint-server",
-          message: exists
-            ? `Paint reference #${paint.id} targets <${exists.tagName}> instead of a supported gradient.`
-            : `Paint reference #${paint.id} does not resolve to a local resource.`,
+          code:
+            server?.type === "pattern"
+              ? "invalid-pattern-paint-server"
+              : exists
+                ? "wrong-paint-server-type"
+                : "missing-paint-server",
+          message:
+            server?.type === "pattern"
+              ? `Paint reference #${paint.id} targets an invalid pattern resource.`
+              : exists
+                ? `Paint reference #${paint.id} targets <${exists.tagName}> instead of a supported paint server.`
+                : `Paint reference #${paint.id} does not resolve to a local resource.`,
           severity: "warning",
           source: node.source,
         });

--- a/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
@@ -79,13 +79,19 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
     const server = document.resources.paints.get(paint.id);
     return server?.type === "linearGradient" || server?.type === "radialGradient";
   });
+  const hasPatternPaint = paints.some(({ paint }) => {
+    if (paint.type !== "reference") return false;
+    const server = document.resources.paints.get(paint.id);
+    return server?.type === "pattern" && !server.invalid;
+  });
+  const hasPaintServer = hasGradientPaint || hasPatternPaint;
   const needsIndependentCompositing =
     containsIndependentCompositing(document.children) || paints.some(({ paint }) => hasIntrinsicAlpha(paint));
 
   if (
     config.preserveColors === false &&
     !needsViewportClip &&
-    !hasGradientPaint &&
+    !hasPaintServer &&
     !needsIndependentCompositing &&
     !containsGeneralViewContent(document.children)
   ) {
@@ -99,12 +105,14 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   if (containsGeneralViewContent(document.children)) reasons.push("document contains non-geometry view content");
   if (needsViewportClip) reasons.push("document contains a clipped nested viewport");
   if (hasGradientPaint) reasons.push("document uses an SVG gradient paint server");
+  if (hasPatternPaint) reasons.push("document uses an SVG pattern paint server");
   if (needsIndependentCompositing) reasons.push("document uses independent paint or group opacity");
 
   const colors = paints.map(({ paint, opacity }) => {
     if (paint.type === "reference") {
       const server = document.resources.paints.get(paint.id);
       if (server?.type === "linearGradient" || server?.type === "radialGradient") return `gradient:#${paint.id}`;
+      if (server?.type === "pattern" && !server.invalid) return `pattern:#${paint.id}`;
     }
     return solidColor(paint, opacity);
   });
@@ -112,7 +120,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   if (!allColorsSupported) {
     return {
       mode:
-        config.preserveColors === true || containsGeneralViewContent(document.children) || hasGradientPaint
+        config.preserveColors === true || containsGeneralViewContent(document.children) || hasPaintServer
           ? "view"
           : "shape",
       reasons: ["one or more source paints require a future paint backend"],

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -1,10 +1,12 @@
 import type { ElementNode } from "svg-parser";
-import { swiftUIColor } from "../colorUtils";
+import { parseRGBAColor, type RGBAColor, swiftUIColor } from "../colorUtils";
 import { handleElement } from "../elementHandlers";
 import { createFunctionTemplate, createStructTemplate } from "../templates";
-import { wrapWithTransform } from "../transformUtils";
-import type { SVGElementProperties, SwiftUIGeneratorConfig, TranspilerOptions } from "../types";
+import { multiplyTransforms, wrapWithTransform } from "../transformUtils";
+import type { SVGElementProperties, SwiftUIGeneratorConfig, TranspilerOptions, ViewBoxData } from "../types";
+import { renderNodeBounds } from "./bounds";
 import { type ResolvedGradient, resolveGradientForShape } from "./gradients";
+import { type ResolvedPattern, resolvePatternForShape } from "./patterns";
 import type { ComputedStyle, Geometry, GradientStop, Paint, RenderDocument, RenderNode, RenderShape } from "./types";
 
 export interface GeneratedSwiftUI {
@@ -18,14 +20,29 @@ interface ShapeHelper {
 }
 
 type GeneratedViewNode =
-  | { type: "paint"; helper: string; swiftColor: string }
+  | {
+      type: "paint";
+      helper: string;
+      swiftColor: string;
+      cgColor: RGBAColor;
+      tileContained?: boolean;
+    }
   | {
       type: "gradient";
       helper: string;
       gradient: ResolvedGradient;
       paintOpacity: number;
-      coordinateWidth: number;
-      coordinateHeight: number;
+      coordinateSpace: ViewBoxData;
+    }
+  | {
+      type: "pattern";
+      helper: string;
+      pattern: ResolvedPattern;
+      paintOpacity: number;
+      coordinateSpace: ViewBoxData;
+      patternIndex: number;
+      tileClip?: string;
+      contentNodes: GeneratedViewNode[];
     }
   | {
       type: "group";
@@ -33,6 +50,7 @@ type GeneratedViewNode =
       opacity: number;
       isolated: boolean;
       clip?: string;
+      tileContained?: boolean;
     };
 
 interface ViewBuildContext {
@@ -40,8 +58,11 @@ interface ViewBuildContext {
   helpers: ShapeHelper[];
   nextLayer: number;
   nextClip: number;
+  nextPattern: number;
   document: RenderDocument;
   precision: number;
+  coordinateSpace: ViewBoxData;
+  activePatterns: Set<string>;
 }
 
 function createOptions(
@@ -163,6 +184,13 @@ function colorForPaint(paint: Paint, opacity: number): string | undefined {
   return undefined;
 }
 
+function rgbaForPaint(paint: Paint, opacity: number): RGBAColor | undefined {
+  const source = paint.type === "solid" ? paint.value : paint.type === "reference" ? paint.fallback : undefined;
+  if (!source) return undefined;
+  const color = parseRGBAColor(source);
+  return color ? { ...color, alpha: color.alpha * opacity } : undefined;
+}
+
 function formatNumber(value: number, precision = 10): string {
   const rounded = Number(value.toFixed(precision));
   return String(Object.is(rounded, -0) ? 0 : rounded);
@@ -177,9 +205,39 @@ function colorForStop(stop: GradientStop, opacity: number, precision: number): s
     : `Color(${channels}, opacity: ${formatNumber(effectiveAlpha, precision)})`;
 }
 
+function rgbaForStop(stop: GradientStop, opacity: number): RGBAColor {
+  return { ...stop.color, alpha: stop.color.alpha * opacity };
+}
+
 function addHelper(context: ViewBuildContext, name: string, lines: string[]): string {
   context.helpers.push({ name, lines });
   return name;
+}
+
+function isContainedInTile(node: RenderNode, pattern: ResolvedPattern): boolean {
+  const bounds = renderNodeBounds(node, pattern.contentTransform);
+  if (!bounds) return false;
+  const epsilon = 1e-9;
+  return (
+    bounds.x >= -epsilon &&
+    bounds.y >= -epsilon &&
+    bounds.x + bounds.width <= pattern.tile.width + epsilon &&
+    bounds.y + bounds.height <= pattern.tile.height + epsilon
+  );
+}
+
+function markTileContained(nodes: GeneratedViewNode[]): GeneratedViewNode[] {
+  return nodes.map((node) => {
+    if (node.type === "paint") return { ...node, tileContained: true };
+    if (node.type === "group") {
+      return {
+        ...node,
+        tileContained: true,
+        children: markTileContained(node.children),
+      };
+    }
+    return node;
+  });
 }
 
 function buildViewNodes(
@@ -252,6 +310,7 @@ function buildViewNodes(
               type: "paint",
               helper,
               swiftColor: colorForStop(server.stops[0]!, paintOpacity, context.precision),
+              cgColor: rgbaForStop(server.stops[0]!, paintOpacity),
             });
             return;
           }
@@ -261,6 +320,7 @@ function buildViewNodes(
               type: "paint",
               helper,
               swiftColor: colorForStop(gradient.stop, paintOpacity, context.precision),
+              cgColor: rgbaForStop(gradient.stop, paintOpacity),
             });
             return;
           }
@@ -270,14 +330,66 @@ function buildViewNodes(
             helper,
             gradient,
             paintOpacity,
-            coordinateWidth: context.document.viewport.coordinateSpace.width,
-            coordinateHeight: context.document.viewport.coordinateSpace.height,
+            coordinateSpace: context.coordinateSpace,
+          });
+          return;
+        }
+        if (server?.type === "pattern" && !server.invalid) {
+          if (context.activePatterns.has(server.id)) return;
+          const pattern = resolvePatternForShape(server, node, kind, ancestorTransforms);
+          if (pattern.type === "none") return;
+          const patternIndex = context.nextPattern++;
+          let tileClip: string | undefined;
+          if (pattern.clipTile) {
+            let clipLines = handleElement(
+              {
+                type: "element",
+                tagName: "rect",
+                properties: {
+                  x: 0,
+                  y: 0,
+                  width: pattern.tile.width,
+                  height: pattern.tile.height,
+                  fill: "black",
+                  stroke: "none",
+                },
+                children: [],
+              },
+              context.options,
+            );
+            clipLines = wrapWithTransform(clipLines, pattern.matrix, context.options);
+            tileClip = addHelper(context, `PatternClip${patternIndex}`, clipLines);
+          }
+          const patternContext: ViewBuildContext = {
+            ...context,
+            options: { ...context.options, lastPathId: 0 },
+            activePatterns: new Set(context.activePatterns).add(server.id),
+          };
+          const contentTransform = multiplyTransforms(pattern.matrix, pattern.contentTransform);
+          const contentNodes = pattern.children.flatMap((child) => {
+            const childNodes = buildViewNodes([child], patternContext, [contentTransform]);
+            return isContainedInTile(child, pattern) ? markTileContained(childNodes) : childNodes;
+          });
+          context.nextLayer = patternContext.nextLayer;
+          context.nextClip = patternContext.nextClip;
+          context.nextPattern = patternContext.nextPattern;
+          if (contentNodes.length === 0) return;
+          paints.push({
+            type: "pattern",
+            helper,
+            pattern,
+            paintOpacity,
+            coordinateSpace: context.coordinateSpace,
+            patternIndex,
+            ...(tileClip ? { tileClip } : {}),
+            contentNodes,
           });
           return;
         }
       }
       const swiftColor = colorForPaint(paint, paintOpacity);
-      if (swiftColor) paints.push({ type: "paint", helper, swiftColor });
+      const cgColor = rgbaForPaint(paint, paintOpacity);
+      if (swiftColor && cgColor) paints.push({ type: "paint", helper, swiftColor, cgColor });
     };
 
     for (const kind of node.style.paintOrder) {
@@ -312,6 +424,12 @@ function gradientStopLiteral(stop: GradientStop, opacity: number): string {
   return `SVGGradientStop(offset: ${formatNumber(stop.offset)}, red: ${formatNumber(stop.color.red)}, green: ${formatNumber(stop.color.green)}, blue: ${formatNumber(stop.color.blue)}, alpha: ${formatNumber(stop.color.alpha * opacity)})`;
 }
 
+function runtimeTransform(matrix: RenderNode["transform"], coordinateSpace: ViewBoxData): string {
+  const scaleX = `size.width / ${formatNumber(coordinateSpace.width)}`;
+  const scaleY = `size.height / ${formatNumber(coordinateSpace.height)}`;
+  return `CGAffineTransform(a: ${formatNumber(matrix.a)} * ${scaleX}, b: ${formatNumber(matrix.b)} * ${scaleY}, c: ${formatNumber(matrix.c)} * ${scaleX}, d: ${formatNumber(matrix.d)} * ${scaleY}, tx: ${formatNumber(matrix.e - coordinateSpace.x)} * ${scaleX}, ty: ${formatNumber(matrix.f - coordinateSpace.y)} * ${scaleY})`;
+}
+
 function renderGradientNode(
   node: Extract<GeneratedViewNode, { type: "gradient" }>,
   level: number,
@@ -324,7 +442,7 @@ function renderGradientNode(
   const gradient = node.gradient;
   const matrix = gradient.matrix;
   const stops = gradient.stops.map((stop) => gradientStopLiteral(stop, node.paintOpacity)).join(", ");
-  const transform = `CGAffineTransform(a: ${formatNumber(matrix.a)} * size.width / ${formatNumber(node.coordinateWidth)}, b: ${formatNumber(matrix.b)} * size.height / ${formatNumber(node.coordinateHeight)}, c: ${formatNumber(matrix.c)} * size.width / ${formatNumber(node.coordinateWidth)}, d: ${formatNumber(matrix.d)} * size.height / ${formatNumber(node.coordinateHeight)}, tx: ${formatNumber(matrix.e)} * size.width / ${formatNumber(node.coordinateWidth)}, ty: ${formatNumber(matrix.f)} * size.height / ${formatNumber(node.coordinateHeight)})`;
+  const transform = runtimeTransform(matrix, node.coordinateSpace);
   const lines = [
     `${prefix}Canvas { context, size in`,
     `${inner}let clipPath = ${node.helper}().path(in: CGRect(origin: .zero, size: size))`,
@@ -358,10 +476,265 @@ function renderGradientNode(
   return lines;
 }
 
+function renderPatternNode(
+  node: Extract<GeneratedViewNode, { type: "pattern" }>,
+  level: number,
+  indentation: string,
+): string[] {
+  const prefix = indentation.repeat(level);
+  const inner = indentation.repeat(level + 1);
+  const lines = [
+    `${prefix}Canvas { context, size in`,
+    `${inner}context.withCGContext { graphics in`,
+    ...renderPatternCommands(node, "graphics", level + 2, indentation),
+    `${inner}}`,
+    `${prefix}}`,
+  ];
+  return lines;
+}
+
+function renderGradientCommands(
+  node: Extract<GeneratedViewNode, { type: "gradient" }>,
+  graphicsName: string,
+  level: number,
+  indentation: string,
+): string[] {
+  const prefix = indentation.repeat(level);
+  const inner = indentation.repeat(level + 1);
+  const nested = indentation.repeat(level + 2);
+  const gradient = node.gradient;
+  const transform = runtimeTransform(gradient.matrix, node.coordinateSpace);
+  const stops = gradient.stops.map((stop) => gradientStopLiteral(stop, node.paintOpacity)).join(", ");
+  const lines = [
+    `${prefix}do {`,
+    `${inner}let clipPath = ${node.helper}().path(in: CGRect(origin: .zero, size: size))`,
+    `${inner}let stops = [${stops}]`,
+    `${inner}if let gradient = svgGradient(stops: stops, spread: .${gradient.spreadMethod === "repeat" ? "repeating" : gradient.spreadMethod}, startT: ${formatNumber(gradient.startT)}, endT: ${formatNumber(gradient.endT)}, linearRGB: ${gradient.colorInterpolation === "linearRGB"}) {`,
+    `${nested}${graphicsName}.saveGState()`,
+    `${nested}${graphicsName}.addPath(clipPath.cgPath)`,
+    `${nested}${graphicsName}.clip()`,
+    `${nested}${graphicsName}.concatenate(${transform})`,
+  ];
+  if (gradient.type === "linearGradient") {
+    const dx = gradient.x2 - gradient.x1;
+    const dy = gradient.y2 - gradient.y1;
+    lines.push(
+      `${nested}${graphicsName}.drawLinearGradient(gradient, start: CGPoint(x: ${formatNumber(gradient.x1 + dx * gradient.startT)}, y: ${formatNumber(gradient.y1 + dy * gradient.startT)}), end: CGPoint(x: ${formatNumber(gradient.x1 + dx * gradient.endT)}, y: ${formatNumber(gradient.y1 + dy * gradient.endT)}), options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
+    );
+  } else {
+    const dx = gradient.cx - gradient.fx;
+    const dy = gradient.cy - gradient.fy;
+    const dr = gradient.r - gradient.fr;
+    lines.push(
+      `${nested}${graphicsName}.drawRadialGradient(gradient, startCenter: CGPoint(x: ${formatNumber(gradient.fx + dx * gradient.startT)}, y: ${formatNumber(gradient.fy + dy * gradient.startT)}), startRadius: ${formatNumber(gradient.fr + dr * gradient.startT)}, endCenter: CGPoint(x: ${formatNumber(gradient.fx + dx * gradient.endT)}, y: ${formatNumber(gradient.fy + dy * gradient.endT)}), endRadius: ${formatNumber(gradient.fr + dr * gradient.endT)}, options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
+    );
+  }
+  lines.push(`${nested}${graphicsName}.restoreGState()`, `${inner}}`, `${prefix}}`);
+  return lines;
+}
+
+function renderGeneratedCommands(
+  nodes: GeneratedViewNode[],
+  graphicsName: string,
+  level: number,
+  indentation: string,
+): string[] {
+  const lines: string[] = [];
+  const prefix = indentation.repeat(level);
+  const inner = indentation.repeat(level + 1);
+  for (const node of nodes) {
+    if (node.type === "paint") {
+      const color = node.cgColor;
+      lines.push(
+        `${prefix}do {`,
+        `${inner}${graphicsName}.saveGState()`,
+        `${inner}${graphicsName}.addPath(${node.helper}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+        `${inner}${graphicsName}.setFillColor(CGColor(colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!, components: [${formatNumber(color.red)}, ${formatNumber(color.green)}, ${formatNumber(color.blue)}, ${formatNumber(color.alpha)}])!)`,
+        `${inner}${graphicsName}.fillPath()`,
+        `${inner}${graphicsName}.restoreGState()`,
+        `${prefix}}`,
+      );
+      continue;
+    }
+    if (node.type === "gradient") {
+      lines.push(...renderGradientCommands(node, graphicsName, level, indentation));
+      continue;
+    }
+    if (node.type === "pattern") {
+      lines.push(...renderPatternCommands(node, graphicsName, level, indentation));
+      continue;
+    }
+    const needsLayer = node.isolated || node.clip !== undefined;
+    if (!needsLayer) {
+      lines.push(...renderGeneratedCommands(node.children, graphicsName, level, indentation));
+      continue;
+    }
+    lines.push(`${prefix}do {`, `${inner}${graphicsName}.saveGState()`);
+    if (node.clip)
+      lines.push(
+        `${inner}${graphicsName}.addPath(${node.clip}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+        `${inner}${graphicsName}.clip()`,
+      );
+    if (node.isolated) {
+      if (node.opacity !== 1) lines.push(`${inner}${graphicsName}.setAlpha(${formatNumber(node.opacity)})`);
+      lines.push(`${inner}${graphicsName}.beginTransparencyLayer(auxiliaryInfo: nil)`);
+    }
+    lines.push(...renderGeneratedCommands(node.children, graphicsName, level + 1, indentation));
+    if (node.isolated) lines.push(`${inner}${graphicsName}.endTransparencyLayer()`);
+    lines.push(`${inner}${graphicsName}.restoreGState()`, `${prefix}}`);
+  }
+  return lines;
+}
+
+interface PatternRepeatRuntime {
+  minRow: number;
+  maxRow: number;
+  minColumn: number;
+  maxColumn: number;
+  columnX: string;
+  columnY: string;
+  rowX: string;
+  rowY: string;
+  originX: string;
+  originY: string;
+  scaleX: string;
+  scaleY: string;
+  suffix: number;
+  tileClip?: string;
+}
+
+function canBatchPatternNode(node: GeneratedViewNode): boolean {
+  if (node.type === "paint") return node.tileContained === true;
+  return (
+    node.type === "group" &&
+    node.tileContained === true &&
+    !node.isolated &&
+    !node.clip &&
+    node.children.every(canBatchPatternNode)
+  );
+}
+
+function renderBatchedPatternNode(
+  node: GeneratedViewNode,
+  runtime: PatternRepeatRuntime,
+  graphicsName: string,
+  level: number,
+  indentation: string,
+): string[] {
+  if (node.type === "group")
+    return node.children.flatMap((child) => renderBatchedPatternNode(child, runtime, graphicsName, level, indentation));
+  if (node.type !== "paint") return [];
+  const prefix = indentation.repeat(level);
+  const inner = indentation.repeat(level + 1);
+  const nested = indentation.repeat(level + 2);
+  const deep = indentation.repeat(level + 3);
+  const color = node.cgColor;
+  return [
+    `${prefix}do {`,
+    `${inner}${graphicsName}.saveGState()`,
+    `${inner}let repeatedPath = CGMutablePath()`,
+    `${inner}for row in (${runtime.minRow})...(${runtime.maxRow}) {`,
+    `${nested}for column in (${runtime.minColumn})...(${runtime.maxColumn}) {`,
+    `${deep}let offsetX${runtime.suffix} = (${runtime.originX} + CGFloat(column) * ${runtime.columnX} + CGFloat(row) * ${runtime.rowX}) * ${runtime.scaleX}`,
+    `${deep}let offsetY${runtime.suffix} = (${runtime.originY} + CGFloat(column) * ${runtime.columnY} + CGFloat(row) * ${runtime.rowY}) * ${runtime.scaleY}`,
+    `${deep}repeatedPath.addPath(${node.helper}().path(in: CGRect(origin: .zero, size: size)).cgPath, transform: CGAffineTransform(translationX: offsetX${runtime.suffix}, y: offsetY${runtime.suffix}))`,
+    `${nested}}`,
+    `${inner}}`,
+    `${inner}${graphicsName}.addPath(repeatedPath)`,
+    `${inner}${graphicsName}.setFillColor(CGColor(colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!, components: [${formatNumber(color.red)}, ${formatNumber(color.green)}, ${formatNumber(color.blue)}, ${formatNumber(color.alpha)}])!)`,
+    `${inner}${graphicsName}.fillPath()`,
+    `${inner}${graphicsName}.restoreGState()`,
+    `${prefix}}`,
+  ];
+}
+
+function renderUnbatchedPatternNode(
+  node: GeneratedViewNode,
+  runtime: PatternRepeatRuntime,
+  graphicsName: string,
+  level: number,
+  indentation: string,
+): string[] {
+  const prefix = indentation.repeat(level);
+  const inner = indentation.repeat(level + 1);
+  const nested = indentation.repeat(level + 2);
+  const lines = [
+    `${prefix}for row in (${runtime.minRow})...(${runtime.maxRow}) {`,
+    `${inner}for column in (${runtime.minColumn})...(${runtime.maxColumn}) {`,
+    `${nested}${graphicsName}.saveGState()`,
+    `${nested}let offsetX${runtime.suffix} = (${runtime.originX} + CGFloat(column) * ${runtime.columnX} + CGFloat(row) * ${runtime.rowX}) * ${runtime.scaleX}`,
+    `${nested}let offsetY${runtime.suffix} = (${runtime.originY} + CGFloat(column) * ${runtime.columnY} + CGFloat(row) * ${runtime.rowY}) * ${runtime.scaleY}`,
+    `${nested}${graphicsName}.translateBy(x: offsetX${runtime.suffix}, y: offsetY${runtime.suffix})`,
+  ];
+  if (runtime.tileClip)
+    lines.push(
+      `${nested}${graphicsName}.addPath(${runtime.tileClip}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+      `${nested}${graphicsName}.clip()`,
+    );
+  lines.push(
+    ...renderGeneratedCommands([node], graphicsName, level + 2, indentation),
+    `${nested}${graphicsName}.restoreGState()`,
+    `${inner}}`,
+    `${prefix}}`,
+  );
+  return lines;
+}
+
+function renderPatternCommands(
+  node: Extract<GeneratedViewNode, { type: "pattern" }>,
+  graphicsName: string,
+  level: number,
+  indentation: string,
+): string[] {
+  const prefix = indentation.repeat(level);
+  const inner = indentation.repeat(level + 1);
+  const pattern = node.pattern;
+  const matrix = pattern.matrix;
+  const runtime: PatternRepeatRuntime = {
+    minRow: pattern.minRow,
+    maxRow: pattern.maxRow,
+    minColumn: pattern.minColumn,
+    maxColumn: pattern.maxColumn,
+    columnX: formatNumber(matrix.a * pattern.tile.width),
+    columnY: formatNumber(matrix.b * pattern.tile.width),
+    rowX: formatNumber(matrix.c * pattern.tile.height),
+    rowY: formatNumber(matrix.d * pattern.tile.height),
+    originX: formatNumber(matrix.a * pattern.tile.x + matrix.c * pattern.tile.y),
+    originY: formatNumber(matrix.b * pattern.tile.x + matrix.d * pattern.tile.y),
+    scaleX: `size.width / ${formatNumber(node.coordinateSpace.width)}`,
+    scaleY: `size.height / ${formatNumber(node.coordinateSpace.height)}`,
+    suffix: node.patternIndex,
+    ...(node.tileClip ? { tileClip: node.tileClip } : {}),
+  };
+  const lines = [
+    `${prefix}do {`,
+    `${inner}${graphicsName}.saveGState()`,
+    `${inner}${graphicsName}.addPath(${node.helper}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+    `${inner}${graphicsName}.clip()`,
+  ];
+  if (node.paintOpacity !== 1) {
+    lines.push(
+      `${inner}${graphicsName}.setAlpha(${formatNumber(node.paintOpacity)})`,
+      `${inner}${graphicsName}.beginTransparencyLayer(auxiliaryInfo: nil)`,
+    );
+  }
+  for (const contentNode of node.contentNodes) {
+    lines.push(
+      ...(canBatchPatternNode(contentNode)
+        ? renderBatchedPatternNode(contentNode, runtime, graphicsName, level + 1, indentation)
+        : renderUnbatchedPatternNode(contentNode, runtime, graphicsName, level + 1, indentation)),
+    );
+  }
+  if (node.paintOpacity !== 1) lines.push(`${inner}${graphicsName}.endTransparencyLayer()`);
+  lines.push(`${inner}${graphicsName}.restoreGState()`, `${prefix}}`);
+  return lines;
+}
+
 function renderViewNode(node: GeneratedViewNode, level: number, indentation: string): string[] {
   const prefix = indentation.repeat(level);
   if (node.type === "paint") return [`${prefix}${node.helper}().fill(${node.swiftColor})`];
   if (node.type === "gradient") return renderGradientNode(node, level, indentation);
+  if (node.type === "pattern") return renderPatternNode(node, level, indentation);
   const lines = [`${prefix}ZStack {`];
   for (const child of node.children) lines.push(...renderViewNode(child, level + 1, indentation));
   lines.push(`${prefix}}`);
@@ -373,7 +746,10 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
 
 function containsGradientNode(nodes: GeneratedViewNode[]): boolean {
   return nodes.some(
-    (node) => node.type === "gradient" || (node.type === "group" && containsGradientNode(node.children)),
+    (node) =>
+      node.type === "gradient" ||
+      (node.type === "group" && containsGradientNode(node.children)) ||
+      (node.type === "pattern" && containsGradientNode(node.contentNodes)),
   );
 }
 
@@ -489,7 +865,12 @@ function createView(
     body.push("", ...layerStruct);
   }
   if (containsGradientNode(nodes)) body.push("", ...gradientSupport(indentationSize));
-  return createStructTemplate({ name, indent: indentationSize, returnType: "View", body });
+  return createStructTemplate({
+    name,
+    indent: indentationSize,
+    returnType: "View",
+    body,
+  });
 }
 
 export function generateShape(
@@ -529,8 +910,11 @@ export function generateView(
     helpers: [],
     nextLayer: 0,
     nextClip: 0,
+    nextPattern: 0,
     document,
     precision: config.precision ?? 10,
+    coordinateSpace: document.viewport.coordinateSpace,
+    activePatterns: new Set(),
   };
   const nodes = buildViewNodes(document.children, context);
   return {

--- a/packages/svg-to-swiftui-core/src/renderTree/gradients.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/gradients.ts
@@ -253,10 +253,7 @@ export function resolvePaintServers(
 
   const result = new Map<string, PaintServer>();
   for (const [id, element] of paintElements) {
-    if (element.tagName === "pattern") {
-      result.set(id, invalidServer(element, "unsupported"));
-      continue;
-    }
+    if (element.tagName === "pattern") continue;
     const chain = chainFor(id);
     if (!chain) {
       result.set(id, invalidServer(element, "invalid"));

--- a/packages/svg-to-swiftui-core/src/renderTree/patterns.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/patterns.ts
@@ -1,0 +1,454 @@
+import type { ElementNode } from "svg-parser";
+import { lengthContext, type ParsedSVGLength, parseSVGLength, resolveSVGLength, SVGLengthError } from "../lengths";
+import type { Presentation, StyleResolution, SVGStyleResolver } from "../styleCascade";
+import { type AffineTransform, IDENTITY_TRANSFORM, multiplyTransforms, parseTransform } from "../transformUtils";
+import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio, parseViewBox, viewBoxTransform } from "../viewports";
+import { geometryBounds, shapePaintBounds } from "./bounds";
+import type {
+  InvalidPaintServer,
+  PaintServer,
+  PatternPaint,
+  PatternUnits,
+  RenderBounds,
+  RenderDiagnostic,
+  RenderNode,
+  RenderShape,
+  SourceLocation,
+} from "./types";
+
+export interface ResolvedPattern {
+  type: "pattern";
+  matrix: AffineTransform;
+  tile: RenderBounds;
+  contentTransform: AffineTransform;
+  children: RenderNode[];
+  minColumn: number;
+  maxColumn: number;
+  minRow: number;
+  maxRow: number;
+  clipTile: boolean;
+}
+
+export type ResolvedPatternPaint = ResolvedPattern | { type: "none" };
+
+const DESCRIPTIVE_ELEMENTS = new Set(["desc", "metadata", "title"]);
+
+function sourceLocation(element: ElementNode): SourceLocation {
+  const id = element.properties?.id;
+  return {
+    element: element.tagName ?? "unknown",
+    ...(id === undefined ? {} : { id: String(id) }),
+  };
+}
+
+function diagnostic(diagnostics: RenderDiagnostic[], element: ElementNode, code: string, message: string): void {
+  diagnostics.push({
+    code,
+    message,
+    severity: "warning",
+    source: sourceLocation(element),
+  });
+}
+
+function children(element: ElementNode): ElementNode[] {
+  return element.children.filter(
+    (child): child is ElementNode => typeof child !== "string" && child.type === "element",
+  );
+}
+
+function containsPattern(element: ElementNode): boolean {
+  return element.tagName === "pattern" || children(element).some(containsPattern);
+}
+
+function href(element: ElementNode): string | undefined {
+  const raw =
+    element.properties?.href ??
+    element.properties?.["xlink:href"] ??
+    element.properties?.xlinkHref ??
+    element.properties?.xLinkHref;
+  if (raw === undefined || String(raw).trim() === "") return undefined;
+  return String(raw).trim();
+}
+
+function invalidServer(element: ElementNode): InvalidPaintServer {
+  return {
+    type: "invalid",
+    id: String(element.properties?.id ?? ""),
+    element: element.tagName ?? "unknown",
+    source: sourceLocation(element),
+  };
+}
+
+function property(chain: ElementNode[], name: string): unknown {
+  for (const element of chain) {
+    const value = element.properties?.[name];
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+function parsedLength(
+  raw: unknown,
+  fallback: string,
+  label: string,
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+): ParsedSVGLength {
+  try {
+    const parsed = parseSVGLength(raw ?? fallback);
+    if (parsed.kind !== "length") throw new SVGLengthError("invalid-pattern-length", `${label} requires a length.`);
+    return parsed;
+  } catch (error) {
+    diagnostic(
+      diagnostics,
+      element,
+      error instanceof SVGLengthError ? error.code : "invalid-pattern-length",
+      `Invalid ${label}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return parseSVGLength(fallback) as ParsedSVGLength;
+  }
+}
+
+function units(
+  raw: unknown,
+  fallback: PatternUnits,
+  label: "patternUnits" | "patternContentUnits",
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+): PatternUnits {
+  const source = String(raw ?? fallback);
+  if (source === "objectBoundingBox" || source === "userSpaceOnUse") return source;
+  diagnostic(diagnostics, element, `invalid-${label}`, `Invalid ${label} '${source}'.`);
+  return fallback;
+}
+
+/** Resolve typed pattern resources, including recursive per-attribute and shadow-content inheritance. */
+export function resolvePatternPaintServers(
+  root: ElementNode,
+  paintElements: Map<string, ElementNode>,
+  definitions: Map<string, ElementNode>,
+  styleResolver: SVGStyleResolver,
+  rootPresentation: Presentation,
+  diagnostics: RenderDiagnostic[],
+): Map<string, PaintServer> {
+  const resolutions = new Map<ElementNode, StyleResolution>();
+  const walk = (element: ElementNode, inherited: Presentation): void => {
+    for (const child of children(element)) {
+      if (!containsPattern(child)) continue;
+      const resolved = styleResolver.resolve(child, inherited);
+      resolutions.set(child, resolved);
+      walk(child, resolved.values);
+    }
+  };
+  walk(root, rootPresentation);
+
+  const chains = new Map<string, ElementNode[] | undefined>();
+  const chainFor = (id: string, stack: string[] = []): ElementNode[] | undefined => {
+    if (chains.has(id)) return chains.get(id);
+    const element = paintElements.get(id);
+    if (!element || element.tagName !== "pattern") return undefined;
+    if (stack.includes(id)) {
+      const cycle = [...stack.slice(stack.indexOf(id)), id];
+      diagnostic(
+        diagnostics,
+        element,
+        "cyclic-pattern-reference",
+        `Pattern reference cycle detected: ${cycle.map((item) => `#${item}`).join(" -> ")}.`,
+      );
+      for (const cycleId of cycle) chains.set(cycleId, undefined);
+      return undefined;
+    }
+    const reference = href(element);
+    if (!reference) {
+      const chain = [element];
+      chains.set(id, chain);
+      return chain;
+    }
+    if (!reference.startsWith("#")) {
+      diagnostic(
+        diagnostics,
+        element,
+        "external-pattern-reference",
+        "Only local pattern href references are supported.",
+      );
+      chains.set(id, undefined);
+      return undefined;
+    }
+    const parentId = reference.slice(1);
+    const referenced = definitions.get(parentId);
+    if (!referenced) {
+      diagnostic(
+        diagnostics,
+        element,
+        "missing-pattern-template",
+        `Pattern #${id} references missing template #${parentId}.`,
+      );
+      chains.set(id, undefined);
+      return undefined;
+    }
+    if (referenced.tagName !== "pattern") {
+      diagnostic(
+        diagnostics,
+        element,
+        "wrong-pattern-template-type",
+        `Pattern #${id} references <${referenced.tagName}> instead of a pattern.`,
+      );
+      chains.set(id, undefined);
+      return undefined;
+    }
+    const parent = chainFor(parentId, [...stack, id]);
+    if (!parent) {
+      chains.set(id, undefined);
+      return undefined;
+    }
+    const chain = [element, ...parent];
+    chains.set(id, chain);
+    return chain;
+  };
+
+  const result = new Map<string, PaintServer>();
+  for (const [id, element] of paintElements) {
+    if (element.tagName !== "pattern") continue;
+    const chain = chainFor(id);
+    if (!chain) {
+      result.set(id, invalidServer(element));
+      continue;
+    }
+
+    const resolved = resolutions.get(element);
+    const patternUnits = units(
+      property(chain, "patternUnits"),
+      "objectBoundingBox",
+      "patternUnits",
+      element,
+      diagnostics,
+    );
+    const contentUnits = units(
+      property(chain, "patternContentUnits"),
+      "userSpaceOnUse",
+      "patternContentUnits",
+      element,
+      diagnostics,
+    );
+
+    let transform = IDENTITY_TRANSFORM;
+    const cssTransform = resolved?.provenance.transform ? resolved.values.transform : undefined;
+    const transformSource = cssTransform ?? property(chain, "patternTransform");
+    if (transformSource !== undefined) {
+      try {
+        transform = parseTransform(transformSource);
+      } catch (error) {
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-pattern-transform",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+
+    let viewBox: ReturnType<typeof parseViewBox>;
+    const viewBoxSource = property(chain, "viewBox");
+    if (viewBoxSource !== undefined) {
+      try {
+        viewBox = parseViewBox(viewBoxSource);
+      } catch (error) {
+        diagnostic(
+          diagnostics,
+          element,
+          error instanceof SVGLengthError ? error.code : "invalid-pattern-viewbox",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+
+    let preserveAspectRatio = DEFAULT_PRESERVE_ASPECT_RATIO;
+    const aspectSource = property(chain, "preserveAspectRatio");
+    if (aspectSource !== undefined) {
+      try {
+        preserveAspectRatio = parsePreserveAspectRatio(aspectSource);
+      } catch (error) {
+        diagnostic(
+          diagnostics,
+          element,
+          error instanceof SVGLengthError ? error.code : "invalid-pattern-preserve-aspect-ratio",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+
+    const contentOwner = chain.find((candidate) =>
+      children(candidate).some((child) => !DESCRIPTIVE_ELEMENTS.has(child.tagName ?? "")),
+    );
+    const width = parsedLength(property(chain, "width"), "0", "pattern width", element, diagnostics);
+    const height = parsedLength(property(chain, "height"), "0", "pattern height", element, diagnostics);
+    if (width.value < 0)
+      diagnostic(diagnostics, element, "negative-pattern-width", "Pattern width cannot be negative.");
+    if (height.value < 0)
+      diagnostic(diagnostics, element, "negative-pattern-height", "Pattern height cannot be negative.");
+
+    const authoredOverflow = resolved?.provenance.overflow ? resolved.values.overflow : "hidden";
+    const paint: PatternPaint = {
+      type: "pattern",
+      id,
+      x: parsedLength(property(chain, "x"), "0", "pattern x", element, diagnostics),
+      y: parsedLength(property(chain, "y"), "0", "pattern y", element, diagnostics),
+      width,
+      height,
+      units: patternUnits,
+      contentUnits,
+      transform,
+      ...(viewBox ? { viewBox } : {}),
+      preserveAspectRatio,
+      overflow: String(authoredOverflow ?? "hidden").toLowerCase(),
+      ...(href(element)?.startsWith("#") ? { href: href(element)!.slice(1) } : {}),
+      source: sourceLocation(element),
+      contentElements: contentOwner ? children(contentOwner) : [],
+      children: [],
+      instances: new Map(),
+      presentation: resolved?.values ?? rootPresentation,
+      invalid: false,
+    };
+    result.set(id, paint);
+  }
+  return result;
+}
+
+function invert(matrix: AffineTransform): AffineTransform | undefined {
+  const determinant = matrix.a * matrix.d - matrix.b * matrix.c;
+  if (Math.abs(determinant) < 1e-12) return undefined;
+  return {
+    a: matrix.d / determinant,
+    b: -matrix.b / determinant,
+    c: -matrix.c / determinant,
+    d: matrix.a / determinant,
+    e: (matrix.c * matrix.f - matrix.d * matrix.e) / determinant,
+    f: (matrix.b * matrix.e - matrix.a * matrix.f) / determinant,
+  };
+}
+
+function point(matrix: AffineTransform, x: number, y: number): { x: number; y: number } {
+  return {
+    x: matrix.a * x + matrix.c * y + matrix.e,
+    y: matrix.b * x + matrix.d * y + matrix.f,
+  };
+}
+
+function localToRoot(shape: RenderShape, ancestors: AffineTransform[]): AffineTransform {
+  return [...ancestors, shape.transform].reduce(
+    (matrix, transform) => multiplyTransforms(matrix, transform),
+    IDENTITY_TRANSFORM,
+  );
+}
+
+function coordinate(
+  value: ParsedSVGLength,
+  axis: "horizontal" | "vertical",
+  unitsValue: PatternUnits,
+  shape: RenderShape,
+): number {
+  const viewport = unitsValue === "objectBoundingBox" ? { width: 1, height: 1 } : shape.paintContext.viewport;
+  const resolved = resolveSVGLength(
+    value,
+    lengthContext(
+      viewport,
+      shape.paintContext.rootViewport,
+      axis === "horizontal" ? "viewport-width" : "viewport-height",
+      axis,
+      shape.paintContext.fontMetrics,
+    ),
+  );
+  return typeof resolved === "number" ? resolved : 0;
+}
+
+function transformedBounds(bounds: RenderBounds, matrix: AffineTransform): RenderBounds {
+  const points = [
+    point(matrix, bounds.x, bounds.y),
+    point(matrix, bounds.x + bounds.width, bounds.y),
+    point(matrix, bounds.x, bounds.y + bounds.height),
+    point(matrix, bounds.x + bounds.width, bounds.y + bounds.height),
+  ];
+  const xs = points.map((item) => item.x);
+  const ys = points.map((item) => item.y);
+  const x = Math.min(...xs);
+  const y = Math.min(...ys);
+  return { x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y };
+}
+
+/** Resolve one pattern against the referencing shape and its current ancestor coordinate system. */
+export function resolvePatternForShape(
+  pattern: PatternPaint,
+  shape: RenderShape,
+  kind: "fill" | "stroke",
+  ancestors: AffineTransform[] = [],
+): ResolvedPatternPaint {
+  if (pattern.invalid || pattern.contentElements.length === 0) return { type: "none" };
+  const geometry = geometryBounds(shape.geometry);
+  const paintBounds = shapePaintBounds(shape, kind);
+  if (!geometry || !paintBounds || paintBounds.width === 0 || paintBounds.height === 0) return { type: "none" };
+  const needsObjectBounds =
+    pattern.units === "objectBoundingBox" || (!pattern.viewBox && pattern.contentUnits === "objectBoundingBox");
+  if (needsObjectBounds && (geometry.width === 0 || geometry.height === 0)) return { type: "none" };
+
+  const x = coordinate(pattern.x, "horizontal", pattern.units, shape);
+  const y = coordinate(pattern.y, "vertical", pattern.units, shape);
+  const width = coordinate(pattern.width, "horizontal", pattern.units, shape);
+  const height = coordinate(pattern.height, "vertical", pattern.units, shape);
+  if (width <= 0 || height <= 0 || pattern.viewBox?.width === 0 || pattern.viewBox?.height === 0)
+    return { type: "none" };
+  const tile = { x, y, width, height };
+
+  const boundsMatrix: AffineTransform = {
+    a: geometry.width,
+    b: 0,
+    c: 0,
+    d: geometry.height,
+    e: geometry.x,
+    f: geometry.y,
+  };
+  const unitsMatrix = pattern.units === "objectBoundingBox" ? boundsMatrix : IDENTITY_TRANSFORM;
+  const patternToLocal = multiplyTransforms(unitsMatrix, pattern.transform);
+  const inversePattern = invert(patternToLocal);
+  if (!inversePattern) return { type: "none" };
+
+  // Pattern content starts at the tile origin. Convert only the relative scale
+  // between patternContentUnits and patternUnits; bounding-box translations do
+  // not move the content away from its tile.
+  const patternScaleX = pattern.units === "objectBoundingBox" ? geometry.width : 1;
+  const patternScaleY = pattern.units === "objectBoundingBox" ? geometry.height : 1;
+  const contentScaleX = pattern.contentUnits === "objectBoundingBox" ? geometry.width : 1;
+  const contentScaleY = pattern.contentUnits === "objectBoundingBox" ? geometry.height : 1;
+  const contentTransform = pattern.viewBox
+    ? viewBoxTransform(
+        pattern.viewBox,
+        { x: 0, y: 0, width: tile.width, height: tile.height },
+        pattern.preserveAspectRatio,
+      )
+    : {
+        a: contentScaleX / patternScaleX,
+        b: 0,
+        c: 0,
+        d: contentScaleY / patternScaleY,
+        e: 0,
+        f: 0,
+      };
+  const covered = transformedBounds(paintBounds, inversePattern);
+  const minColumn = Math.floor((covered.x - x) / width);
+  const maxColumn = Math.ceil((covered.x + covered.width - x) / width) - 1;
+  const minRow = Math.floor((covered.y - y) / height);
+  const maxRow = Math.ceil((covered.y + covered.height - y) / height) - 1;
+  if (maxColumn < minColumn || maxRow < minRow) return { type: "none" };
+
+  return {
+    type: "pattern",
+    matrix: multiplyTransforms(localToRoot(shape, ancestors), patternToLocal),
+    tile,
+    contentTransform,
+    children: pattern.instances.get(shape)?.children ?? pattern.children,
+    minColumn,
+    maxColumn,
+    minRow,
+    maxRow,
+    clipTile: pattern.overflow !== "visible",
+  };
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -75,6 +75,40 @@ export interface RadialGradientPaint extends GradientPaintBase {
   fr: ParsedSVGLength;
 }
 
+export type PatternUnits = "objectBoundingBox" | "userSpaceOnUse";
+
+export interface PatternContentInstance {
+  /** Children resolved in the coordinate context of one referencing shape. */
+  children: RenderNode[];
+}
+
+export interface PatternPaint {
+  type: "pattern";
+  id: string;
+  x: ParsedSVGLength;
+  y: ParsedSVGLength;
+  width: ParsedSVGLength;
+  height: ParsedSVGLength;
+  units: PatternUnits;
+  contentUnits: PatternUnits;
+  transform: AffineTransform;
+  viewBox?: ViewBoxData;
+  preserveAspectRatio: PreserveAspectRatio;
+  overflow: string;
+  href?: string;
+  source: SourceLocation;
+  /** Ordered shadow-tree content retained from the nearest template with children. */
+  contentElements: ElementNode[];
+  /** First materialized render-tree instance, useful for resource inspection. */
+  children: RenderNode[];
+  /** Per-reference render trees preserve nested viewport percentage semantics. */
+  instances: Map<RenderShape, PatternContentInstance>;
+  /** Computed presentation inherited by shadow-tree children. */
+  presentation: Readonly<Record<string, string | number>>;
+  /** Set when nested use/paint dependency analysis finds a cycle. */
+  invalid: boolean;
+}
+
 export interface InvalidPaintServer {
   type: "invalid" | "unsupported";
   id: string;
@@ -83,7 +117,7 @@ export interface InvalidPaintServer {
 }
 
 export type GradientPaint = LinearGradientPaint | RadialGradientPaint;
-export type PaintServer = GradientPaint | InvalidPaintServer;
+export type PaintServer = GradientPaint | PatternPaint | InvalidPaintServer;
 
 export interface StrokeStyle {
   width: number;

--- a/packages/svg-to-swiftui-core/src/tests/patterns.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/patterns.test.ts
@@ -1,0 +1,182 @@
+import { __testing, convert } from "../index";
+import { resolvePatternForShape } from "../renderTree/patterns";
+import type { PatternPaint, RenderNode, RenderShape } from "../renderTree/types";
+
+function flatten(nodes: RenderNode[]): RenderNode[] {
+  return nodes.flatMap((node) => (node.type === "group" ? [node, ...flatten(node.children)] : [node]));
+}
+
+function pattern(source: string, id: string): PatternPaint {
+  const server = __testing.parseRenderDocument(source).resources.paints.get(id);
+  if (server?.type !== "pattern") throw new Error(`Missing #${id}`);
+  return server;
+}
+
+describe("typed SVG pattern resources", () => {
+  test("retains coordinate units, transforms, viewBox behavior, overflow, and ordered children", () => {
+    const server = pattern(
+      `<svg viewBox="0 0 100 50"><defs><pattern id="p" x="10%" y="2" width="25%" height="12" patternUnits="userSpaceOnUse" patternContentUnits="objectBoundingBox" patternTransform="skewX(12)" viewBox="0 0 4 2" preserveAspectRatio="xMaxYMax slice" overflow="visible"><rect width="4" height="2"/><circle cx="2" cy="1" r="1"/></pattern></defs><rect width="100" height="50" fill="url(#p)"/></svg>`,
+      "p",
+    );
+    expect(server).toMatchObject({
+      type: "pattern",
+      units: "userSpaceOnUse",
+      contentUnits: "objectBoundingBox",
+      x: { value: 10, unit: "%" },
+      y: { value: 2, unit: "" },
+      width: { value: 25, unit: "%" },
+      height: { value: 12, unit: "" },
+      viewBox: { x: 0, y: 0, width: 4, height: 2 },
+      preserveAspectRatio: { align: "xMaxYMax", meetOrSlice: "slice" },
+      overflow: "visible",
+    });
+    expect(server.transform.c).not.toBe(0);
+    expect(server.children.map((node) => node.source.element)).toEqual(["rect", "circle"]);
+  });
+
+  test("inherits each href attribute and shadow content, while local children replace inherited children", () => {
+    const document = __testing.parseRenderDocument(`<svg viewBox="0 0 100 100"><defs>
+      <pattern id="base" x="5" y="6" width="20" height="25" patternUnits="userSpaceOnUse"><rect id="base-child" width="10" height="10"/></pattern>
+      <pattern id="inherited" href="#base" x="8"/>
+      <pattern id="override" xlink:href="#inherited"><circle id="local-child" cx="4" cy="4" r="3"/></pattern>
+    </defs><rect width="40" height="40" fill="url(#inherited)"/><rect x="50" width="40" height="40" fill="url(#override)"/></svg>`);
+    const inherited = document.resources.paints.get("inherited");
+    const override = document.resources.paints.get("override");
+    expect(inherited).toMatchObject({
+      type: "pattern",
+      href: "base",
+      x: { value: 8 },
+      y: { value: 6 },
+    });
+    expect(inherited?.type === "pattern" ? inherited.contentElements.map((item) => item.properties?.id) : []).toEqual([
+      "base-child",
+    ]);
+    expect(override?.type === "pattern" ? override.contentElements.map((item) => item.properties?.id) : []).toEqual([
+      "local-child",
+    ]);
+  });
+
+  test("materializes user-space percentage content per referencing viewport", () => {
+    const document = __testing.parseRenderDocument(`<svg viewBox="0 0 200 100"><defs>
+      <pattern id="p" width="20" height="20" patternUnits="userSpaceOnUse"><rect id="content" width="50%" height="50%"/></pattern>
+    </defs><rect id="outer" width="100" height="100" fill="url(#p)"/><svg x="100" width="100" height="100" viewBox="0 0 50 50"><rect id="inner" width="50" height="50" fill="url(#p)"/></svg></svg>`);
+    const server = document.resources.paints.get("p");
+    if (server?.type !== "pattern") throw new Error("missing pattern");
+    const shapes = flatten(document.children).filter((node): node is RenderShape => node.type === "shape");
+    const outer = shapes.find((shape) => shape.source.id === "outer")!;
+    const inner = shapes.find((shape) => shape.source.id === "inner")!;
+    const outerChild = flatten(server.instances.get(outer)!.children).find(
+      (node): node is RenderShape => node.type === "shape",
+    )!;
+    const innerChild = flatten(server.instances.get(inner)!.children).find(
+      (node): node is RenderShape => node.type === "shape",
+    )!;
+    expect(outerChild.geometry).toMatchObject({
+      type: "rect",
+      width: 100,
+      height: 50,
+    });
+    expect(innerChild.geometry).toMatchObject({
+      type: "rect",
+      width: 25,
+      height: 25,
+    });
+  });
+
+  test("resolves object bounding box and user-space tiles against the referencing shape", () => {
+    const source = `<svg viewBox="0 0 200 100"><defs>
+      <pattern id="box" x="10%" y="20%" width="25%" height="50%"><rect width="1" height="1"/></pattern>
+      <pattern id="user" x="10%" y="20%" width="25%" height="50%" patternUnits="userSpaceOnUse"><rect width="10" height="10"/></pattern>
+      <pattern id="mixed" width="20" height="10" patternUnits="userSpaceOnUse" patternContentUnits="objectBoundingBox"><rect width="1" height="1"/></pattern>
+    </defs><rect id="target" x="30" y="40" width="80" height="20" fill="url(#box)"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    const shape = flatten(document.children).find((node): node is RenderShape => node.type === "shape")!;
+    const box = document.resources.paints.get("box") as PatternPaint;
+    const user = document.resources.paints.get("user") as PatternPaint;
+    const mixed = document.resources.paints.get("mixed") as PatternPaint;
+    expect(resolvePatternForShape(box, shape, "fill")).toMatchObject({
+      type: "pattern",
+      matrix: { a: 80, d: 20, e: 30, f: 40 },
+      tile: { x: 0.1, y: 0.2, width: 0.25, height: 0.5 },
+      contentTransform: { a: 0.0125, d: 0.05, e: 0, f: 0 },
+    });
+    expect(resolvePatternForShape(user, shape, "fill")).toMatchObject({
+      type: "pattern",
+      matrix: { a: 1, d: 1, e: 0, f: 0 },
+      tile: { x: 20, y: 20, width: 50, height: 50 },
+    });
+    expect(resolvePatternForShape(mixed, shape, "fill")).toMatchObject({
+      type: "pattern",
+      matrix: { a: 1, d: 1, e: 0, f: 0 },
+      contentTransform: { a: 80, d: 20, e: 0, f: 0 },
+    });
+  });
+
+  test("diagnoses invalid templates, units, dimensions, transforms, and nested paint/use cycles", () => {
+    const document = __testing.parseRenderDocument(`<svg viewBox="0 0 20 20"><defs>
+      <rect id="shape" width="2" height="2"/>
+      <pattern id="wrong" href="#shape"/><pattern id="missing" href="#nope"/>
+      <pattern id="a" href="#b"/><pattern id="b" href="#a"/>
+      <pattern id="bad" patternUnits="space" patternContentUnits="box" patternTransform="wat(1)" width="-1" height="-2"><rect/></pattern>
+      <pattern id="paint-a" width="4" height="4" patternUnits="userSpaceOnUse"><rect width="4" height="4" fill="url(#paint-b)"/></pattern>
+      <pattern id="paint-b" width="4" height="4" patternUnits="userSpaceOnUse"><rect width="4" height="4" fill="url(#paint-a)"/></pattern>
+      <g id="use-a"><use href="#use-b"/></g><g id="use-b"><use href="#use-a"/></g>
+      <pattern id="use-cycle" width="4" height="4" patternUnits="userSpaceOnUse"><use href="#use-a"/></pattern>
+    </defs><rect width="10" height="10" fill="url(#paint-a) red"/><rect x="10" width="10" height="10" fill="url(#use-cycle) blue"/></svg>`);
+    expect(document.diagnostics.map(({ code }) => code)).toEqual(
+      expect.arrayContaining([
+        "wrong-pattern-template-type",
+        "missing-pattern-template",
+        "cyclic-pattern-reference",
+        "invalid-patternUnits",
+        "invalid-patternContentUnits",
+        "invalid-pattern-transform",
+        "negative-pattern-width",
+        "negative-pattern-height",
+        "cyclic-pattern-content-reference",
+        "cyclic-pattern-use-reference",
+        "invalid-pattern-paint-server",
+      ]),
+    );
+    const output = convert(
+      `<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="url(#missing) currentColor" color="#123456"/></svg>`,
+      { preserveColors: true },
+    );
+    expect(output).toContain("Color(red: 0.0706, green: 0.2039, blue: 0.3373)");
+  });
+
+  test("uses the View backend and emits direct vector Canvas tiling for pattern fills and strokes", () => {
+    const source = `<svg viewBox="0 0 20 20"><defs><pattern id="p" width="5" height="5" patternUnits="userSpaceOnUse"><rect width="3" height="5" fill="red"/><rect x="3" width="2" height="5" fill="blue"/></pattern></defs><circle cx="10" cy="10" r="8" fill="url(#p)" stroke="url(#p)" stroke-width="2"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(__testing.analyzeCapabilities(document, { preserveColors: false })).toMatchObject({
+      mode: "view",
+      reasons: expect.arrayContaining(["document uses an SVG pattern paint server"]),
+    });
+    const output = convert(source);
+    expect(output).toContain("context.withCGContext");
+    expect(output).toContain("for row in");
+    expect(output).toContain("CGAffineTransform(translationX:");
+    expect(output.match(/context\.withCGContext/g)).toHaveLength(2);
+  });
+
+  test("paints nothing for zero dimensions, negative dimensions, singular transforms, and zero object bounds", () => {
+    for (const attributes of [
+      `width="0" height="5" patternUnits="userSpaceOnUse"`,
+      `width="-2" height="5" patternUnits="userSpaceOnUse"`,
+      `width="5" height="5" patternUnits="userSpaceOnUse" patternTransform="scale(0)"`,
+    ]) {
+      const source = `<svg viewBox="0 0 10 10"><defs><pattern id="p" ${attributes}><rect width="5" height="5"/></pattern></defs><rect width="10" height="10" fill="url(#p) red"/></svg>`;
+      expect(convert(source, { preserveColors: true })).not.toContain("for row in");
+    }
+
+    const document = __testing.parseRenderDocument(
+      `<svg viewBox="0 0 10 10"><defs><pattern id="p" width="50%" height="50%"><rect width="1" height="1"/></pattern></defs><rect id="flat" width="10" height="0" fill="url(#p)"/></svg>`,
+    );
+    const shape = flatten(document.children).find(
+      (node): node is RenderShape => node.type === "shape" && node.source.id === "flat",
+    )!;
+    expect(resolvePatternForShape(document.resources.paints.get("p") as PatternPaint, shape, "fill")).toEqual({
+      type: "none",
+    });
+  });
+});

--- a/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
@@ -10736,6 +10736,144 @@
       "expectedMode": "shape",
       "tags": ["geometry", "path", "shape", "stroke"]
     },
+    "pattern-alpha": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": ["circle", "geometry", "opacity", "pattern", "pattern-units", "rect", "view"]
+    },
+    "pattern-asymmetric-origin": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": ["circle", "geometry", "path", "pattern", "pattern-units", "rect", "view"]
+    },
+    "pattern-coordinate-units": {
+      "width": 128,
+      "height": 96,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "geometry",
+        "path",
+        "pattern",
+        "pattern-content-units",
+        "pattern-units",
+        "rect",
+        "units",
+        "view"
+      ]
+    },
+    "pattern-fill-stroke": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": ["circle", "geometry", "path", "pattern", "pattern-transform", "pattern-units", "rect", "stroke", "view"]
+    },
+    "pattern-fractional-1x": {
+      "width": 128,
+      "height": 64,
+      "scale": 1,
+      "expectedMode": "view",
+      "tags": ["geometry", "opacity", "pattern", "pattern-units", "rect", "view"],
+      "tolerance": { "maxOutsidePercent": 19, "maxMeanRgbError": 12, "maxMeanAlphaError": 9 },
+      "toleranceReason": "Resvg rasterizes fractional pattern cells at 1x while generated SwiftUI keeps vector edges."
+    },
+    "pattern-fractional-2x": {
+      "width": 128,
+      "height": 64,
+      "scale": 2,
+      "expectedMode": "view",
+      "tags": ["geometry", "opacity", "pattern", "pattern-units", "rect", "view"],
+      "tolerance": { "maxOutsidePercent": 6, "maxMeanRgbError": 4 },
+      "toleranceReason": "Resvg and CoreGraphics quantize fractional pattern-cell edges differently."
+    },
+    "pattern-fractional-3x": {
+      "width": 128,
+      "height": 64,
+      "scale": 3,
+      "expectedMode": "view",
+      "tags": ["geometry", "opacity", "pattern", "pattern-units", "rect", "view"],
+      "tolerance": { "maxOutsidePercent": 6, "maxMeanRgbError": 4 },
+      "toleranceReason": "Resvg and CoreGraphics quantize fractional pattern-cell edges differently."
+    },
+    "pattern-href-inheritance": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "geometry",
+        "path",
+        "pattern",
+        "pattern-href",
+        "pattern-transform",
+        "pattern-units",
+        "rect",
+        "view"
+      ]
+    },
+    "pattern-nested-content": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "g",
+        "geometry",
+        "linearGradient",
+        "opacity",
+        "path",
+        "pattern",
+        "pattern-units",
+        "rect",
+        "stop",
+        "use",
+        "view"
+      ]
+    },
+    "pattern-nested": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": ["circle", "ellipse", "geometry", "opacity", "path", "pattern", "pattern-units", "rect", "view"]
+    },
+    "pattern-simple-checkerboard": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": ["geometry", "pattern", "pattern-units", "rect", "view"]
+    },
+    "pattern-tile-clipping": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": ["circle", "geometry", "pattern", "pattern-units", "rect", "view"]
+    },
+    "pattern-transformed-object": {
+      "width": 128,
+      "height": 57,
+      "expectedMode": "view",
+      "tags": ["g", "geometry", "path", "pattern", "pattern-content-units", "rect", "transform", "units", "view"],
+      "tolerance": { "maxOutsidePercent": 10, "maxMeanRgbError": 8 },
+      "toleranceReason": "Resvg and CoreGraphics use different antialias coverage for transformed repeated edges."
+    },
+    "pattern-transforms": {
+      "width": 128,
+      "height": 78,
+      "expectedMode": "view",
+      "tags": ["circle", "geometry", "path", "pattern", "pattern-transform", "pattern-units", "rect", "view"],
+      "tolerance": { "maxOutsidePercent": 16, "maxMeanRgbError": 10, "maxMeanAlphaError": 5 },
+      "toleranceReason": "Resvg and CoreGraphics use different antialias coverage after pattern rotation and skew."
+    },
+    "pattern-viewbox-aspect": {
+      "width": 128,
+      "height": 77,
+      "expectedMode": "view",
+      "tags": ["circle", "g", "geometry", "pattern", "pattern-units", "preserve-aspect-ratio", "rect", "use", "view"],
+      "tolerance": { "maxOutsidePercent": 10, "maxMeanRgbError": 7, "maxMeanAlphaError": 5 },
+      "toleranceReason": "Resvg and CoreGraphics use different antialias coverage for repeated viewBox-scaled circles."
+    },
     "plusRounded": {
       "width": 128,
       "height": 128,

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-alpha.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-alpha.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <rect width="128" height="80" fill="#0f172a"/>
+  <defs>
+    <pattern id="alpha" width="18" height="18" patternUnits="userSpaceOnUse">
+      <rect width="18" height="18" fill="#38bdf8" fill-opacity=".35"/>
+      <circle cx="6" cy="6" r="6" fill="#f472b6" opacity=".72"/>
+      <circle cx="12" cy="12" r="6" fill="#facc15" opacity=".58"/>
+    </pattern>
+  </defs>
+  <rect x="5" y="5" width="118" height="70" fill="url(#alpha)" fill-opacity=".82"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-asymmetric-origin.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-asymmetric-origin.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <defs>
+    <pattern id="asymmetric" x="5" y="7" width="20" height="16" patternUnits="userSpaceOnUse">
+      <rect width="20" height="16" fill="#fef3c7"/>
+      <rect width="7" height="16" fill="#f97316"/>
+      <circle cx="15" cy="5" r="3" fill="#7c3aed"/>
+    </pattern>
+  </defs>
+  <path d="M9 6H119V72H9Z" fill="url(#asymmetric)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-coordinate-units.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-coordinate-units.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 96">
+  <defs>
+    <pattern id="object" width="25%" height="50%" patternContentUnits="objectBoundingBox">
+      <rect width="1" height="1" fill="#dbeafe"/>
+      <rect width=".5" height=".5" fill="#2563eb"/>
+    </pattern>
+    <pattern id="user" x="4" y="3" width="16" height="12" patternUnits="userSpaceOnUse">
+      <rect width="16" height="12" fill="#dcfce7"/>
+      <path d="M0 0L16 12H0Z" fill="#16a34a"/>
+    </pattern>
+    <pattern id="object-user" width="25%" height="50%">
+      <rect width="14" height="21" fill="#ffedd5"/>
+      <path d="M0 0L14 21H0Z" fill="#ea580c"/>
+    </pattern>
+    <pattern id="mixed" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse" patternContentUnits="objectBoundingBox">
+      <rect width="1" height="1" fill="#fae8ff"/>
+      <circle cx=".5" cy=".5" r=".22" fill="#c026d3"/>
+    </pattern>
+  </defs>
+  <rect x="4" y="4" width="56" height="38" fill="url(#object)"/>
+  <rect x="68" y="4" width="56" height="38" fill="url(#user)"/>
+  <rect x="4" y="50" width="56" height="42" fill="url(#object-user)"/>
+  <rect x="68" y="50" width="56" height="42" fill="url(#mixed)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-fill-stroke.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-fill-stroke.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <defs>
+    <pattern id="stripes" width="12" height="12" patternUnits="userSpaceOnUse" patternTransform="rotate(12)"><rect width="12" height="12" fill="#fef3c7"/><rect width="4" height="12" fill="#d97706"/></pattern>
+  </defs>
+  <circle cx="36" cy="40" r="27" fill="url(#stripes)"/>
+  <path d="M72 16C108 4 118 30 95 40C72 50 82 76 118 64" fill="none" stroke="url(#stripes)" stroke-width="9" stroke-linecap="round"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-fractional-1x.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-fractional-1x.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 64">
+  <defs><pattern id="fractional" x=".25" y=".5" width="31.5" height="27.25" patternUnits="userSpaceOnUse"><rect width="31.5" height="27.25" fill="#0d9488"/><rect width="10.5" height="27.25" fill="#fef08a"/><rect width="31.5" height="5.5" fill="#f97316" opacity=".75"/></pattern></defs>
+  <rect x="3" y="3" width="122" height="58" fill="url(#fractional)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-fractional-2x.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-fractional-2x.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 64">
+  <defs><pattern id="fractional" x=".25" y=".5" width="31.5" height="27.25" patternUnits="userSpaceOnUse"><rect width="31.5" height="27.25" fill="#0d9488"/><rect width="10.5" height="27.25" fill="#fef08a"/><rect width="31.5" height="5.5" fill="#f97316" opacity=".75"/></pattern></defs>
+  <rect x="3" y="3" width="122" height="58" fill="url(#fractional)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-fractional-3x.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-fractional-3x.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 64">
+  <defs><pattern id="fractional" x=".25" y=".5" width="31.5" height="27.25" patternUnits="userSpaceOnUse"><rect width="31.5" height="27.25" fill="#0d9488"/><rect width="10.5" height="27.25" fill="#fef08a"/><rect width="31.5" height="5.5" fill="#f97316" opacity=".75"/></pattern></defs>
+  <rect x="3" y="3" width="122" height="58" fill="url(#fractional)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-href-inheritance.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-href-inheritance.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <pattern id="base" x="2" y="3" width="16" height="16" patternUnits="userSpaceOnUse">
+      <rect width="16" height="16" fill="#ede9fe"/><circle cx="5" cy="5" r="4" fill="#7c3aed"/>
+    </pattern>
+    <pattern id="inherited" href="#base" x="6" patternTransform="rotate(8)"/>
+    <pattern id="override" xlink:href="#inherited"><rect width="16" height="16" fill="#cffafe"/><path d="M0 0L16 16H0Z" fill="#0891b2"/></pattern>
+  </defs>
+  <rect x="4" y="4" width="56" height="72" fill="url(#inherited)"/>
+  <rect x="68" y="4" width="56" height="72" fill="url(#override)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-nested-content.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-nested-content.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <defs>
+    <linearGradient id="tile-gradient" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#fde68a"/><stop offset="1" stop-color="#f97316"/></linearGradient>
+    <path id="diamond" d="M8 2L14 8L8 14L2 8Z"/>
+    <pattern id="complex" width="16" height="16" patternUnits="userSpaceOnUse">
+      <rect width="16" height="16" fill="url(#tile-gradient)"/>
+      <g opacity=".72"><use href="#diamond" fill="#7c2d12"/><circle cx="8" cy="8" r="2" fill="#fff7ed"/></g>
+    </pattern>
+  </defs>
+  <path d="M6 8H122V72H6Z" fill="url(#complex)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-nested.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-nested.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <defs>
+    <pattern id="dots" width="8" height="8" patternUnits="userSpaceOnUse"><rect width="8" height="8" fill="#e0f2fe"/><circle cx="2" cy="2" r="1.5" fill="#0369a1"/></pattern>
+    <pattern id="nested" width="24" height="16" patternUnits="userSpaceOnUse"><rect width="24" height="16" fill="url(#dots)"/><path d="M0 16L24 0V5L0 21Z" fill="#fb7185" opacity=".75"/></pattern>
+  </defs>
+  <ellipse cx="64" cy="40" rx="58" ry="34" fill="url(#nested)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-simple-checkerboard.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-simple-checkerboard.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <defs>
+    <pattern id="checker" width="16" height="16" patternUnits="userSpaceOnUse">
+      <rect width="16" height="16" fill="#f1f5f9"/>
+      <rect width="8" height="8" fill="#2563eb"/>
+      <rect x="8" y="8" width="8" height="8" fill="#2563eb"/>
+    </pattern>
+  </defs>
+  <rect x="4" y="4" width="120" height="72" rx="5" fill="url(#checker)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-tile-clipping.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-tile-clipping.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <defs>
+    <pattern id="clipped" width="20" height="20" patternUnits="userSpaceOnUse">
+      <rect width="20" height="20" fill="#e0f2fe"/>
+      <circle cx="0" cy="10" r="8" fill="#0284c7"/>
+    </pattern>
+  </defs>
+  <rect x="4" y="4" width="120" height="72" rx="8" fill="url(#clipped)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-transformed-object.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-transformed-object.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 80">
+  <defs>
+    <pattern id="local" width="20%" height="35%" patternContentUnits="objectBoundingBox"><rect width="1" height="1" fill="#e2e8f0"/><path d="M0 0L.2 .35H0Z" fill="#334155"/></pattern>
+  </defs>
+  <g transform="translate(30 5) rotate(13 45 35) scale(1.25 .8)"><rect x="0" y="0" width="90" height="70" rx="8" fill="url(#local)"/></g>
+  <rect x="130" y="10" width="38" height="60" fill="url(#local)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-transforms.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-transforms.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 144 88">
+  <defs>
+    <pattern id="rotate" width="14" height="14" patternUnits="userSpaceOnUse" patternTransform="rotate(24)">
+      <rect width="14" height="14" fill="#fee2e2"/><rect width="5" height="14" fill="#dc2626"/>
+    </pattern>
+    <pattern id="scale" width="12" height="12" patternUnits="userSpaceOnUse" patternTransform="translate(3 2) scale(1.35 .75)">
+      <rect width="12" height="12" fill="#dbeafe"/><circle cx="6" cy="6" r="4" fill="#2563eb"/>
+    </pattern>
+    <pattern id="skew" width="14" height="12" patternUnits="userSpaceOnUse" patternTransform="skewX(22) skewY(-10)">
+      <rect width="14" height="12" fill="#dcfce7"/><path d="M0 0H7V12H0Z" fill="#16a34a"/>
+    </pattern>
+  </defs>
+  <rect x="4" y="4" width="40" height="80" fill="url(#rotate)"/>
+  <rect x="52" y="4" width="40" height="80" fill="url(#scale)"/>
+  <rect x="100" y="4" width="40" height="80" fill="url(#skew)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-viewbox-aspect.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-viewbox-aspect.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 96">
+  <defs>
+    <g id="motif"><rect width="10" height="20" fill="#e0e7ff"/><circle cx="5" cy="10" r="4" fill="#4f46e5"/></g>
+    <pattern id="none" width="28" height="24" patternUnits="userSpaceOnUse" viewBox="0 0 10 20" preserveAspectRatio="none"><use href="#motif"/></pattern>
+    <pattern id="min" width="28" height="24" patternUnits="userSpaceOnUse" viewBox="0 0 10 20" preserveAspectRatio="xMinYMin meet"><use href="#motif"/></pattern>
+    <pattern id="mid" width="28" height="24" patternUnits="userSpaceOnUse" viewBox="0 0 10 20" preserveAspectRatio="xMidYMid meet"><use href="#motif"/></pattern>
+    <pattern id="max" width="28" height="24" patternUnits="userSpaceOnUse" viewBox="0 0 10 20" preserveAspectRatio="xMaxYMax meet"><use href="#motif"/></pattern>
+    <pattern id="slice" width="28" height="24" patternUnits="userSpaceOnUse" viewBox="0 0 10 20" preserveAspectRatio="xMidYMid slice"><use href="#motif"/></pattern>
+  </defs>
+  <rect x="2" y="4" width="28" height="88" fill="url(#none)"/>
+  <rect x="34" y="4" width="28" height="88" fill="url(#min)"/>
+  <rect x="66" y="4" width="28" height="88" fill="url(#mid)"/>
+  <rect x="98" y="4" width="28" height="88" fill="url(#max)"/>
+  <rect x="130" y="4" width="28" height="88" fill="url(#slice)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
@@ -43,6 +43,7 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   if (name.startsWith("css-")) tags.add("css");
   if (name.startsWith("compositing-")) tags.add("compositing");
   if (name.startsWith("gradient-")) tags.add("gradient");
+  if (name.startsWith("pattern-")) tags.add("pattern");
   if (name.startsWith("viewport-")) tags.add("viewport");
   if (name.startsWith("viewport-realistic-")) tags.add("realistic");
   for (const element of [
@@ -57,6 +58,7 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
     "linearGradient",
     "radialGradient",
     "stop",
+    "pattern",
     "use",
     "symbol",
     "switch",
@@ -78,6 +80,10 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   if (/\bgradientTransform\s*=/.test(source)) tags.add("gradient-transform");
   if (/\bspreadMethod\s*=/.test(source)) tags.add("gradient-spread");
   if (/<(?:linearGradient|radialGradient)\b[^>]*(?:href|xlink:href)\s*=/.test(source)) tags.add("gradient-href");
+  if (/\bpatternUnits\s*=/.test(source)) tags.add("pattern-units");
+  if (/\bpatternContentUnits\s*=/.test(source)) tags.add("pattern-content-units");
+  if (/\bpatternTransform\s*=/.test(source)) tags.add("pattern-transform");
+  if (/<pattern\b[^>]*(?:href|xlink:href)\s*=/.test(source)) tags.add("pattern-href");
   if (/var\(\s*--|--[\w-]+\s*:/.test(source)) tags.add("css-variables");
   return [...tags].sort();
 }


### PR DESCRIPTION
Closes #57

## Summary
- add typed `<pattern>` resources with href inheritance, coordinate systems, viewBox behavior, transforms, nested content, and cycle diagnostics
- generate scale-correct vector SwiftUI Canvas tiling for pattern fills and strokes, including tile clipping, alpha, nested gradients/patterns, and seam-free compound paths
- add 15 targeted RGBA fixtures, 1x/2x/3x fractional coverage, unit tests, documentation, and a changeset

## Validation
- 134 unit tests pass
- 1,835/1,835 visual fixtures pass
- core format, lint, typecheck, build, and fixture-manifest verification pass