### PR TITLE
Implement SVG clip paths

### DIFF
--- a/.changeset/static-svg-clip-paths.md
+++ b/.changeset/static-svg-clip-paths.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Render typed SVG clipping paths with clip rules, user-space and object-bounding-box coordinates, transforms, nested intersections, diagnostics, and browser-matched RGBA regression coverage.

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -39,6 +39,12 @@ Element and group `opacity` are applied once after their children have been pain
 
 The render tree also exposes shared painted-bounds queries through `__testing`. Bounds include transforms and stroke extents, exclude `display: none`, retain zero-opacity geometry, and intersect nested viewport clips. Future marker and filter tickets can extend the same query.
 
+### Clipping paths
+
+`clip-path: url(#id)` and `<clipPath>` are resolved as typed resources. Generated SwiftUI supports `userSpaceOnUse` and `objectBoundingBox`, resource/target/content transforms, `clip-rule`, groups, `use`, overlapping child unions, nested intersections, empty clips, and clipping on groups and painted shapes.
+
+Clip coverage uses raw geometry only: source fill, stroke, stroke width, paint, and opacity do not affect it. Object bounding boxes likewise use unclipped geometry without stroke, markers, masks, or other effects. Invalid local references apply no clipping and emit a diagnostic; empty, cyclic, or zero-bounds object-box clips render no coverage. Strict conversion rejects every such diagnostic. CSS basic-shape clip paths are diagnosed and deferred.
+
 ### Masks, blend modes, and isolation
 
 `mask` definitions are typed resources with the SVG defaults for `maskUnits`, `maskContentUnits`, the expanded `-10%/-10%/120%/120%` region, and luminance interpretation. Generated SwiftUI supports alpha and luminance masks, object-bounding-box and user-space coordinates, region clipping, transforms, nested masks, groups, `use`, gradients, patterns, opacity, empty masks, and structured diagnostics for missing, wrong-type, malformed, or cyclic references.
@@ -132,6 +138,7 @@ The default antialiasing allowance is 24/255 per channel, at most 3% pixels outs
 - [x] Solid fill/stroke styling with colours
 - [x] Linear/radial gradient fills and strokes, stops, inheritance, transforms, and spread methods
 - [x] Pattern fills and strokes, inheritance, coordinate systems, transforms, viewBox behavior, and vector tiling
+- [x] SVG clipping paths, clip rules, coordinate systems, transforms, unions, and nested intersections
 - [x] SVG masks, Level 1 blend modes, group compositing, and isolation
 - [x] Embedded CSS cascade, custom properties, and computed presentation styles
 - [ ] SVG `<text>` element

--- a/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
@@ -1,6 +1,6 @@
 import { SVGPathData } from "svg-pathdata";
 import { type AffineTransform, IDENTITY_TRANSFORM, multiplyTransforms } from "../transformUtils";
-import type { Geometry, RenderBounds, RenderDocument, RenderNode, RenderShape } from "./types";
+import type { ClipPathInstance, Geometry, RenderBounds, RenderDocument, RenderNode, RenderShape } from "./types";
 
 function union(left: RenderBounds | undefined, right: RenderBounds | undefined): RenderBounds | undefined {
   if (!left) return right;
@@ -154,6 +154,44 @@ function hidden(visibility: string): boolean {
   return visibility === "hidden" || visibility === "collapse";
 }
 
+/** Raw clip geometry bounds. Paint, stroke, opacity, masks, and filters do not contribute. */
+function clipNodesBounds(nodes: RenderNode[], parent: AffineTransform): RenderBounds | undefined {
+  let bounds: RenderBounds | undefined;
+  for (const node of nodes) {
+    if (node.style.display === "none") continue;
+    const transform = multiplyTransforms(parent, node.transform);
+    let candidate: RenderBounds | undefined;
+    if (node.type === "shape") {
+      if (hidden(node.style.visibility)) continue;
+      const geometry = geometryBounds(node.geometry);
+      candidate = geometry
+        ? transformedRect(geometry.x, geometry.y, geometry.width, geometry.height, transform)
+        : undefined;
+    } else if (node.type === "group") {
+      candidate = clipNodesBounds(node.children, transform);
+    }
+    if (node.clipPath) {
+      const nested = clipPathInstanceBounds(node.clipPath, transform);
+      candidate = nested ? intersect(candidate, nested) : undefined;
+    }
+    bounds = union(bounds, candidate);
+  }
+  return bounds;
+}
+
+function clipPathInstanceBounds(
+  instance: ClipPathInstance,
+  targetTransform: AffineTransform,
+): RenderBounds | undefined {
+  if (instance.invalid || instance.children.length === 0) return undefined;
+  const content = instance.children.map((node) =>
+    node.type === "group"
+      ? { ...node, transform: multiplyTransforms(node.transform, instance.contentTransform) }
+      : node,
+  );
+  return clipNodesBounds(content, targetTransform);
+}
+
 /** Painted axis-aligned bounds for a node in the generated root coordinate space. */
 export function renderNodeBounds(node: RenderNode, parent = IDENTITY_TRANSFORM): RenderBounds | undefined {
   if (node.style.display === "none") return undefined;
@@ -161,7 +199,12 @@ export function renderNodeBounds(node: RenderNode, parent = IDENTITY_TRANSFORM):
   if (node.type === "shape") {
     if (hidden(node.style.visibility)) return undefined;
     const bounds = localShapeBounds(node);
-    return bounds ? transformedRect(bounds.x, bounds.y, bounds.width, bounds.height, transform) : undefined;
+    let painted = bounds ? transformedRect(bounds.x, bounds.y, bounds.width, bounds.height, transform) : undefined;
+    if (node.clipPath) {
+      const clip = clipPathInstanceBounds(node.clipPath, transform);
+      painted = clip ? intersect(painted, clip) : undefined;
+    }
+    return painted;
   }
   if (node.type === "group") {
     let bounds = renderNodesBounds(node.children, transform);
@@ -169,6 +212,10 @@ export function renderNodeBounds(node: RenderNode, parent = IDENTITY_TRANSFORM):
       const clip = node.viewport.rect;
       const clipTransform = multiplyTransforms(parent, node.viewport.clipTransform);
       bounds = intersect(bounds, transformedRect(clip.x, clip.y, clip.width, clip.height, clipTransform));
+    }
+    if (node.clipPath) {
+      const clip = clipPathInstanceBounds(node.clipPath, transform);
+      bounds = clip ? intersect(bounds, clip) : undefined;
     }
     return bounds;
   }

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -14,6 +14,7 @@ import { type Presentation, type StyleResolution, SVGStyleResolver } from "../st
 import { type AffineTransform, IDENTITY_TRANSFORM, multiplyTransforms, parseTransform } from "../transformUtils";
 import type { SVGElementProperties, ViewBoxData } from "../types";
 import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio, parseViewBox, viewBoxTransform } from "../viewports";
+import { resolveClipPathInstance, resolveClipPathResources } from "./clips";
 import { resolvePaintServers } from "./gradients";
 import { resolveMaskInstance, resolveMaskResources } from "./masks";
 import { resolvePatternPaintServers } from "./patterns";
@@ -292,6 +293,28 @@ function computedMask(value: unknown, element: ElementNode, context: BuildContex
   return { invalid: true };
 }
 
+function computedClipPath(value: unknown, element: ElementNode, context: BuildContext, css?: CSSDiagnosticContext) {
+  const normalized = String(value ?? "none").trim();
+  if (normalized.toLowerCase() === "none") return undefined;
+  const local = /^url\(\s*["']?#([^\s)"']+)["']?\s*\)$/i.exec(normalized);
+  if (local) return { id: local[1]!, invalid: false };
+
+  let code = "invalid-clip-path-reference";
+  if (/^url\(/i.test(normalized)) code = "external-clip-path-reference";
+  else if (/^(?:circle|ellipse|inset|polygon|path|rect|xywh)\s*\(/i.test(normalized))
+    code = "unsupported-clip-path-basic-shape";
+  addDiagnostic(
+    context,
+    element,
+    code,
+    code === "unsupported-clip-path-basic-shape"
+      ? `CSS basic-shape clip-path '${normalized}' is outside the current static profile; use a local <clipPath> URL.`
+      : `Only one local clip-path reference of the form url(#id) is supported; received '${normalized}'.`,
+    css,
+  );
+  return { invalid: true };
+}
+
 function computeStyle(
   effective: Presentation,
   provenance: StyleResolution["provenance"],
@@ -306,6 +329,8 @@ function computeStyle(
   const color = String(effective.color ?? "black");
   const fillRule = String(effective["fill-rule"] ?? effective.fillRule ?? "nonzero").toLowerCase();
   const clipRule = String(effective["clip-rule"] ?? "nonzero").toLowerCase();
+  if (clipRule !== "nonzero" && clipRule !== "evenodd")
+    addDiagnostic(context, element, "invalid-clip-rule", `Invalid clip-rule '${clipRule}'.`, provenance["clip-rule"]);
   const isolationValue = String(effective.isolation ?? "auto")
     .trim()
     .toLowerCase();
@@ -349,6 +374,7 @@ function computeStyle(
     if (resolved.length > 0 && resolved.every((value): value is number => value !== undefined)) dashArray = resolved;
   }
   const mask = computedMask(effective.mask, element, context, provenance.mask);
+  const clipPath = computedClipPath(effective["clip-path"], element, context, provenance["clip-path"]);
 
   return {
     fill: parsePaint(isLine ? "none" : (effective.fill ?? "black"), color),
@@ -378,6 +404,7 @@ function computeStyle(
     visibility: String(effective.visibility ?? "visible")
       .trim()
       .toLowerCase(),
+    ...(clipPath ? { clipPath } : {}),
     ...(mask ? { mask } : {}),
     blendMode: computedBlendMode(effective["mix-blend-mode"], element, context, provenance["mix-blend-mode"]),
     isolation: isolationValue === "isolate" ? "isolate" : "auto",
@@ -575,6 +602,7 @@ function createRegistry(root: ElementNode): ResourceRegistry {
     paints: new Map(),
     paintElements: new Map(),
     clips: new Map(),
+    clipElements: new Map(),
     masks: new Map(),
     maskElements: new Map(),
     markers: new Map(),
@@ -590,7 +618,7 @@ function createRegistry(root: ElementNode): ResourceRegistry {
       if (element.tagName === "view") registry.views.set(id, element);
       if (["linearGradient", "radialGradient", "pattern"].includes(element.tagName ?? ""))
         registry.paintElements.set(id, element);
-      if (element.tagName === "clipPath") registry.clips.set(id, element);
+      if (element.tagName === "clipPath") registry.clipElements.set(id, element);
       if (element.tagName === "mask") registry.maskElements.set(id, element);
       if (element.tagName === "marker") registry.markers.set(id, element);
       if (element.tagName === "filter") registry.filters.set(id, element);
@@ -990,6 +1018,13 @@ export function buildRenderDocument(
     resources.paints.set(id, paint);
   }
   resources.masks = resolveMaskResources(svg, resources.maskElements, styleResolver, resolved.effective, diagnostics);
+  resources.clips = resolveClipPathResources(
+    svg,
+    resources.clipElements,
+    styleResolver,
+    resolved.effective,
+    diagnostics,
+  );
   const rootTransform = multiplyTransforms(computedTransform(svg, resolved, context), properties.viewBoxTransform);
   const childCoordinate = { ...coordinate, fontMetrics: resolved.fontMetrics };
   const root: RenderGroup = {
@@ -1099,6 +1134,133 @@ export function buildRenderDocument(
   }
   materializeReferencedPatterns(children);
 
+  function diagnoseClipOnce(node: RenderNode, code: string, message: string): void {
+    if (
+      diagnostics.some(
+        (item) =>
+          item.code === code &&
+          item.source.element === node.source.element &&
+          item.source.id === node.source.id &&
+          item.message === message,
+      )
+    )
+      return;
+    diagnostics.push({ code, message, severity: "warning", source: node.source });
+  }
+
+  function emptyClip() {
+    return {
+      children: [],
+      contentTransform: IDENTITY_TRANSFORM,
+      invalid: true,
+    };
+  }
+
+  function materializeClipPaths(nodes: RenderNode[], stack: string[] = []): void {
+    for (const node of nodes) {
+      if (node.type === "group") materializeClipPaths(node.children, stack);
+      const reference = node.style.clipPath;
+      if (!reference || reference.invalid || !reference.id) continue;
+      const id = reference.id;
+      const resource = resources.clips.get(id);
+      if (!resource) {
+        const target = resources.definitions.get(id);
+        diagnoseClipOnce(
+          node,
+          target ? "wrong-clip-path-resource-type" : "missing-clip-path-resource",
+          target
+            ? `Clip-path reference #${id} targets <${target.tagName}> instead of a clipPath.`
+            : `Clip-path reference #${id} does not resolve to a local clipPath resource.`,
+        );
+        // CSS Masking specifies that an invalid URI reference applies no clipping.
+        // Strict conversion still fails because the diagnostic remains observable.
+        continue;
+      }
+      if (stack.includes(id)) {
+        const cycle = [...stack.slice(stack.indexOf(id)), id];
+        diagnoseClipOnce(
+          node,
+          "cyclic-clip-path-reference",
+          `Clip-path cycle detected: ${cycle.map((item) => `#${item}`).join(" -> ")}.`,
+        );
+        node.clipPath = emptyClip();
+        continue;
+      }
+
+      const viewport =
+        resource.units === "objectBoundingBox" ? { width: 1, height: 1 } : { ...node.paintContext.viewport };
+      const effective = { ...resource.presentation } as Presentation;
+      const inheritedFontSize = node.paintContext.fontMetrics.fontSize;
+      const resourceFontSize = typeof effective["font-size"] === "number" ? effective["font-size"] : inheritedFontSize;
+      const fontMetrics = defaultFontMetrics(resourceFontSize, node.paintContext.fontMetrics.rootFontSize);
+      const clipCoordinate: CoordinateContext = {
+        viewport,
+        rootViewport: { ...node.paintContext.rootViewport },
+        fontMetrics,
+      };
+      const resourceStyle = computeStyle(
+        effective,
+        resource.provenance,
+        clipCoordinate,
+        fontMetrics,
+        resource.element,
+        context,
+      );
+      const resourceResolved = {
+        effective,
+        fontMetrics,
+        style: resourceStyle,
+        provenance: resource.provenance,
+      };
+      const clipContext: BuildContext = {
+        ...context,
+        activeReferences: new Set(context.activeReferences).add(resource.id),
+      };
+      const built: RenderNode[] = [];
+      for (const content of resource.contentElements) {
+        try {
+          built.push(...buildNode(content, effective, clipCoordinate, clipContext));
+        } catch (error) {
+          diagnoseClipOnce(
+            node,
+            "invalid-clip-path-content-reference",
+            `ClipPath #${id} content could not be resolved: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+      const rootGroup: RenderGroup = {
+        type: "group",
+        children: built,
+        // display does not apply to the clipPath element itself. Other computed
+        // properties still inherit normally into its graphics children.
+        style: { ...resourceStyle, display: "inline" },
+        transform: computedTransform(resource.element, resourceResolved, context),
+        source: resource.source,
+        paintContext: {
+          viewport: { ...clipCoordinate.viewport },
+          rootViewport: { ...clipCoordinate.rootViewport },
+          fontMetrics: { ...fontMetrics },
+        },
+      };
+      materializeClipPaths([rootGroup], [...stack, id]);
+      const instance = resolveClipPathInstance(resource, node, [rootGroup]);
+      if (instance.invalid && resource.units === "objectBoundingBox")
+        diagnoseClipOnce(
+          node,
+          "degenerate-clip-path-object-bounding-box",
+          `ClipPath #${id} cannot resolve objectBoundingBox units against an empty or zero-sized target geometry.`,
+        );
+      resource.instances.set(node, instance);
+      if (resource.children.length === 0) resource.children = [rootGroup];
+      node.clipPath = instance;
+    }
+  }
+  materializeClipPaths(children);
+  for (const paint of resources.paints.values()) {
+    if (paint.type !== "pattern") continue;
+    for (const instance of paint.instances.values()) materializeClipPaths(instance.children);
+  }
+
   function diagnoseMaskOnce(node: RenderNode, code: string, message: string): void {
     if (diagnostics.some((item) => item.code === code && item.source === node.source && item.message === message))
       return;
@@ -1168,6 +1330,7 @@ export function buildRenderDocument(
         }
       }
       materializeReferencedPatterns(built);
+      materializeClipPaths(built);
       materializeMasks(built, [...stack, id]);
       const instance = resolveMaskInstance(resource, node, built);
       resource.instances.set(node, instance);

--- a/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
@@ -52,6 +52,7 @@ function containsIndependentCompositing(nodes: RenderNode[]): boolean {
       node.style.fillOpacity !== 1 ||
       node.style.strokeOpacity !== 1 ||
       node.style.isolation === "isolate" ||
+      node.clipPath !== undefined ||
       node.style.mask !== undefined ||
       node.style.blendMode !== "normal"
     )

--- a/packages/svg-to-swiftui-core/src/renderTree/clips.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/clips.ts
@@ -1,0 +1,102 @@
+import type { ElementNode } from "svg-parser";
+import type { Presentation, StyleResolution, SVGStyleResolver } from "../styleCascade";
+import { type AffineTransform, IDENTITY_TRANSFORM } from "../transformUtils";
+import { objectBoundingBox } from "./bounds";
+import type {
+  ClipPathInstance,
+  ClipPathResource,
+  ClipPathUnits,
+  RenderDiagnostic,
+  RenderNode,
+  SourceLocation,
+} from "./types";
+
+function sourceLocation(element: ElementNode): SourceLocation {
+  const id = element.properties?.id;
+  return { element: element.tagName ?? "unknown", ...(id === undefined ? {} : { id: String(id) }) };
+}
+
+function diagnostic(diagnostics: RenderDiagnostic[], element: ElementNode, code: string, message: string): void {
+  diagnostics.push({ code, message, severity: "warning", source: sourceLocation(element) });
+}
+
+function children(element: ElementNode): ElementNode[] {
+  return element.children.filter(
+    (child): child is ElementNode => typeof child !== "string" && child.type === "element",
+  );
+}
+
+function containsClipPath(element: ElementNode): boolean {
+  return element.tagName === "clipPath" || children(element).some(containsClipPath);
+}
+
+function units(element: ElementNode, diagnostics: RenderDiagnostic[]): ClipPathUnits {
+  const value = String(element.properties?.clipPathUnits ?? "userSpaceOnUse");
+  if (value === "objectBoundingBox" || value === "userSpaceOnUse") return value;
+  diagnostic(diagnostics, element, "invalid-clipPathUnits", `Invalid clipPathUnits '${value}'.`);
+  return "userSpaceOnUse";
+}
+
+/** Resolve local clipPath definitions while preserving their document-tree inheritance. */
+export function resolveClipPathResources(
+  root: ElementNode,
+  clipElements: Map<string, ElementNode>,
+  styleResolver: SVGStyleResolver,
+  rootPresentation: Presentation,
+  diagnostics: RenderDiagnostic[],
+): Map<string, ClipPathResource> {
+  const resolutions = new Map<ElementNode, StyleResolution>();
+  const walk = (element: ElementNode, inherited: Presentation): void => {
+    for (const child of children(element)) {
+      if (!containsClipPath(child)) continue;
+      const resolved = styleResolver.resolve(child, inherited);
+      resolutions.set(child, resolved);
+      walk(child, resolved.values);
+    }
+  };
+  walk(root, rootPresentation);
+
+  const resources = new Map<string, ClipPathResource>();
+  for (const [id, element] of clipElements) {
+    const resolved = resolutions.get(element);
+    resources.set(id, {
+      id,
+      units: units(element, diagnostics),
+      source: sourceLocation(element),
+      element,
+      contentElements: children(element),
+      children: [],
+      instances: new Map(),
+      presentation: resolved?.values ?? rootPresentation,
+      provenance: resolved?.provenance ?? {},
+    });
+  }
+  return resources;
+}
+
+/** Resolve clipPathUnits for one target before the target's own transform. */
+export function resolveClipPathInstance(
+  resource: ClipPathResource,
+  node: RenderNode,
+  children: RenderNode[],
+): ClipPathInstance {
+  if (resource.units === "userSpaceOnUse") {
+    return { resource, children, contentTransform: IDENTITY_TRANSFORM, invalid: false };
+  }
+
+  // SVG object bounding boxes use geometry only: stroke, markers, clipping, masking,
+  // filtering, and other paint effects do not contribute.
+  const bounds = objectBoundingBox(node);
+  if (!bounds || bounds.width === 0 || bounds.height === 0) {
+    return { resource, children: [], contentTransform: IDENTITY_TRANSFORM, invalid: true };
+  }
+  const contentTransform: AffineTransform = {
+    a: bounds.width,
+    b: 0,
+    c: 0,
+    d: bounds.height,
+    e: bounds.x,
+    f: bounds.y,
+  };
+  return { resource, children, contentTransform, invalid: false };
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -8,6 +8,7 @@ import { renderNodeBounds } from "./bounds";
 import { type ResolvedGradient, resolveGradientForShape } from "./gradients";
 import { type ResolvedPattern, resolvePatternForShape } from "./patterns";
 import type {
+  ClipPathInstance,
   ComputedStyle,
   Geometry,
   GradientStop,
@@ -36,6 +37,7 @@ type GeneratedViewNode =
       swiftColor: string;
       cgColor: RGBAColor;
       tileContained?: boolean;
+      clipUnions?: string[][];
     }
   | {
       type: "gradient";
@@ -60,7 +62,8 @@ type GeneratedViewNode =
       opacity: number;
       isolated: boolean;
       blendMode: SVGBlendMode;
-      clip?: string;
+      viewportClip?: string;
+      clipPath?: GeneratedClipPath;
       mask?: GeneratedMask;
       tileContained?: boolean;
     };
@@ -69,6 +72,10 @@ interface GeneratedMask {
   children: GeneratedViewNode[];
   clip: string;
   luminance: boolean;
+}
+
+interface GeneratedClipPath {
+  children: GeneratedViewNode[];
 }
 
 interface ViewBuildContext {
@@ -288,10 +295,114 @@ function buildViewNodes(
     return { children, clip, luminance: mask.maskType === "luminance" };
   };
 
+  let buildClipPath: (
+    clipPath: ClipPathInstance | undefined,
+    targetTransforms: RenderNode["transform"][],
+  ) => GeneratedClipPath | undefined;
+
+  const addCoverageClip = (node: GeneratedViewNode, helpers: string[]): GeneratedViewNode => {
+    if (node.type === "paint") return { ...node, clipUnions: [...(node.clipUnions ?? []), helpers] };
+    if (node.type === "group")
+      return { ...node, children: node.children.map((child) => addCoverageClip(child, helpers)) };
+    return node;
+  };
+
+  const buildClipCoverage = (
+    clipNodes: RenderNode[],
+    coverageTransforms: RenderNode["transform"][],
+  ): GeneratedViewNode[] => {
+    const coverage: GeneratedViewNode[] = [];
+    for (const clipNode of clipNodes) {
+      if (clipNode.style.display === "none") continue;
+      const targetTransforms = [...coverageTransforms, clipNode.transform];
+      if (clipNode.type === "group") {
+        const children = buildClipCoverage(clipNode.children, targetTransforms);
+        const nested = buildClipPath(clipNode.clipPath, targetTransforms);
+        if (nested) {
+          const helpers = simpleClipPathHelpers(nested);
+          // Intersection distributes over the clip subtree's logical union.
+          // Simple nested regions become GraphicsContext clips on each leaf;
+          // SwiftUI otherwise ignores nested view masks inside mask content.
+          if (helpers && helpers.length > 0) {
+            coverage.push(...children.map((child) => addCoverageClip(child, helpers)));
+          } else {
+            for (const child of children)
+              coverage.push({
+                type: "group",
+                children: [child],
+                opacity: 1,
+                isolated: true,
+                blendMode: "normal",
+                clipPath: nested,
+              });
+          }
+        } else if (children.length > 0) {
+          coverage.push({
+            type: "group",
+            children,
+            opacity: 1,
+            isolated: false,
+            blendMode: "normal",
+          });
+        }
+        continue;
+      }
+      if (
+        clipNode.type !== "shape" ||
+        clipNode.style.visibility === "hidden" ||
+        clipNode.style.visibility === "collapse"
+      )
+        continue;
+
+      // A clipPath consumes raw geometry. Convert clip-rule into the helper's
+      // non-zero-compatible path representation, independent of source paint.
+      const coverageShape: RenderShape = {
+        ...clipNode,
+        style: { ...clipNode.style, fillRule: clipNode.style.clipRule },
+      };
+      let lines = renderShape(coverageShape, context.options, { fill: "black", stroke: "none" });
+      for (let index = coverageTransforms.length - 1; index >= 0; index--)
+        lines = wrapWithTransform(lines, coverageTransforms[index]!, context.options);
+      if (lines.length === 0) continue;
+      const helper = addHelper(context, `ClipCoverage${context.nextClip++}`, lines);
+      const path: GeneratedViewNode = {
+        type: "paint",
+        helper,
+        swiftColor: "Color.white",
+        cgColor: { red: 1, green: 1, blue: 1, alpha: 1 },
+      };
+      const nested = buildClipPath(clipNode.clipPath, targetTransforms);
+      const helpers = nested ? simpleClipPathHelpers(nested) : undefined;
+      const clippedPath = helpers && helpers.length > 0 ? addCoverageClip(path, helpers) : path;
+      coverage.push({
+        type: "group",
+        children: [clippedPath],
+        opacity: 1,
+        isolated: !!nested && !helpers,
+        blendMode: "normal",
+        ...(nested && !helpers ? { clipPath: nested } : {}),
+      });
+    }
+    return coverage;
+  };
+
+  buildClipPath = (clipPath, targetTransforms) => {
+    if (!clipPath) return undefined;
+    const content = clipPath.children.map((node) =>
+      node.type === "group"
+        ? { ...node, transform: multiplyTransforms(node.transform, clipPath.contentTransform) }
+        : node,
+    );
+    // clipPath's transform operates outside the clipPathUnits mapping:
+    // target × resource-transform × object-bounding-box.
+    const children = clipPath.invalid ? [] : buildClipCoverage(content, targetTransforms);
+    return { children };
+  };
+
   for (const node of nodes) {
     if (node.style.display === "none") continue;
     if (node.type === "group") {
-      let clip: string | undefined;
+      let viewportClip: string | undefined;
       if (node.viewport?.clip) {
         const { rect, clipTransform } = node.viewport;
         let clipLines = handleElement(
@@ -314,11 +425,12 @@ function buildViewNodes(
         for (let index = ancestorTransforms.length - 1; index >= 0; index--) {
           clipLines = wrapWithTransform(clipLines, ancestorTransforms[index]!, context.options);
         }
-        clip = addHelper(context, `Clip${context.nextClip++}`, clipLines);
+        viewportClip = addHelper(context, `Clip${context.nextClip++}`, clipLines);
       }
       const targetTransforms = [...ancestorTransforms, node.transform];
       const children = buildViewNodes(node.children, context, targetTransforms);
       if (children.length > 0) {
+        const clipPath = buildClipPath(node.clipPath, targetTransforms);
         const mask = buildMask(node.mask, targetTransforms);
         generated.push({
           type: "group",
@@ -328,9 +440,11 @@ function buildViewNodes(
             node.style.opacity !== 1 ||
             node.style.isolation === "isolate" ||
             node.style.blendMode !== "normal" ||
+            !!clipPath ||
             !!mask,
           blendMode: node.style.blendMode,
-          ...(clip ? { clip } : {}),
+          ...(viewportClip ? { viewportClip } : {}),
+          ...(clipPath ? { clipPath } : {}),
           ...(mask ? { mask } : {}),
         });
       }
@@ -451,14 +565,21 @@ function buildViewNodes(
       }
     }
     if (paints.length > 0) {
-      const mask = buildMask(node.mask, [...ancestorTransforms, node.transform]);
+      const targetTransforms = [...ancestorTransforms, node.transform];
+      const clipPath = buildClipPath(node.clipPath, targetTransforms);
+      const mask = buildMask(node.mask, targetTransforms);
       generated.push({
         type: "group",
         children: paints,
         opacity: node.style.opacity,
         isolated:
-          node.style.opacity !== 1 || node.style.isolation === "isolate" || node.style.blendMode !== "normal" || !!mask,
+          node.style.opacity !== 1 ||
+          node.style.isolation === "isolate" ||
+          node.style.blendMode !== "normal" ||
+          !!clipPath ||
+          !!mask,
         blendMode: node.style.blendMode,
+        ...(clipPath ? { clipPath } : {}),
         ...(mask ? { mask } : {}),
       });
     }
@@ -618,17 +739,31 @@ function renderGeneratedCommands(
       lines.push(...renderPatternCommands(node, graphicsName, level, indentation));
       continue;
     }
-    const needsLayer = node.isolated || node.clip !== undefined || node.blendMode !== "normal";
+    const commandClipHelpers = node.clipPath ? simpleClipPathHelpers(node.clipPath) : [];
+    const needsLayer =
+      node.isolated || node.viewportClip !== undefined || node.clipPath !== undefined || node.blendMode !== "normal";
     if (!needsLayer) {
       lines.push(...renderGeneratedCommands(node.children, graphicsName, level, indentation));
       continue;
     }
     lines.push(`${prefix}do {`, `${inner}${graphicsName}.saveGState()`);
-    if (node.clip)
+    if (node.viewportClip)
       lines.push(
-        `${inner}${graphicsName}.addPath(${node.clip}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+        `${inner}${graphicsName}.addPath(${node.viewportClip}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
         `${inner}${graphicsName}.clip()`,
       );
+    if (commandClipHelpers && commandClipHelpers.length > 0) {
+      lines.push(`${inner}let clipUnion = CGMutablePath()`);
+      for (const helper of commandClipHelpers)
+        lines.push(`${inner}clipUnion.addPath(${helper}().path(in: CGRect(origin: .zero, size: size)).cgPath)`);
+      lines.push(`${inner}${graphicsName}.addPath(clipUnion)`, `${inner}${graphicsName}.clip()`);
+    } else if (node.clipPath) {
+      // Complex clip subtrees are rendered correctly by the SwiftUI view path.
+      // Command-mode pattern content currently has no Core Graphics path
+      // boolean operation for a nested clipped union, so an empty clip is the
+      // safe deterministic result instead of leaking unclipped paint.
+      lines.push(`${inner}${graphicsName}.clip(to: .zero)`);
+    }
     if (node.blendMode !== "normal")
       lines.push(`${inner}${graphicsName}.setBlendMode(.${swiftBlendMode(node.blendMode)})`);
     if (node.isolated) {
@@ -640,6 +775,32 @@ function renderGeneratedCommands(
     lines.push(`${inner}${graphicsName}.restoreGState()`, `${prefix}}`);
   }
   return lines;
+}
+
+function simpleClipPathHelpers(clipPath: GeneratedClipPath): string[] | undefined {
+  const helpers: string[] = [];
+  const visit = (nodes: GeneratedViewNode[]): boolean => {
+    for (const node of nodes) {
+      if (node.type === "paint") {
+        if (node.clipUnions) return false;
+        helpers.push(node.helper);
+        continue;
+      }
+      if (
+        node.type !== "group" ||
+        node.opacity !== 1 ||
+        node.isolated ||
+        node.blendMode !== "normal" ||
+        node.viewportClip ||
+        node.clipPath ||
+        node.mask ||
+        !visit(node.children)
+      )
+        return false;
+    }
+    return true;
+  };
+  return visit(clipPath.children) ? helpers : undefined;
 }
 
 interface PatternRepeatRuntime {
@@ -665,7 +826,8 @@ function canBatchPatternNode(node: GeneratedViewNode): boolean {
     node.type === "group" &&
     node.tileContained === true &&
     !node.isolated &&
-    !node.clip &&
+    !node.viewportClip &&
+    !node.clipPath &&
     !node.mask &&
     node.blendMode === "normal" &&
     node.children.every(canBatchPatternNode)
@@ -790,13 +952,62 @@ function renderPatternCommands(
 
 function renderViewNode(node: GeneratedViewNode, level: number, indentation: string): string[] {
   const prefix = indentation.repeat(level);
-  if (node.type === "paint") return [`${prefix}${node.helper}().fill(${node.swiftColor})`];
+  if (node.type === "paint") {
+    if (!node.clipUnions) return [`${prefix}${node.helper}().fill(${node.swiftColor})`];
+    const inner = `${prefix}${indentation}`;
+    const deep = `${inner}${indentation}`;
+    const lines = [
+      `${prefix}Canvas { context, size in`,
+      `${inner}context.withCGContext { graphics in`,
+      `${deep}graphics.saveGState()`,
+    ];
+    for (const [index, helpers] of node.clipUnions.entries()) {
+      lines.push(`${deep}let clipUnion${index} = CGMutablePath()`);
+      for (const helper of helpers)
+        lines.push(`${deep}clipUnion${index}.addPath(${helper}().path(in: CGRect(origin: .zero, size: size)).cgPath)`);
+      lines.push(`${deep}graphics.addPath(clipUnion${index})`, `${deep}graphics.clip()`);
+    }
+    lines.push(
+      `${deep}graphics.addPath(${node.helper}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+      `${deep}graphics.setFillColor(CGColor(colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!, components: [${formatNumber(node.cgColor.red)}, ${formatNumber(node.cgColor.green)}, ${formatNumber(node.cgColor.blue)}, ${formatNumber(node.cgColor.alpha)}])!)`,
+      `${deep}graphics.fillPath()`,
+      `${deep}graphics.restoreGState()`,
+      `${inner}}`,
+      `${prefix}}`,
+    );
+    return lines;
+  }
   if (node.type === "gradient") return renderGradientNode(node, level, indentation);
   if (node.type === "pattern") return renderPatternNode(node, level, indentation);
   const lines = [`${prefix}ZStack {`];
   for (const child of node.children) lines.push(...renderViewNode(child, level + 1, indentation));
   lines.push(`${prefix}}`);
-  if (node.clip) lines.push(`${prefix}.clipShape(${node.clip}())`);
+  // Flatten the source subtree before applying SVG effects. SwiftUI otherwise
+  // distributes masks and opacity across ZStack children, which changes
+  // overlap colors and prevents nested clip-path intersections from composing.
+  if (node.isolated) lines.push(`${prefix}.compositingGroup()`);
+  if (node.viewportClip) lines.push(`${prefix}.clipShape(${node.viewportClip}())`);
+  if (node.clipPath) {
+    const simpleHelpers = simpleClipPathHelpers(node.clipPath);
+    if (simpleHelpers?.length === 1) {
+      lines.push(`${prefix}.clipShape(${simpleHelpers[0]}())`);
+    } else {
+      lines.push(
+        `${prefix}.mask {`,
+        `${prefix}${indentation}GeometryReader { proxy in`,
+        `${prefix}${indentation}${indentation}ZStack {`,
+      );
+      if (node.clipPath.children.length === 0)
+        lines.push(`${prefix}${indentation}${indentation}${indentation}Color.clear`);
+      else for (const child of node.clipPath.children) lines.push(...renderViewNode(child, level + 3, indentation));
+      lines.push(
+        `${prefix}${indentation}${indentation}}`,
+        `${prefix}${indentation}${indentation}.frame(width: proxy.size.width, height: proxy.size.height)`,
+        `${prefix}${indentation}}`,
+        `${prefix}}`,
+      );
+    }
+  }
   if (node.mask) {
     if (node.mask.luminance) {
       lines.push(
@@ -847,7 +1058,6 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
       lines.push(`${prefix}${indentation}}`, `${prefix}${indentation}.clipShape(${node.mask.clip}())`, `${prefix}}`);
     }
   }
-  if (node.isolated) lines.push(`${prefix}.compositingGroup()`);
   if (node.opacity !== 1) lines.push(`${prefix}.opacity(${swiftNumber(node.opacity)})`);
   if (node.blendMode !== "normal") lines.push(`${prefix}.blendMode(.${swiftBlendMode(node.blendMode)})`);
   return lines;
@@ -862,7 +1072,9 @@ function containsGradientNode(nodes: GeneratedViewNode[]): boolean {
     (node) =>
       node.type === "gradient" ||
       (node.type === "group" &&
-        (containsGradientNode(node.children) || (node.mask ? containsGradientNode(node.mask.children) : false))) ||
+        (containsGradientNode(node.children) ||
+          (node.clipPath ? containsGradientNode(node.clipPath.children) : false) ||
+          (node.mask ? containsGradientNode(node.mask.children) : false))) ||
       (node.type === "pattern" && containsGradientNode(node.contentNodes)),
   );
 }

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -77,6 +77,7 @@ export interface RadialGradientPaint extends GradientPaintBase {
 
 export type PatternUnits = "objectBoundingBox" | "userSpaceOnUse";
 export type MaskUnits = "objectBoundingBox" | "userSpaceOnUse";
+export type ClipPathUnits = "objectBoundingBox" | "userSpaceOnUse";
 export type MaskType = "alpha" | "luminance";
 export type SVGBlendMode =
   | "normal"
@@ -129,6 +130,30 @@ export interface MaskInstance {
 }
 
 export interface MaskReference {
+  id?: string;
+  invalid: boolean;
+}
+
+export interface ClipPathResource {
+  id: string;
+  units: ClipPathUnits;
+  source: SourceLocation;
+  element: ElementNode;
+  contentElements: ElementNode[];
+  children: RenderNode[];
+  instances: Map<RenderNode, ClipPathInstance>;
+  presentation: Readonly<Record<string, string | number>>;
+  provenance: Readonly<Record<string, CSSDiagnosticContext>>;
+}
+
+export interface ClipPathInstance {
+  resource?: ClipPathResource;
+  children: RenderNode[];
+  contentTransform: AffineTransform;
+  invalid: boolean;
+}
+
+export interface ClipPathReference {
   id?: string;
   invalid: boolean;
 }
@@ -200,6 +225,7 @@ export interface ComputedStyle {
   clipRule: "nonzero" | "evenodd";
   display: string;
   visibility: string;
+  clipPath?: ClipPathReference;
   mask?: MaskReference;
   blendMode: SVGBlendMode;
   isolation: "auto" | "isolate";
@@ -227,6 +253,7 @@ export interface RenderShape {
   source: SourceLocation;
   /** Coordinate context at the referencing element, retained for user-space paint percentages. */
   paintContext: NodeCoordinateContext;
+  clipPath?: ClipPathInstance;
   mask?: MaskInstance;
 }
 
@@ -237,6 +264,7 @@ export interface RenderGroup {
   transform: AffineTransform;
   source: SourceLocation;
   paintContext: NodeCoordinateContext;
+  clipPath?: ClipPathInstance;
   mask?: MaskInstance;
   /** True when this group came from a referenced definition. */
   referenceId?: string;
@@ -261,6 +289,7 @@ export interface RenderText {
   transform: AffineTransform;
   source: SourceLocation;
   paintContext: NodeCoordinateContext;
+  clipPath?: ClipPathInstance;
   mask?: MaskInstance;
 }
 
@@ -272,6 +301,7 @@ export interface RenderImage {
   transform: AffineTransform;
   source: SourceLocation;
   paintContext: NodeCoordinateContext;
+  clipPath?: ClipPathInstance;
   mask?: MaskInstance;
 }
 
@@ -285,7 +315,8 @@ export interface ResourceRegistry {
   paints: Map<string, PaintServer>;
   /** Original paint elements retained for future pattern/resource resolvers. */
   paintElements: Map<string, ElementNode>;
-  clips: Map<string, ElementNode>;
+  clips: Map<string, ClipPathResource>;
+  clipElements: Map<string, ElementNode>;
   masks: Map<string, MaskResource>;
   maskElements: Map<string, ElementNode>;
   markers: Map<string, ElementNode>;

--- a/packages/svg-to-swiftui-core/src/tests/clips.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/clips.test.ts
@@ -1,0 +1,176 @@
+import { __testing, convert } from "../index";
+import type { RenderNode } from "../renderTree/types";
+
+function flatten(nodes: RenderNode[]): RenderNode[] {
+  return nodes.flatMap((node) => (node.type === "group" ? [node, ...flatten(node.children)] : [node]));
+}
+
+function nodeById(nodes: RenderNode[], id: string): RenderNode | undefined {
+  return flatten(nodes).find((node) => node.source.id === id);
+}
+
+describe("SVG clip paths", () => {
+  test("retains typed defaults and materializes all graphics children as one target instance", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 50"><defs>
+        <clipPath id="clip"><rect width="30" height="50"/><circle cx="50" cy="25" r="20"/></clipPath>
+      </defs><rect id="target" width="100" height="50" fill="red" clip-path="url(#clip)"/></svg>
+    `);
+    const resource = document.resources.clips.get("clip");
+    const target = nodeById(document.children, "target");
+
+    expect(resource).toMatchObject({ id: "clip", units: "userSpaceOnUse" });
+    expect(resource?.contentElements).toHaveLength(2);
+    expect(resource?.children[0]).toMatchObject({ type: "group" });
+    expect(target?.clipPath).toMatchObject({
+      resource: { id: "clip" },
+      contentTransform: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+      invalid: false,
+    });
+    expect(target?.clipPath?.children[0]?.type === "group" ? target.clipPath.children[0].children : []).toHaveLength(2);
+  });
+
+  test("resolves objectBoundingBox from unclipped geometry without stroke or target transforms", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 200 100"><defs>
+        <clipPath id="box" clipPathUnits="objectBoundingBox" transform="translate(.1 .2)">
+          <rect x=".1" y=".2" width=".5" height=".5" transform="scale(.8)"/>
+        </clipPath>
+      </defs>
+      <rect id="target" x="20" y="10" width="100" height="40" stroke="black" stroke-width="30"
+        transform="translate(30 5)" clip-path="url(#box)"/>
+    </svg>`);
+    const target = nodeById(document.children, "target");
+    expect(target?.clipPath).toMatchObject({
+      contentTransform: { a: 100, b: 0, c: 0, d: 40, e: 20, f: 10 },
+      invalid: false,
+    });
+    expect(target?.clipPath?.children[0]?.transform).toMatchObject({ e: 0.1, f: 0.2 });
+    const bounds = target && __testing.renderNodeBounds(target);
+    expect(bounds?.x).toBeCloseTo(58.1);
+    expect(bounds?.y).toBeCloseTo(21.6);
+    expect(bounds?.width).toBeCloseTo(40);
+    expect(bounds?.height).toBeCloseTo(16);
+  });
+
+  test("uses clip-rule independently from fill-rule and ignores clip paint properties", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20"><defs><clipPath id="hole">
+        <path id="clip-shape" d="M1 1h18v18H1zM6 6h8v8H6z" fill-rule="nonzero" clip-rule="evenodd"
+          fill="none" stroke="red" stroke-width="50" opacity="0"/>
+      </clipPath></defs><rect width="20" height="20" fill="blue" clip-path="url(#hole)"/></svg>
+    `);
+    const shape = nodeById(document.resources.clips.get("hole")?.children ?? [], "clip-shape");
+    expect(shape?.style).toMatchObject({ fillRule: "nonzero", clipRule: "evenodd", opacity: 0 });
+
+    const output = convert(`
+      <svg viewBox="0 0 20 20"><defs><clipPath id="hole">
+        <path d="M1 1h18v18H1zM6 6h8v8H6z" fill="none" stroke="red" opacity="0" clip-rule="evenodd"/>
+      </clipPath></defs><rect width="20" height="20" fill="blue" clip-path="url(#hole)"/></svg>
+    `);
+    expect(output).toContain("ClipCoverage");
+    expect(output).toContain(".clipShape(ClipCoverage");
+    expect(output).not.toContain("opacity(0)");
+  });
+
+  test("intersects nested clips on clipPath roots and individual children", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 40 20"><defs>
+        <clipPath id="left"><rect width="20" height="20"/></clipPath>
+        <clipPath id="both" clip-path="url(#left)">
+          <rect width="40" height="20"/>
+          <circle id="nested-child" cx="30" cy="10" r="10" clip-path="url(#left)"/>
+        </clipPath>
+      </defs><g id="target" clip-path="url(#both)"><rect width="40" height="20" fill="green"/></g></svg>
+    `);
+    const target = nodeById(document.children, "target");
+    const root = target?.clipPath?.children[0];
+    const child = nodeById(root ? [root] : [], "nested-child");
+    expect(root?.clipPath?.resource?.id).toBe("left");
+    expect(child?.clipPath?.resource?.id).toBe("left");
+    const output = convert(`
+      <svg viewBox="0 0 40 20"><defs>
+        <clipPath id="left"><rect width="20" height="20"/></clipPath>
+        <clipPath id="both" clip-path="url(#left)"><rect width="40" height="20"/></clipPath>
+      </defs><rect width="40" height="20" clip-path="url(#both)"/></svg>
+    `);
+    expect(output).toContain(".mask {");
+    expect(output).toContain("graphics.clip()");
+  });
+
+  test("diagnoses malformed resources and follows invalid-reference versus empty/cyclic behavior", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 60 10"><defs>
+        <path id="wrong" d="M0 0h1v1z"/>
+        <clipPath id="bad-units" clipPathUnits="viewport"><rect width="1" height="1" clip-rule="wat"/></clipPath>
+        <clipPath id="a" clip-path="url(#b)"><rect width="10" height="10"/></clipPath>
+        <clipPath id="b" clip-path="url(#a)"><rect width="10" height="10"/></clipPath>
+      </defs>
+      <rect id="missing" width="10" height="10" clip-path="url(#nope)"/>
+      <rect id="wrong-target" x="10" width="10" height="10" clip-path="url(#wrong)"/>
+      <rect id="basic" x="20" width="10" height="10" clip-path="circle(50%)"/>
+      <rect id="external" x="30" width="10" height="10" clip-path="url(other.svg#clip)"/>
+      <rect id="cycle" x="40" width="10" height="10" clip-path="url(#a)"/>
+      <rect id="bad-unit-target" x="50" width="10" height="10" clip-path="url(#bad-units)"/>
+    </svg>`);
+    expect(document.diagnostics.map((item) => item.code)).toEqual(
+      expect.arrayContaining([
+        "invalid-clipPathUnits",
+        "invalid-clip-rule",
+        "missing-clip-path-resource",
+        "wrong-clip-path-resource-type",
+        "unsupported-clip-path-basic-shape",
+        "external-clip-path-reference",
+        "cyclic-clip-path-reference",
+      ]),
+    );
+    expect(nodeById(document.children, "missing")?.clipPath).toBeUndefined();
+    expect(nodeById(document.children, "wrong-target")?.clipPath).toBeUndefined();
+    expect(nodeById(document.children, "cycle")?.clipPath?.invalid).toBe(false);
+    expect(() =>
+      convert(`<svg><rect width="1" height="1" clip-path="url(#missing)"/></svg>`, { strict: true }),
+    ).toThrow("does not resolve");
+  });
+
+  test("empty and degenerate objectBoundingBox clips remove all output", () => {
+    const empty = convert(
+      `<svg viewBox="0 0 10 10"><defs><clipPath id="empty"/></defs><rect width="10" height="10" clip-path="url(#empty)"/></svg>`,
+    );
+    expect(empty).toContain("Color.clear");
+
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 10 10"><defs><clipPath id="box" clipPathUnits="objectBoundingBox"><rect width="1" height="1"/></clipPath></defs>
+        <line id="zero" x1="5" y1="1" x2="5" y2="9" stroke="black" clip-path="url(#box)"/>
+      </svg>`);
+    expect(nodeById(document.children, "zero")?.clipPath?.invalid).toBe(true);
+    expect(document.diagnostics.map((item) => item.code)).toContain("degenerate-clip-path-object-bounding-box");
+  });
+
+  test("clips the rendered group before mask, opacity, and blend", () => {
+    const output = convert(`
+      <svg viewBox="0 0 20 20"><defs>
+        <clipPath id="clip"><circle cx="10" cy="10" r="8"/></clipPath>
+        <mask id="mask" mask-type="alpha"><rect width="20" height="20" fill="white"/></mask>
+      </defs><g clip-path="url(#clip)" mask="url(#mask)" opacity=".5" mix-blend-mode="screen">
+        <rect width="20" height="20" fill="red"/><circle cx="10" cy="10" r="6" fill="blue"/>
+      </g></svg>
+    `);
+    const clipEffect = output.indexOf(".clipShape(ClipCoverage");
+    const svgMask = output.indexOf(".mask {", clipEffect);
+    const opacity = output.indexOf(".opacity(0.5)", svgMask);
+    const blend = output.indexOf(".blendMode(.screen)", opacity);
+    expect(clipEffect).toBeGreaterThan(0);
+    expect(svgMask).toBeGreaterThan(clipEffect);
+    expect(opacity).toBeGreaterThan(svgMask);
+    expect(blend).toBeGreaterThan(opacity);
+  });
+
+  test("intersects painted bounds without changing the target object bounding box", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 100"><defs><clipPath id="clip"><rect x="25" y="20" width="10" height="15"/></clipPath></defs>
+        <rect id="target" x="10" y="10" width="60" height="50" fill="red" stroke="black" stroke-width="10" clip-path="url(#clip)"/>
+      </svg>`);
+    const target = nodeById(document.children, "target");
+    expect(target && __testing.renderNodeBounds(target)).toEqual({ x: 25, y: 20, width: 10, height: 15 });
+  });
+});

--- a/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
@@ -79,6 +79,108 @@
       "expectedMode": "shape",
       "tags": ["circle", "geometry", "shape"]
     },
+    "clip-invalid-empty-cycle": {
+      "width": 128,
+      "height": 32,
+      "expectedMode": "view",
+      "tags": ["clip-path", "clipPath", "geometry", "rect", "view"]
+    },
+    "clip-mask-opacity-order": {
+      "width": 128,
+      "height": 85,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "clip-path",
+        "clipPath",
+        "g",
+        "geometry",
+        "linearGradient",
+        "mask",
+        "mask-type",
+        "mask-units",
+        "opacity",
+        "rect",
+        "stop",
+        "view"
+      ]
+    },
+    "clip-nested-group-gradient": {
+      "width": 128,
+      "height": 96,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "clip-path",
+        "clipPath",
+        "g",
+        "geometry",
+        "linearGradient",
+        "opacity",
+        "rect",
+        "stop",
+        "transform",
+        "view"
+      ]
+    },
+    "clip-nested-intersection": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": ["circle", "clip-path", "clipPath", "g", "geometry", "rect", "transform", "view"]
+    },
+    "clip-object-bbox-transform": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": ["clip-path", "clip-path-units", "clipPath", "geometry", "rect", "stroke", "transform", "view"]
+    },
+    "clip-rule-holes": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": ["clip-path", "clip-rule", "clipPath", "geometry", "path", "rect", "view"]
+    },
+    "clip-simple-overlap-paint": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "clip-path",
+        "clipPath",
+        "geometry",
+        "linearGradient",
+        "opacity",
+        "rect",
+        "stop",
+        "stroke",
+        "view"
+      ]
+    },
+    "clip-units-transforms": {
+      "width": 128,
+      "height": 128,
+      "expectedMode": "view",
+      "tags": ["circle", "clip-path", "clipPath", "g", "geometry", "rect", "transform", "view"]
+    },
+    "clip-use-css": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": [
+        "clip-path",
+        "clipPath",
+        "geometry",
+        "linearGradient",
+        "path",
+        "rect",
+        "stop",
+        "transform",
+        "use",
+        "view"
+      ]
+    },
     "compositing-display-none": {
       "width": 128,
       "height": 75,

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-invalid-empty-cycle.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-invalid-empty-cycle.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 40">
+  <defs>
+    <clipPath id="empty"/>
+    <clipPath id="a" clip-path="url(#b)"><rect width="40" height="40"/></clipPath>
+    <clipPath id="b" clip-path="url(#a)"><rect width="40" height="40"/></clipPath>
+  </defs>
+  <rect width="40" height="40" fill="#e84118" clip-path="url(#missing)"/>
+  <rect x="40" width="40" height="40" fill="#fbc531" clip-path="url(#empty)"/>
+  <rect x="80" width="40" height="40" fill="#44bd32" clip-path="url(#a)"/>
+  <rect x="120" width="40" height="40" fill="#0097e6"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-mask-opacity-order.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-mask-opacity-order.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="20 10 120 80">
+  <defs>
+    <clipPath id="clip"><circle cx="80" cy="50" r="34"/></clipPath>
+    <linearGradient id="fade" x1="0" y1="0" x2="1" y2="0">
+      <stop stop-color="white"/>
+      <stop offset="1" stop-color="black"/>
+    </linearGradient>
+    <mask id="mask" mask-type="luminance" maskUnits="userSpaceOnUse" x="20" y="10" width="120" height="80">
+      <rect x="20" y="10" width="120" height="80" fill="url(#fade)"/>
+    </mask>
+  </defs>
+  <g clip-path="url(#clip)" mask="url(#mask)" opacity=".7">
+    <rect x="20" y="10" width="120" height="80" fill="#9c88ff"/>
+    <circle cx="62" cy="46" r="28" fill="#fbc531"/>
+    <circle cx="98" cy="54" r="28" fill="#e84118"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-nested-group-gradient.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-nested-group-gradient.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 96">
+  <defs>
+    <linearGradient id="rainbow" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#00d2d3"/>
+      <stop offset=".5" stop-color="#5f27cd"/>
+      <stop offset="1" stop-color="#ff6b6b"/>
+    </linearGradient>
+    <clipPath id="left"><rect x="10" y="10" width="84" height="76" rx="12"/></clipPath>
+    <clipPath id="nested" clip-path="url(#left)">
+      <circle cx="64" cy="48" r="42"/>
+      <rect x="76" y="22" width="42" height="52" rx="8"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#nested)" transform="rotate(4 64 48)">
+    <rect x="4" y="4" width="120" height="88" fill="url(#rainbow)"/>
+    <circle cx="48" cy="44" r="24" fill="#ffffff" opacity=".45"/>
+    <circle cx="82" cy="54" r="24" fill="#000000" opacity=".25"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-nested-intersection.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-nested-intersection.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <defs>
+    <clipPath id="left"><rect x="8" y="8" width="58" height="64"/></clipPath>
+    <clipPath id="circle"><circle cx="64" cy="40" r="34" clip-path="url(#left)"/></clipPath>
+  </defs>
+  <g transform="rotate(8 64 40)" clip-path="url(#circle)">
+    <rect width="128" height="80" fill="#00a8ff"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-object-bbox-transform.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-object-bbox-transform.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <defs>
+    <clipPath id="box" clipPathUnits="objectBoundingBox" transform="translate(.05 .05)">
+      <rect x=".1" y=".1" width=".7" height=".8"/>
+    </clipPath>
+  </defs>
+  <rect x="28" y="14" width="72" height="52" fill="#44bd32" stroke="black" stroke-width="12" transform="rotate(12 64 40)" clip-path="url(#box)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-rule-holes.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-rule-holes.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <defs>
+    <clipPath id="even-odd">
+      <path clip-rule="evenodd" fill-rule="nonzero" d="M8 8H60V72H8ZM22 24H46V56H22Z"/>
+    </clipPath>
+    <clipPath id="nonzero">
+      <path clip-rule="nonzero" fill-rule="evenodd" d="M68 8H120V72H68ZM82 24H106V56H82Z"/>
+    </clipPath>
+  </defs>
+  <rect x="8" y="8" width="52" height="64" fill="#00a8ff" clip-path="url(#even-odd)"/>
+  <rect x="68" y="8" width="52" height="64" fill="#fbc531" clip-path="url(#nonzero)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-simple-overlap-paint.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-simple-overlap-paint.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <defs>
+    <linearGradient id="paint" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#ff4d6d"/>
+      <stop offset="1" stop-color="#5f27cd"/>
+    </linearGradient>
+    <clipPath id="overlap">
+      <circle cx="46" cy="40" r="30" fill="none" stroke="red" stroke-width="18" opacity=".1"/>
+      <rect x="48" y="18" width="62" height="44" fill="none"/>
+    </clipPath>
+  </defs>
+  <rect width="128" height="80" rx="10" fill="url(#paint)" clip-path="url(#overlap)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-units-transforms.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-units-transforms.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
+  <defs>
+    <clipPath id="user" transform="rotate(-12 40 40)">
+      <rect x="12" y="18" width="56" height="44" rx="10" transform="translate(4)"/>
+    </clipPath>
+  </defs>
+  <g transform="translate(3 2)" clip-path="url(#user)">
+    <rect x="4" y="4" width="72" height="72" fill="#e84118"/>
+    <circle cx="44" cy="38" r="30" fill="#fbc531"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-use-css.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/clip-use-css.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80">
+  <style>.clipped { clip-path: url(#windows); }</style>
+  <defs>
+    <path id="window" d="M8 8H52V34H8Z"/>
+    <clipPath id="windows">
+      <use href="#window"/>
+      <use href="#window" transform="translate(60 38)"/>
+    </clipPath>
+    <linearGradient id="paint" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#00d2d3"/>
+      <stop offset="1" stop-color="#5f27cd"/>
+    </linearGradient>
+  </defs>
+  <rect class="clipped" width="128" height="80" fill="url(#paint)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
@@ -58,6 +58,7 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   if (name.startsWith("gradient-")) tags.add("gradient");
   if (name.startsWith("pattern-")) tags.add("pattern");
   if (name.startsWith("mask-")) tags.add("mask");
+  if (name.startsWith("clip-")) tags.add("clip-path");
   if (name.startsWith("blend-")) tags.add("blend-mode");
   if (name.startsWith("viewport-")) tags.add("viewport");
   if (name.startsWith("viewport-realistic-")) tags.add("realistic");
@@ -75,6 +76,7 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
     "stop",
     "pattern",
     "mask",
+    "clipPath",
     "use",
     "symbol",
     "switch",
@@ -102,6 +104,8 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   if (/\bmaskUnits\s*=/.test(source)) tags.add("mask-units");
   if (/\bmaskContentUnits\s*=/.test(source)) tags.add("mask-content-units");
   if (/\bmask-type\s*(?:=|:)/.test(source)) tags.add("mask-type");
+  if (/\bclipPathUnits\s*=/.test(source)) tags.add("clip-path-units");
+  if (/\bclip-rule\s*(?:=|:)/.test(source)) tags.add("clip-rule");
   if (/\bmix-blend-mode\s*(?:=|:)/.test(source)) tags.add("blend-mode");
   if (/\bisolation\s*(?:=|:)/.test(source)) tags.add("isolation");
   if (/<pattern\b[^>]*(?:href|xlink:href)\s*=/.test(source)) tags.add("pattern-href");


### PR DESCRIPTION
## Summary

- resolve `<clipPath>` and `clip-path: url(#id)` as typed render-tree resources
- support `userSpaceOnUse`, `objectBoundingBox`, `clip-rule`, transforms, raw-geometry unions, nested intersections, groups, and local `use` references
- generate ordered SwiftUI clipping before masks, opacity, and blending while preserving fast paths for simple vector clips
- diagnose malformed, external, missing, wrong-type, cyclic, empty, and degenerate references with strict-mode failures
- document clipping behavior and add nine browser-compared RGBA fixtures

## Validation

- `bun run build`
- `bun run test`
- `bun run --filter svg-to-swiftui-core lint`
- `bun run --filter svg-to-swiftui-core typecheck`
- `bun run --filter svg-to-swiftui-core build`
- `bun run --filter svg-to-swiftui-core visual-test:verify`
- full deterministic RGBA suite: 1,852 passed, 0 failed, 0 errors

Closes #59
