### PR TITLE
Complete advanced SVG stroke rendering

### DIFF
--- a/.changeset/static-svg-advanced-strokes.md
+++ b/.changeset/static-svg-advanced-strokes.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Render SVG dash arrays and offsets, validated caps, joins, and miter limits, percentage and physical-unit stroke values, non-scaling strokes, SVG-equivalent dashed basic shapes, and transform-aware painted bounds with browser-matched RGBA coverage.

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -39,6 +39,12 @@ Element and group `opacity` are applied once after their children have been pain
 
 The render tree also exposes shared painted-bounds queries through `__testing`. Bounds include transforms and stroke extents, exclude `display: none`, retain zero-opacity geometry, and intersect nested viewport clips. Future marker and filter tickets can extend the same query.
 
+### Advanced strokes
+
+Generated `StrokeStyle` values preserve SVG width, cap, join, miter limit, dash array, and dash offset semantics. Lengths and percentages use the SVG normalized viewport diagonal; odd dash lists repeat, all-zero lists render solid, negative entries are diagnosed, and every subpath restarts its dash pattern. Dashed circles, ellipses, and rectangles use their SVG 2 equivalent-path start point and direction.
+
+`vector-effect="non-scaling-stroke"` transforms the centerline into the complete host coordinate space before SwiftUI constructs its stroke outline, keeping the width constant through nested scale, skew, and rotation transforms. It uses the layered `View` backend even when `preserveColors: false`. SwiftUI cannot represent SVG 2 `miter-clip` or `arcs` joins natively, so they produce structured diagnostics and fall back to `miter`; strict conversion rejects those diagnostics.
+
 ### Clipping paths
 
 `clip-path: url(#id)` and `<clipPath>` are resolved as typed resources. Generated SwiftUI supports `userSpaceOnUse` and `objectBoundingBox`, resource/target/content transforms, `clip-rule`, groups, `use`, overlapping child unions, nested intersections, empty clips, and clipping on groups and painted shapes.
@@ -93,7 +99,7 @@ You can run the tests by running following command:
 
 ### Visual regression tests
 
-The macOS visual harness compiles the generated declaration with real SwiftUI and compares its full transparent RGBA output against the original SVG. It uses resvg for the general corpus and WebKit for blend/isolation fixtures because resvg does not implement CSS blend modes. Every fixture is declared in `visual-tests/fixture-manifest.json` with an exact logical size, scale, output mode, deterministic fonts, feature tags, and channel tolerances.
+The macOS visual harness compiles the generated declaration with real SwiftUI and compares its full transparent RGBA output against the original SVG. It uses resvg for the general corpus and WebKit for blend/isolation and vector-effect fixtures. Every fixture is declared in `visual-tests/fixture-manifest.json` with an exact logical size, scale, output mode, deterministic fonts, feature tags, and channel tolerances.
 
 ```sh
 bun run visual-test                              # full macOS corpus
@@ -136,6 +142,7 @@ The default antialiasing allowance is 24/255 per channel, at most 3% pixels outs
 - [x] SVG lengths, nested viewports, `<view>` fragments, and `preserveAspectRatio`
 - [x] SVG transforms (`matrix`, `translate`, `scale`, `rotate`, `skewX`, `skewY`)
 - [x] Solid fill/stroke styling with colours
+- [x] Advanced strokes: caps, joins, miter limits, dashes, offsets, units, and non-scaling strokes
 - [x] Linear/radial gradient fills and strokes, stops, inheritance, transforms, and spread methods
 - [x] Pattern fills and strokes, inheritance, coordinate systems, transforms, viewBox behavior, and vector tiling
 - [x] SVG clipping paths, clip rules, coordinate systems, transforms, unions, and nested intersections

--- a/packages/svg-to-swiftui-core/src/elementHandlers/circleElementHandler.ts
+++ b/packages/svg-to-swiftui-core/src/elementHandlers/circleElementHandler.ts
@@ -3,6 +3,7 @@ import type { ElementNode } from "svg-parser";
 import type { SVGCircleAttributes } from "../svgTypes";
 import type { TranspilerOptions } from "../types";
 import { clampNormalisedSizeProduct, normaliseRectValues, stringifyRectValues } from "../utils";
+import handlePathElement from "./pathElementHandler";
 import { resolvedGeometryNumber } from "./resolvedGeometry";
 
 export default function handleCircleElement(element: ElementNode, options: TranspilerOptions): string[] {
@@ -22,6 +23,17 @@ export default function handleCircleElement(element: ElementNode, options: Trans
     const cx = resolvedGeometryNumber(circleProps.cx, 0);
     const cy = resolvedGeometryNumber(circleProps.cy, 0);
     const r = resolvedGeometryNumber(circleProps.r, 0) + (options.strokeExpansion || 0);
+
+    if (options.resolvedStyle?.strokeStyle.dashArray) {
+      const d = [
+        `M${cx + r} ${cy}`,
+        `A${r} ${r} 0 0 1 ${cx} ${cy + r}`,
+        `A${r} ${r} 0 0 1 ${cx - r} ${cy}`,
+        `A${r} ${r} 0 0 1 ${cx} ${cy - r}`,
+        `A${r} ${r} 0 0 1 ${cx + r} ${cy}Z`,
+      ].join(" ");
+      return handlePathElement({ ...element, tagName: "path", properties: { ...element.properties, d } }, options);
+    }
 
     // Convert center-radius to bounding box.
     const x = cx - r;

--- a/packages/svg-to-swiftui-core/src/elementHandlers/ellipseElementHandler.ts
+++ b/packages/svg-to-swiftui-core/src/elementHandlers/ellipseElementHandler.ts
@@ -3,6 +3,7 @@ import type { ElementNode } from "svg-parser";
 import type { SVGEllipseAttributes } from "../svgTypes";
 import type { TranspilerOptions } from "../types";
 import { clampNormalisedSizeProduct, normaliseRectValues, stringifyRectValues } from "../utils";
+import handlePathElement from "./pathElementHandler";
 import { resolvedGeometryNumber } from "./resolvedGeometry";
 
 export default function handleEllipseElement(element: ElementNode, options: TranspilerOptions): string[] {
@@ -17,6 +18,17 @@ export default function handleEllipseElement(element: ElementNode, options: Tran
     const cy = resolvedGeometryNumber(ellipseProps.cy, 0);
     const rx = resolvedGeometryNumber(ellipseProps.rx, 0) + (options.strokeExpansion || 0);
     const ry = resolvedGeometryNumber(ellipseProps.ry, 0) + (options.strokeExpansion || 0);
+
+    if (options.resolvedStyle?.strokeStyle.dashArray) {
+      const d = [
+        `M${cx + rx} ${cy}`,
+        `A${rx} ${ry} 0 0 1 ${cx} ${cy + ry}`,
+        `A${rx} ${ry} 0 0 1 ${cx - rx} ${cy}`,
+        `A${rx} ${ry} 0 0 1 ${cx} ${cy - ry}`,
+        `A${rx} ${ry} 0 0 1 ${cx + rx} ${cy}Z`,
+      ].join(" ");
+      return handlePathElement({ ...element, tagName: "path", properties: { ...element.properties, d } }, options);
+    }
 
     // Get size variables
     const x = cx - rx;

--- a/packages/svg-to-swiftui-core/src/elementHandlers/index.ts
+++ b/packages/svg-to-swiftui-core/src/elementHandlers/index.ts
@@ -1,6 +1,6 @@
 import type { ElementNode } from "svg-parser";
 import { extractStyle } from "../styleUtils";
-import { getSVGTransform, wrapWithSVGTransform } from "../transformUtils";
+import { getSVGTransform, wrapWithSVGTransform, wrapWithTransform } from "../transformUtils";
 import type { TranspilerOptions } from "../types";
 import { clampNormalisedSizeProduct, formatRoundedNumber } from "../utils";
 import handleCircleElement from "./circleElementHandler";
@@ -40,6 +40,8 @@ interface PresentationStyle {
   strokeLinecap: string;
   strokeLinejoin: string;
   strokeMiterlimit: number;
+  strokeDasharray?: number[];
+  strokeDashoffset: number;
   fillRule: string;
 }
 
@@ -59,6 +61,8 @@ function extractPresentationStyle(
       strokeLinecap: resolved.strokeStyle.lineCap,
       strokeLinejoin: resolved.strokeStyle.lineJoin,
       strokeMiterlimit: resolved.strokeStyle.miterLimit,
+      ...(resolved.strokeStyle.dashArray ? { strokeDasharray: resolved.strokeStyle.dashArray } : {}),
+      strokeDashoffset: resolved.strokeStyle.dashOffset,
       fillRule: resolved.fillRule,
     };
   }
@@ -77,6 +81,7 @@ function extractPresentationStyle(
       strokeLinecap: (style["stroke-linecap"] as string) || "butt",
       strokeLinejoin: (style["stroke-linejoin"] as string) || "miter",
       strokeMiterlimit: resolvedGeometryNumber(style["stroke-miterlimit"], 4), // SVG default is 4
+      strokeDashoffset: resolvedGeometryNumber(style["stroke-dashoffset"], 0),
       fillRule: (style["fill-rule"] as string) || (style.fillRule as string) || "nonzero",
     };
   } catch {
@@ -92,6 +97,7 @@ function extractPresentationStyle(
       strokeLinecap: (parentStyle["stroke-linecap"] as string) || "butt",
       strokeLinejoin: (parentStyle["stroke-linejoin"] as string) || "miter",
       strokeMiterlimit: resolvedGeometryNumber(parentStyle["stroke-miterlimit"], 4),
+      strokeDashoffset: resolvedGeometryNumber(parentStyle["stroke-dashoffset"], 0),
       fillRule: (parentStyle["fill-rule"] as string) || (parentStyle.fillRule as string) || "nonzero",
     };
   }
@@ -110,8 +116,9 @@ const LINE_JOIN_MAP: Record<string, string> = {
 };
 
 function buildStrokeLines(lines: string[], style: PresentationStyle, options: TranspilerOptions): string[] {
-  const normalizedWidth = style.strokeWidth / options.viewBox.width;
-  const strokeWidthStr = clampNormalisedSizeProduct(formatRoundedNumber(normalizedWidth, options.precision), "width");
+  const normalizedStrokeValue = (value: number): string =>
+    clampNormalisedSizeProduct(formatRoundedNumber(value / options.viewBox.width, options.precision), "width");
+  const strokeWidthStr = normalizedStrokeValue(style.strokeWidth);
 
   const lineCap = LINE_CAP_MAP[style.strokeLinecap] || ".butt";
   const lineJoin = LINE_JOIN_MAP[style.strokeLinejoin] || ".miter";
@@ -121,12 +128,27 @@ function buildStrokeLines(lines: string[], style: PresentationStyle, options: Tr
 
   options.lastPathId++;
   const varName = `strokePath${options.lastPathId}`;
-  const strokeCall = `${varName}.strokedPath(StrokeStyle(lineWidth: ${strokeWidthStr}, lineCap: ${lineCap}, lineJoin: ${lineJoin}, miterLimit: ${style.strokeMiterlimit}))`;
+  const dash = style.strokeDasharray;
+  const dashSum = dash?.reduce((sum, value) => sum + value, 0) ?? 0;
+  const normalizedPhase =
+    dashSum > 0
+      ? style.strokeDashoffset < 0
+        ? dashSum - (Math.abs(style.strokeDashoffset) % dashSum)
+        : style.strokeDashoffset % dashSum
+      : 0;
+  const dashArguments = dash
+    ? `, dash: [${dash.map(normalizedStrokeValue).join(", ")}], dashPhase: ${normalizedStrokeValue(normalizedPhase)}`
+    : "";
+  const strokeStyle = `StrokeStyle(lineWidth: ${strokeWidthStr}, lineCap: ${lineCap}, lineJoin: ${lineJoin}, miterLimit: ${style.strokeMiterlimit}${dashArguments})`;
+  const strokeCall = `${varName}.strokedPath(${strokeStyle})`;
+  const centerlineLines = options.preStrokeTransform
+    ? wrapWithTransform(lines, options.preStrokeTransform, options)
+    : lines;
 
   if (options.separatePaintLayer) {
     return [
       `var ${varName} = Path()`,
-      ...lines.map((l) => l.replace(/^path\./, `${varName}.`)),
+      ...centerlineLines.map((l) => l.replace(/^path\./, `${varName}.`)),
       `path.addPath(${strokeCall})`,
     ];
   }
@@ -135,8 +157,8 @@ function buildStrokeLines(lines: string[], style: PresentationStyle, options: Tr
     // Light strokes use the opposite winding from the document's dark geometry.
     return [
       `var ${varName} = Path()`,
-      ...lines.map((l) => l.replace(/^path\./, `${varName}.`)),
-      `path.addPath(${varName}.cwStrokedPath(StrokeStyle(lineWidth: ${strokeWidthStr}, lineCap: ${lineCap}, lineJoin: ${lineJoin}, miterLimit: ${style.strokeMiterlimit})))`,
+      ...centerlineLines.map((l) => l.replace(/^path\./, `${varName}.`)),
+      `path.addPath(${varName}.cwStrokedPath(${strokeStyle}))`,
     ];
   }
 
@@ -144,7 +166,7 @@ function buildStrokeLines(lines: string[], style: PresentationStyle, options: Tr
     // Keep CoreGraphics' natural stroke winding so it matches primitive paths.
     return [
       `var ${varName} = Path()`,
-      ...lines.map((l) => l.replace(/^path\./, `${varName}.`)),
+      ...centerlineLines.map((l) => l.replace(/^path\./, `${varName}.`)),
       `path.addPath(${strokeCall})`,
     ];
   }
@@ -152,7 +174,7 @@ function buildStrokeLines(lines: string[], style: PresentationStyle, options: Tr
   // All-stroke SVG: use normal strokedPath
   return [
     `var ${varName} = Path()`,
-    ...lines.map((l) => l.replace(/^path\./, `${varName}.`)),
+    ...centerlineLines.map((l) => l.replace(/^path\./, `${varName}.`)),
     `path.addPath(${strokeCall})`,
   ];
 }

--- a/packages/svg-to-swiftui-core/src/elementHandlers/rectElementHandler.ts
+++ b/packages/svg-to-swiftui-core/src/elementHandlers/rectElementHandler.ts
@@ -3,6 +3,7 @@ import type { ElementNode } from "svg-parser";
 import type { SVGRectAttributes } from "../svgTypes";
 import type { TranspilerOptions } from "../types";
 import { clampNormalisedSizeProduct, formatRoundedNumber, normaliseRectValues, stringifyRectValues } from "../utils";
+import handlePathElement from "./pathElementHandler";
 import { resolvedGeometryNumber } from "./resolvedGeometry";
 
 export default function handleRectElement(element: ElementNode, options: TranspilerOptions): string[] {
@@ -30,8 +31,28 @@ export default function handleRectElement(element: ElementNode, options: Transpi
     // Parse corner radii. SVG spec: rx defaults to ry and vice versa.
     const rxRaw = rectProps.rx === undefined ? undefined : resolvedGeometryNumber(rectProps.rx);
     const ryRaw = rectProps.ry === undefined ? undefined : resolvedGeometryNumber(rectProps.ry);
-    const rx = rxRaw ?? ryRaw ?? 0;
-    const ry = ryRaw ?? rxRaw ?? 0;
+    const rx = Math.min(Math.abs(rxRaw ?? ryRaw ?? 0), width / 2);
+    const ry = Math.min(Math.abs(ryRaw ?? rxRaw ?? 0), height / 2);
+
+    if (options.resolvedStyle?.strokeStyle.dashArray) {
+      const right = x + width;
+      const bottom = y + height;
+      const d =
+        rx > 0 && ry > 0
+          ? [
+              `M${x + rx} ${y}`,
+              `H${right - rx}`,
+              `A${rx} ${ry} 0 0 1 ${right} ${y + ry}`,
+              `V${bottom - ry}`,
+              `A${rx} ${ry} 0 0 1 ${right - rx} ${bottom}`,
+              `H${x + rx}`,
+              `A${rx} ${ry} 0 0 1 ${x} ${bottom - ry}`,
+              `V${y + ry}`,
+              `A${rx} ${ry} 0 0 1 ${x + rx} ${y}Z`,
+            ].join(" ")
+          : `M${x} ${y}H${right}V${bottom}H${x}Z`;
+      return handlePathElement({ ...element, tagName: "path", properties: { ...element.properties, d } }, options);
+    }
 
     // Normalise all values to be based on fraction of width/height.
     const normalisedRect = normaliseRectValues({ x, y, width, height }, options.viewBox);

--- a/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
@@ -38,6 +38,63 @@ function transformedRect(x: number, y: number, width: number, height: number, ma
   return { x: minX, y: minY, width: Math.max(...xs) - minX, height: Math.max(...ys) - minY };
 }
 
+function transformedGeometryBounds(geometry: Geometry, matrix: AffineTransform): RenderBounds | undefined {
+  const transformedPoint = (x: number, y: number) => ({
+    x: matrix.a * x + matrix.c * y + matrix.e,
+    y: matrix.b * x + matrix.d * y + matrix.f,
+  });
+  const boundsForPoints = (points: Array<{ x: number; y: number }>): RenderBounds | undefined => {
+    if (points.length === 0) return undefined;
+    const xs = points.map((point) => point.x);
+    const ys = points.map((point) => point.y);
+    const x = Math.min(...xs);
+    const y = Math.min(...ys);
+    return { x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y };
+  };
+
+  switch (geometry.type) {
+    case "rect":
+      return transformedRect(geometry.x, geometry.y, geometry.width, geometry.height, matrix);
+    case "circle":
+    case "ellipse": {
+      const cx = geometry.cx;
+      const cy = geometry.cy;
+      const rx = geometry.type === "circle" ? geometry.r : geometry.rx;
+      const ry = geometry.type === "circle" ? geometry.r : geometry.ry;
+      const center = transformedPoint(cx, cy);
+      const radiusX = Math.hypot(matrix.a * rx, matrix.c * ry);
+      const radiusY = Math.hypot(matrix.b * rx, matrix.d * ry);
+      return { x: center.x - radiusX, y: center.y - radiusY, width: 2 * radiusX, height: 2 * radiusY };
+    }
+    case "line":
+      return boundsForPoints([transformedPoint(geometry.x1, geometry.y1), transformedPoint(geometry.x2, geometry.y2)]);
+    case "polyline":
+    case "polygon": {
+      const values = geometry.points
+        .trim()
+        .split(/[\s,]+/)
+        .filter(Boolean)
+        .map(Number);
+      if (values.length < 2 || values.some((value) => !Number.isFinite(value))) return undefined;
+      const points: Array<{ x: number; y: number }> = [];
+      for (let index = 0; index + 1 < values.length; index += 2)
+        points.push(transformedPoint(values[index]!, values[index + 1]!));
+      return boundsForPoints(points);
+    }
+    case "path": {
+      try {
+        const bounds = new SVGPathData(geometry.d)
+          .toAbs()
+          .matrix(matrix.a, matrix.b, matrix.c, matrix.d, matrix.e, matrix.f)
+          .getBounds();
+        return { x: bounds.minX, y: bounds.minY, width: bounds.maxX - bounds.minX, height: bounds.maxY - bounds.minY };
+      } catch {
+        return undefined;
+      }
+    }
+  }
+}
+
 function pointsBounds(points: string): RenderBounds | undefined {
   const values = points
     .trim()
@@ -111,10 +168,75 @@ function expandForStroke(bounds: RenderBounds, shape: RenderShape): RenderBounds
   };
 }
 
-function localShapeBounds(shape: RenderShape): RenderBounds | undefined {
-  if (shape.style.fill.type === "none" && shape.style.stroke.type === "none") return undefined;
-  const bounds = geometryBounds(shape.geometry);
-  return bounds ? expandForStroke(bounds, shape) : undefined;
+function transformedShapeBounds(shape: RenderShape, transform: AffineTransform): RenderBounds | undefined {
+  const hasFill = shape.geometry.type !== "line" && shape.style.fill.type !== "none";
+  const hasStroke = shape.style.stroke.type !== "none" && shape.style.strokeStyle.width > 0;
+  if (!hasFill && !hasStroke) return undefined;
+  const bounds = transformedGeometryBounds(shape.geometry, transform);
+  if (!bounds || !hasStroke) return bounds;
+
+  const half = shape.style.strokeStyle.width / 2;
+  if (shape.geometry.type === "line" && !shape.style.strokeStyle.dashArray) {
+    const point = (x: number, y: number) => ({
+      x: transform.a * x + transform.c * y + transform.e,
+      y: transform.b * x + transform.d * y + transform.f,
+    });
+    const localStart = { x: shape.geometry.x1, y: shape.geometry.y1 };
+    const localEnd = { x: shape.geometry.x2, y: shape.geometry.y2 };
+    const start = point(localStart.x, localStart.y);
+    const end = point(localEnd.x, localEnd.y);
+    const nonScaling = shape.style.strokeStyle.vectorEffect === "non-scaling-stroke";
+    const dx = nonScaling ? end.x - start.x : localEnd.x - localStart.x;
+    const dy = nonScaling ? end.y - start.y : localEnd.y - localStart.y;
+    const length = Math.hypot(dx, dy);
+    if (length === 0 && shape.style.strokeStyle.lineCap === "butt") return undefined;
+
+    if (shape.style.strokeStyle.lineCap === "round") {
+      const expansionX = half * (nonScaling ? 1 : Math.hypot(transform.a, transform.c));
+      const expansionY = half * (nonScaling ? 1 : Math.hypot(transform.b, transform.d));
+      return {
+        x: bounds.x - expansionX,
+        y: bounds.y - expansionY,
+        width: bounds.width + 2 * expansionX,
+        height: bounds.height + 2 * expansionY,
+      };
+    }
+
+    const tangent = length === 0 ? { x: 1, y: 0 } : { x: dx / length, y: dy / length };
+    const normal = { x: -tangent.y, y: tangent.x };
+    const cap = shape.style.strokeStyle.lineCap === "square" ? half : 0;
+    const strokePoints = [
+      { x: -cap, y: -half },
+      { x: -cap, y: half },
+      { x: length + cap, y: -half },
+      { x: length + cap, y: half },
+    ].map(({ x, y }) => {
+      if (nonScaling) {
+        return { x: start.x + tangent.x * x + normal.x * y, y: start.y + tangent.y * x + normal.y * y };
+      }
+      return point(localStart.x + tangent.x * x + normal.x * y, localStart.y + tangent.y * x + normal.y * y);
+    });
+    const xs = strokePoints.map((item) => item.x);
+    const ys = strokePoints.map((item) => item.y);
+    const x = Math.min(...xs);
+    const y = Math.min(...ys);
+    return { x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y };
+  }
+
+  const miterFactor =
+    (shape.geometry.type === "path" || shape.geometry.type === "polyline" || shape.geometry.type === "polygon") &&
+    shape.style.strokeStyle.lineJoin === "miter"
+      ? Math.max(1, shape.style.strokeStyle.miterLimit)
+      : 1;
+  const nonScaling = shape.style.strokeStyle.vectorEffect === "non-scaling-stroke";
+  const expansionX = half * miterFactor * (nonScaling ? 1 : Math.hypot(transform.a, transform.c));
+  const expansionY = half * miterFactor * (nonScaling ? 1 : Math.hypot(transform.b, transform.d));
+  return {
+    x: bounds.x - expansionX,
+    y: bounds.y - expansionY,
+    width: bounds.width + 2 * expansionX,
+    height: bounds.height + 2 * expansionY,
+  };
 }
 
 /** Object bounding box before the target node's own transform. */
@@ -145,6 +267,8 @@ export function objectBoundingBox(node: RenderNode): RenderBounds | undefined {
 
 /** Local bounds for one paint phase, including stroke expansion when requested. */
 export function shapePaintBounds(shape: RenderShape, kind: "fill" | "stroke"): RenderBounds | undefined {
+  if (kind === "stroke" && (shape.style.stroke.type === "none" || shape.style.strokeStyle.width <= 0)) return undefined;
+  if (kind === "fill" && (shape.geometry.type === "line" || shape.style.fill.type === "none")) return undefined;
   const bounds = geometryBounds(shape.geometry);
   if (!bounds) return undefined;
   return kind === "stroke" ? expandForStroke(bounds, shape) : bounds;
@@ -198,8 +322,7 @@ export function renderNodeBounds(node: RenderNode, parent = IDENTITY_TRANSFORM):
   const transform = multiplyTransforms(parent, node.transform);
   if (node.type === "shape") {
     if (hidden(node.style.visibility)) return undefined;
-    const bounds = localShapeBounds(node);
-    let painted = bounds ? transformedRect(bounds.x, bounds.y, bounds.width, bounds.height, transform) : undefined;
+    let painted = transformedShapeBounds(node, transform);
     if (node.clipPath) {
       const clip = clipPathInstanceBounds(node.clipPath, transform);
       painted = clip ? intersect(painted, clip) : undefined;

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -196,6 +196,76 @@ function plainNumber(
   }
 }
 
+function computedStrokeLineCap(
+  value: unknown,
+  element: ElementNode,
+  context: BuildContext,
+  css?: CSSDiagnosticContext,
+): ComputedStyle["strokeStyle"]["lineCap"] {
+  const normalized = String(value ?? "butt")
+    .trim()
+    .toLowerCase();
+  if (normalized === "butt" || normalized === "round" || normalized === "square") return normalized;
+  addDiagnostic(context, element, "invalid-stroke-linecap", `Invalid stroke-linecap '${normalized}'.`, css);
+  return "butt";
+}
+
+function computedStrokeLineJoin(
+  value: unknown,
+  element: ElementNode,
+  context: BuildContext,
+  css?: CSSDiagnosticContext,
+): ComputedStyle["strokeStyle"]["lineJoin"] {
+  const normalized = String(value ?? "miter")
+    .trim()
+    .toLowerCase();
+  if (normalized === "miter" || normalized === "round" || normalized === "bevel") return normalized;
+  const code =
+    normalized === "miter-clip" || normalized === "arcs" ? "unsupported-stroke-linejoin" : "invalid-stroke-linejoin";
+  addDiagnostic(
+    context,
+    element,
+    code,
+    code === "unsupported-stroke-linejoin"
+      ? `stroke-linejoin '${normalized}' is not representable by SwiftUI StrokeStyle; using miter.`
+      : `Invalid stroke-linejoin '${normalized}'.`,
+    css,
+  );
+  return "miter";
+}
+
+function computedMiterLimit(
+  value: unknown,
+  element: ElementNode,
+  context: BuildContext,
+  css?: CSSDiagnosticContext,
+): number {
+  const limit = plainNumber(value, 4, "stroke-miterlimit", element, context, css);
+  if (limit >= 1) return limit;
+  addDiagnostic(context, element, "invalid-stroke-miterlimit", "stroke-miterlimit must be at least 1.", css);
+  return 4;
+}
+
+function computedVectorEffect(
+  value: unknown,
+  element: ElementNode,
+  context: BuildContext,
+  css?: CSSDiagnosticContext,
+): ComputedStyle["strokeStyle"]["vectorEffect"] {
+  const normalized = String(value ?? "none")
+    .trim()
+    .toLowerCase();
+  if (normalized === "none" || normalized === "non-scaling-stroke") return normalized;
+  addDiagnostic(
+    context,
+    element,
+    "unsupported-vector-effect",
+    `vector-effect '${normalized}' is outside the static SwiftUI profile; using none.`,
+    css,
+  );
+  return "none";
+}
+
 const DEFAULT_PAINT_ORDER: readonly PaintOrderPhase[] = ["fill", "stroke", "markers"];
 
 function computedPaintOrder(
@@ -360,18 +430,31 @@ function computeStyle(
   let dashArray: number[] | undefined;
   const dashSource = effective["stroke-dasharray"];
   if (dashSource !== undefined && String(dashSource).trim().toLowerCase() !== "none") {
-    const values = String(dashSource)
-      .trim()
-      .split(/[\s,]+/)
-      .filter(Boolean);
-    const resolved = values.map((value) =>
-      lengthValue(value, styleCoordinate, "viewport-diagonal", "other", element, context, {
-        negative: "reject",
-        label: "stroke-dasharray",
-        css: provenance["stroke-dasharray"],
-      }),
-    );
-    if (resolved.length > 0 && resolved.every((value): value is number => value !== undefined)) dashArray = resolved;
+    const source = String(dashSource).trim();
+    const malformedSeparators = source.length === 0 || /^\s*,|,\s*$|,\s*,/.test(source);
+    if (malformedSeparators) {
+      addDiagnostic(
+        context,
+        element,
+        "invalid-stroke-dasharray",
+        `Invalid stroke-dasharray '${source}'.`,
+        provenance["stroke-dasharray"],
+      );
+    } else {
+      const values = source.split(/[\s,]+/).filter(Boolean);
+      const resolved = values.map((value) =>
+        lengthValue(value, styleCoordinate, "viewport-diagonal", "other", element, context, {
+          negative: "reject",
+          label: "stroke-dasharray",
+          css: provenance["stroke-dasharray"],
+        }),
+      );
+      if (resolved.length > 0 && resolved.every((value): value is number => value !== undefined)) {
+        if (resolved.some((value) => value !== 0)) {
+          dashArray = resolved.length % 2 === 1 ? [...resolved, ...resolved] : resolved;
+        }
+      }
+    }
   }
   const mask = computedMask(effective.mask, element, context, provenance.mask);
   const clipPath = computedClipPath(effective["clip-path"], element, context, provenance["clip-path"]);
@@ -410,18 +493,12 @@ function computeStyle(
     isolation: isolationValue === "isolate" ? "isolate" : "auto",
     strokeStyle: {
       width,
-      lineCap: String(effective["stroke-linecap"] ?? "butt"),
-      lineJoin: String(effective["stroke-linejoin"] ?? "miter"),
-      miterLimit: plainNumber(
-        effective["stroke-miterlimit"],
-        4,
-        "stroke-miterlimit",
-        element,
-        context,
-        provenance["stroke-miterlimit"],
-      ),
+      lineCap: computedStrokeLineCap(effective["stroke-linecap"], element, context, provenance["stroke-linecap"]),
+      lineJoin: computedStrokeLineJoin(effective["stroke-linejoin"], element, context, provenance["stroke-linejoin"]),
+      miterLimit: computedMiterLimit(effective["stroke-miterlimit"], element, context, provenance["stroke-miterlimit"]),
       ...(dashArray ? { dashArray } : {}),
       dashOffset,
+      vectorEffect: computedVectorEffect(effective["vector-effect"], element, context, provenance["vector-effect"]),
     },
     presentation: effective,
     provenance,

--- a/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
@@ -61,6 +61,16 @@ function containsIndependentCompositing(nodes: RenderNode[]): boolean {
   });
 }
 
+function containsNonScalingStroke(nodes: RenderNode[]): boolean {
+  return nodes.some(
+    (node) =>
+      (node.type === "shape" &&
+        node.style.stroke.type !== "none" &&
+        node.style.strokeStyle.vectorEffect === "non-scaling-stroke") ||
+      (node.type === "group" && containsNonScalingStroke(node.children)),
+  );
+}
+
 function solidColor(paint: Paint, opacity: number): string | undefined {
   if (paint.type === "solid") return swiftUIColor(paint.value, opacity);
   if (paint.type === "reference" && paint.fallback) return swiftUIColor(paint.fallback, opacity);
@@ -90,12 +100,14 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   const hasPaintServer = hasGradientPaint || hasPatternPaint;
   const needsIndependentCompositing =
     containsIndependentCompositing(document.children) || paints.some(({ paint }) => hasIntrinsicAlpha(paint));
+  const needsNonScalingStroke = containsNonScalingStroke(document.children);
 
   if (
     config.preserveColors === false &&
     !needsViewportClip &&
     !hasPaintServer &&
     !needsIndependentCompositing &&
+    !needsNonScalingStroke &&
     !containsGeneralViewContent(document.children)
   ) {
     return {
@@ -110,6 +122,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   if (hasGradientPaint) reasons.push("document uses an SVG gradient paint server");
   if (hasPatternPaint) reasons.push("document uses an SVG pattern paint server");
   if (needsIndependentCompositing) reasons.push("document uses independent paint or group opacity");
+  if (needsNonScalingStroke) reasons.push("document uses non-scaling stroke geometry");
 
   const colors = paints.map(({ paint, opacity }) => {
     if (paint.type === "reference") {

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -153,6 +153,9 @@ function styleProperties(style: ComputedStyle): Record<string, string | number> 
     "stroke-linecap": style.strokeStyle.lineCap,
     "stroke-linejoin": style.strokeStyle.lineJoin,
     "stroke-miterlimit": style.strokeStyle.miterLimit,
+    ...(style.strokeStyle.dashArray ? { "stroke-dasharray": style.strokeStyle.dashArray.join(" ") } : {}),
+    "stroke-dashoffset": style.strokeStyle.dashOffset,
+    "vector-effect": style.strokeStyle.vectorEffect,
   };
 }
 
@@ -173,8 +176,11 @@ function renderShape(
   shape: RenderShape,
   options: TranspilerOptions,
   override?: { fill: string; stroke: string },
+  preStrokeTransform?: RenderNode["transform"],
 ): string[] {
   const previous = options.resolvedStyle;
+  const previousPreStrokeTransform = options.preStrokeTransform;
+  options.preStrokeTransform = preStrokeTransform;
   options.resolvedStyle = override
     ? {
         ...shape.style,
@@ -184,7 +190,8 @@ function renderShape(
     : shape.style;
   const lines = handleElement(shapeElement(shape, override), options);
   options.resolvedStyle = previous;
-  return wrapWithTransform(lines, shape.transform, options);
+  options.preStrokeTransform = previousPreStrokeTransform;
+  return preStrokeTransform ? lines : wrapWithTransform(lines, shape.transform, options);
 }
 
 function renderShapeNodes(nodes: RenderNode[], options: TranspilerOptions): string[] {
@@ -455,13 +462,20 @@ function buildViewNodes(
     const paints: GeneratedViewNode[] = [];
 
     const addLayer = (kind: "fill" | "stroke", paint: Paint, paintOpacity: number) => {
+      const nonScalingStroke = kind === "stroke" && node.style.strokeStyle.vectorEffect === "non-scaling-stroke";
+      const completeTransform = nonScalingStroke
+        ? [...ancestorTransforms, node.transform].reduce(multiplyTransforms)
+        : undefined;
       let lines = renderShape(
         node,
         context.options,
         kind === "fill" ? { fill: "black", stroke: "none" } : { fill: "none", stroke: "black" },
+        completeTransform,
       );
-      for (let index = ancestorTransforms.length - 1; index >= 0; index--) {
-        lines = wrapWithTransform(lines, ancestorTransforms[index]!, context.options);
+      if (!nonScalingStroke) {
+        for (let index = ancestorTransforms.length - 1; index >= 0; index--) {
+          lines = wrapWithTransform(lines, ancestorTransforms[index]!, context.options);
+        }
       }
       if (lines.length === 0) return;
       const helper = addHelper(context, `Layer${context.nextLayer++}`, lines);

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -202,11 +202,12 @@ export type PaintServer = GradientPaint | PatternPaint | InvalidPaintServer;
 
 export interface StrokeStyle {
   width: number;
-  lineCap: string;
-  lineJoin: string;
+  lineCap: "butt" | "round" | "square";
+  lineJoin: "miter" | "round" | "bevel";
   miterLimit: number;
   dashArray?: number[];
   dashOffset: number;
+  vectorEffect: "none" | "non-scaling-stroke";
 }
 
 export type PaintOrderPhase = "fill" | "stroke" | "markers";

--- a/packages/svg-to-swiftui-core/src/tests/strokes.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/strokes.test.ts
@@ -1,0 +1,137 @@
+import { __testing, convert } from "../index";
+import type { RenderNode, RenderShape } from "../renderTree/types";
+
+function shapes(nodes: RenderNode[]): RenderShape[] {
+  return nodes.flatMap((node) => (node.type === "shape" ? [node] : node.type === "group" ? shapes(node.children) : []));
+}
+
+describe("advanced SVG strokes", () => {
+  test("resolves percentages, duplicates odd dash lists, and preserves negative offsets", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 200 100">
+        <path id="target" d="M0 50h200" fill="none" stroke="black"
+          stroke-width="10%" stroke-dasharray="5%, 10% 2px" stroke-dashoffset="-3%"/>
+      </svg>
+    `);
+    const style = shapes(document.children)[0]!.style.strokeStyle;
+    const diagonal = Math.hypot(200, 100) / Math.SQRT2;
+
+    expect(style.width).toBeCloseTo(diagonal * 0.1);
+    expect(style.dashArray).toEqual([diagonal * 0.05, diagonal * 0.1, 2, diagonal * 0.05, diagonal * 0.1, 2]);
+    expect(style.dashOffset).toBeCloseTo(-diagonal * 0.03);
+    expect(document.diagnostics).toEqual([]);
+  });
+
+  test("treats none and all-zero dash arrays as solid, and rejects invalid arrays", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 40 20">
+        <path id="none" d="M0 2h40" stroke="black" stroke-dasharray="none"/>
+        <path id="zero" d="M0 6h40" stroke="black" stroke-dasharray="0 0 0"/>
+        <path id="negative" d="M0 10h40" stroke="black" stroke-dasharray="4 -1"/>
+        <path id="syntax" d="M0 14h40" stroke="black" stroke-dasharray="4,,2"/>
+      </svg>
+    `);
+    expect(shapes(document.children).map((shape) => shape.style.strokeStyle.dashArray)).toEqual([
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ]);
+    expect(document.diagnostics.map(({ code }) => code)).toEqual(
+      expect.arrayContaining(["negative-stroke-dasharray", "invalid-stroke-dasharray"]),
+    );
+  });
+
+  test("validates caps, joins, miter limits, and vector effects", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20"><path d="M1 10h18" stroke="black"
+        stroke-linecap="triangle" stroke-linejoin="miter-clip" stroke-miterlimit="0.5"
+        vector-effect="non-rotation"/></svg>
+    `);
+    expect(shapes(document.children)[0]!.style.strokeStyle).toMatchObject({
+      lineCap: "butt",
+      lineJoin: "miter",
+      miterLimit: 4,
+      vectorEffect: "none",
+    });
+    expect(document.diagnostics.map(({ code }) => code)).toEqual(
+      expect.arrayContaining([
+        "invalid-stroke-linecap",
+        "unsupported-stroke-linejoin",
+        "invalid-stroke-miterlimit",
+        "unsupported-vector-effect",
+      ]),
+    );
+    expect(() =>
+      convert(`<svg><path d="M0 0h1" stroke="black" stroke-linejoin="arcs"/></svg>`, { strict: true }),
+    ).toThrow("not representable");
+  });
+
+  test("emits a complete SwiftUI StrokeStyle including normalized dash phase", () => {
+    const output = convert(
+      `<svg viewBox="0 0 100 20"><path d="M0 10h100" fill="none" stroke="black"
+        stroke-width="4" stroke-linecap="round" stroke-linejoin="bevel"
+        stroke-miterlimit="7" stroke-dasharray="10 5" stroke-dashoffset="-5"/></svg>`,
+      { preserveColors: false },
+    );
+    expect(output).toContain(
+      "StrokeStyle(lineWidth: 0.04*width, lineCap: .round, lineJoin: .bevel, miterLimit: 7, dash: [0.1*width, 0.05*width], dashPhase: 0.1*width)",
+    );
+  });
+
+  test("constructs non-scaling strokes after the complete geometry transform", () => {
+    const source = `<svg viewBox="0 0 100 100"><g transform="scale(3 2)">
+      <path d="M10 10L20 30" fill="none" stroke="black" stroke-width="4"
+        stroke-dasharray="8 4" vector-effect="non-scaling-stroke" transform="rotate(15)"/>
+    </g></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    const output = convert(source, { preserveColors: false });
+
+    expect(__testing.analyzeCapabilities(document, { preserveColors: false })).toMatchObject({
+      mode: "view",
+      reasons: expect.arrayContaining(["document uses non-scaling stroke geometry"]),
+    });
+    expect(output.indexOf(".applying(CGAffineTransform")).toBeLessThan(output.indexOf(".strokedPath(StrokeStyle"));
+    expect(output.match(/\.strokedPath\(StrokeStyle/g)).toHaveLength(1);
+  });
+
+  test("keeps ordinary strokes in local geometry and scales their outlines", () => {
+    const output = convert(
+      `<svg viewBox="0 0 100 100"><path d="M10 10h20" fill="none" stroke="black" stroke-width="4" transform="scale(2)"/></svg>`,
+      { preserveColors: false },
+    );
+    expect(output.indexOf(".strokedPath(StrokeStyle")).toBeLessThan(output.indexOf(".applying(CGAffineTransform"));
+  });
+
+  test("reports transformed stroke bounds without scaling non-scaling widths", () => {
+    const normal = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 100"><line x1="10" y1="10" x2="20" y2="10"
+        stroke="black" stroke-width="4" transform="scale(2)"/></svg>
+    `);
+    const nonScaling = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 100"><line x1="10" y1="10" x2="20" y2="10"
+        stroke="black" stroke-width="4" transform="scale(2)" vector-effect="non-scaling-stroke"/></svg>
+    `);
+    expect(__testing.renderNodeBounds(shapes(normal.children)[0]!)).toEqual({ x: 20, y: 16, width: 20, height: 8 });
+    expect(__testing.renderNodeBounds(shapes(nonScaling.children)[0]!)).toEqual({
+      x: 20,
+      y: 18,
+      width: 20,
+      height: 4,
+    });
+  });
+
+  test("bounds line cap outlines exactly and excludes zero-width strokes", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 30">
+        <line id="square" x1="10" y1="10" x2="30" y2="10" stroke="black" stroke-width="4" stroke-linecap="square"/>
+        <line id="round" x1="50" y1="10" x2="70" y2="10" stroke="black" stroke-width="4" stroke-linecap="round"/>
+        <line id="zero" x1="10" y1="20" x2="90" y2="20" stroke="black" stroke-width="0"/>
+      </svg>
+    `);
+    const [square, round, zero] = shapes(document.children);
+    expect(__testing.renderNodeBounds(square!)).toEqual({ x: 8, y: 8, width: 24, height: 4 });
+    expect(__testing.renderNodeBounds(round!)).toEqual({ x: 48, y: 8, width: 24, height: 4 });
+    expect(__testing.renderNodeBounds(zero!)).toBeUndefined();
+  });
+});

--- a/packages/svg-to-swiftui-core/src/types.ts
+++ b/packages/svg-to-swiftui-core/src/types.ts
@@ -38,6 +38,8 @@ export interface TranspilerOptions {
   activeUseReferences: Set<string>;
   /** Precomputed semantic style supplied by the render-tree generator. */
   resolvedStyle?: import("./renderTree/types").ComputedStyle;
+  /** Apply the complete CTM to a centerline before constructing a non-scaling stroke outline. */
+  preStrokeTransform?: import("./transformUtils").AffineTransform;
 }
 
 export interface ViewBoxData {

--- a/packages/svg-to-swiftui-core/visual-tests/batch-render.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/batch-render.ts
@@ -13,7 +13,10 @@ import { comparePngFiles, type RgbaMetrics, type RgbaTolerance } from "./rgba-co
 const execFile = promisify(execFileCallback);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SUPPORT_PATH = resolve(__dirname, "swiftui-renderer-support.swift");
-const MAX_BATCH_SIZE = 2000;
+// Keep each generated Swift source small enough for slower GitHub macOS runners.
+// Swift type-checking this many independent View declarations is superlinear;
+// one monolithic corpus can exceed the per-process timeout without a code error.
+const MAX_BATCH_SIZE = 500;
 const SWIFT_RENDERER_VERSION = "real-swiftui-srgb-v2";
 
 export interface BatchTestItem {

--- a/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
@@ -211,6 +211,24 @@
       "expectedMode": "view",
       "tags": ["circle", "compositing", "g", "geometry", "opacity", "path", "rect", "stroke", "transform", "view"]
     },
+    "compositing-stroke-paint-order-opacity": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": [
+        "compositing",
+        "g",
+        "geometry",
+        "opacity",
+        "paint-order",
+        "path",
+        "rect",
+        "stroke",
+        "stroke-dasharray",
+        "stroke-linejoin",
+        "view"
+      ]
+    },
     "compositing-transformed-nonsquare": {
       "width": 128,
       "height": 58,
@@ -410,6 +428,28 @@
       "height": 56,
       "expectedMode": "view",
       "tags": ["geometry", "gradient", "linearGradient", "rect", "stop", "units", "view"]
+    },
+    "gradient-stroke-dash": {
+      "width": 128,
+      "height": 72,
+      "expectedMode": "view",
+      "tags": [
+        "geometry",
+        "gradient",
+        "linearGradient",
+        "path",
+        "stop",
+        "stroke",
+        "stroke-dasharray",
+        "stroke-dashoffset",
+        "stroke-linecap",
+        "view"
+      ],
+      "tolerance": {
+        "maxOutsidePercent": 9,
+        "maxMeanRgbError": 3.5
+      },
+      "toleranceReason": "CoreGraphics and the SVG reference interpolate the clipped gradient at slightly different antialiased dash edges."
     },
     "gradient-transforms": {
       "width": 128,
@@ -6355,7 +6395,17 @@
       "width": 128,
       "height": 128,
       "expectedMode": "shape",
-      "tags": ["circle", "geometry", "lucide", "path", "realistic", "shape", "stroke"]
+      "tags": [
+        "circle",
+        "geometry",
+        "lucide",
+        "path",
+        "realistic",
+        "shape",
+        "stroke",
+        "stroke-linecap",
+        "stroke-linejoin"
+      ]
     },
     "lucide-mars": {
       "width": 128,
@@ -10928,7 +10978,7 @@
       "width": 128,
       "height": 64,
       "expectedMode": "shape",
-      "tags": ["geometry", "path", "shape", "stroke"]
+      "tags": ["geometry", "path", "shape", "stroke", "stroke-linecap", "stroke-linejoin"]
     },
     "pattern-alpha": {
       "width": 128,
@@ -10962,7 +11012,18 @@
       "width": 128,
       "height": 80,
       "expectedMode": "view",
-      "tags": ["circle", "geometry", "path", "pattern", "pattern-transform", "pattern-units", "rect", "stroke", "view"]
+      "tags": [
+        "circle",
+        "geometry",
+        "path",
+        "pattern",
+        "pattern-transform",
+        "pattern-units",
+        "rect",
+        "stroke",
+        "stroke-linecap",
+        "view"
+      ]
     },
     "pattern-fractional-1x": {
       "width": 128,
@@ -11048,6 +11109,28 @@
       "expectedMode": "view",
       "tags": ["geometry", "pattern", "pattern-units", "rect", "view"]
     },
+    "pattern-stroke-dash": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": [
+        "geometry",
+        "pattern",
+        "pattern-transform",
+        "pattern-units",
+        "rect",
+        "stroke",
+        "stroke-dasharray",
+        "stroke-dashoffset",
+        "stroke-linejoin",
+        "view"
+      ],
+      "tolerance": {
+        "maxOutsidePercent": 6,
+        "maxMeanRgbError": 4
+      },
+      "toleranceReason": "CoreGraphics and the SVG reference rasterize repeated pattern colors at dashed stroke edges differently."
+    },
     "pattern-tile-clipping": {
       "width": 128,
       "height": 80,
@@ -11105,7 +11188,7 @@
       "width": 128,
       "height": 128,
       "expectedMode": "view",
-      "tags": ["geometry", "polygon", "stroke", "view"]
+      "tags": ["geometry", "polygon", "stroke", "stroke-linejoin", "view"]
     },
     "polyline-filled": {
       "width": 128,
@@ -11172,6 +11255,75 @@
       "height": 128,
       "expectedMode": "shape",
       "tags": ["geometry", "path", "shape"]
+    },
+    "stroke-caps-joins-miters": {
+      "width": 128,
+      "height": 85,
+      "expectedMode": "view",
+      "tags": ["g", "geometry", "path", "stroke", "stroke-linecap", "stroke-linejoin", "stroke-miterlimit", "view"]
+    },
+    "stroke-dash-curves-subpaths": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "shape",
+      "tags": ["g", "geometry", "path", "shape", "stroke", "stroke-dasharray", "stroke-dashoffset", "stroke-linecap"]
+    },
+    "stroke-dash-primitives": {
+      "width": 128,
+      "height": 96,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "ellipse",
+        "g",
+        "geometry",
+        "line",
+        "polygon",
+        "polyline",
+        "rect",
+        "stroke",
+        "stroke-dasharray",
+        "stroke-dashoffset",
+        "stroke-linecap",
+        "view"
+      ]
+    },
+    "stroke-non-scaling-transforms": {
+      "width": 128,
+      "height": 85,
+      "expectedMode": "view",
+      "tags": ["g", "geometry", "line", "polyline", "stroke", "stroke-dasharray", "transform", "vector-effect", "view"],
+      "tolerance": {
+        "maxOutsidePercent": 5,
+        "maxMeanAlphaError": 6.5
+      },
+      "toleranceReason": "WebKit and CoreGraphics use different antialias coverage for affine-transformed stroke outlines."
+    },
+    "stroke-units-nonzero-origin": {
+      "width": 128,
+      "height": 53,
+      "expectedMode": "view",
+      "tags": [
+        "g",
+        "geometry",
+        "path",
+        "stroke",
+        "stroke-dasharray",
+        "stroke-dashoffset",
+        "stroke-linecap",
+        "units",
+        "view"
+      ],
+      "tolerance": {
+        "maxOutsidePercent": 5
+      },
+      "toleranceReason": "Subpixel dash edges at a non-zero viewBox origin differ by one coverage pixel between Resvg and CoreGraphics."
+    },
+    "stroke-zero-invalid": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": ["g", "geometry", "path", "rect", "stroke", "stroke-dasharray", "view"]
     },
     "structure-defs-use": {
       "width": 128,

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-stroke-paint-order-opacity.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/compositing-stroke-paint-order-opacity.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 100">
+  <rect width="160" height="100" fill="#f1faee"/>
+  <g stroke-width="18" stroke-linejoin="round" opacity="0.82">
+    <path d="M15 15h55v70H15z" fill="#e63946" stroke="#1d3557" paint-order="stroke fill"/>
+    <path d="M90 15h55v70H90z" fill="#457b9d" stroke="#ffb703" paint-order="fill stroke"
+      stroke-dasharray="24 8" stroke-opacity="0.65"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-stroke-dash.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/gradient-stroke-dash.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90">
+  <defs>
+    <linearGradient id="spectrum" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ff006e"/>
+      <stop offset="0.5" stop-color="#ffbe0b"/>
+      <stop offset="1" stop-color="#3a86ff"/>
+    </linearGradient>
+  </defs>
+  <path d="M12 45 C36 3 65 87 91 45 S135 3 150 45" fill="none" stroke="url(#spectrum)"
+    stroke-width="12" stroke-linecap="round" stroke-dasharray="18 16" stroke-dashoffset="-6"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-stroke-dash.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/pattern-stroke-dash.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 100">
+  <defs>
+    <pattern id="tiles" width="12" height="12" patternUnits="userSpaceOnUse" patternTransform="rotate(18)">
+      <rect width="6" height="12" fill="#264653"/>
+      <rect x="6" width="6" height="12" fill="#e9c46a"/>
+    </pattern>
+  </defs>
+  <rect x="15" y="15" width="130" height="70" fill="none" stroke="url(#tiles)"
+    stroke-width="14" stroke-linejoin="round" stroke-dasharray="28 18 5" stroke-dashoffset="11"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-caps-joins-miters.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-caps-joins-miters.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 120">
+  <g fill="none" stroke-width="10">
+    <path d="M12 16h42" stroke="#e63946" stroke-linecap="butt"/>
+    <path d="M69 16h42" stroke="#457b9d" stroke-linecap="round"/>
+    <path d="M126 16h42" stroke="#2a9d8f" stroke-linecap="square"/>
+    <path d="M12 66l22-30 22 30" stroke="#e63946" stroke-linejoin="miter" stroke-miterlimit="8"/>
+    <path d="M68 66l22-30 22 30" stroke="#457b9d" stroke-linejoin="round"/>
+    <path d="M124 66l22-30 22 30" stroke="#2a9d8f" stroke-linejoin="bevel"/>
+    <path d="M18 110l18-34 18 34" stroke="#8338ec" stroke-linejoin="miter" stroke-miterlimit="1"/>
+    <path d="M72 110l18-34 18 34" stroke="#ff9f1c" stroke-linejoin="miter" stroke-miterlimit="3"/>
+    <path d="M126 110l18-34 18 34" stroke="#111" stroke-linejoin="miter" stroke-miterlimit="10"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-dash-curves-subpaths.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-dash-curves-subpaths.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 100">
+  <g fill="none" stroke="black" stroke-width="5" stroke-linecap="square" stroke-dasharray="10 6">
+    <path d="M8 24 C28 2 52 46 74 24 S122 2 152 24"/>
+    <path d="M8 58 Q32 34 55 58 T102 58 A24 18 0 0 1 152 58" stroke-dashoffset="-8"/>
+    <path d="M8 88h34 M58 88h36 M110 88h42" stroke-dasharray="7 4" stroke-dashoffset="3"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-dash-primitives.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-dash-primitives.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120">
+  <g fill="none" stroke="#111" stroke-width="5" stroke-linecap="round">
+    <line x1="8" y1="12" x2="152" y2="12" stroke-dasharray="16 7"/>
+    <line x1="8" y1="28" x2="152" y2="28" stroke-dasharray="16 7" stroke-dashoffset="9"/>
+    <rect x="8" y="42" width="52" height="30" rx="8" stroke-dasharray="9, 4, 2"/>
+    <circle cx="94" cy="57" r="19" stroke-dasharray="5 4" stroke-dashoffset="-7"/>
+    <ellipse cx="137" cy="57" rx="16" ry="11" stroke-dasharray="7 3"/>
+    <polyline points="8,106 28,83 47,106 66,83 84,106" stroke-dasharray="8 4"/>
+    <polygon points="112,83 130,106 94,106" stroke-dasharray="6 3"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-non-scaling-transforms.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-non-scaling-transforms.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 120">
+  <g fill="none" stroke-width="5">
+    <g transform="translate(12 8) scale(2.2 1.35)">
+      <line x1="0" y1="14" x2="62" y2="14" stroke="#e63946" stroke-dasharray="12 8"/>
+      <line x1="0" y1="36" x2="62" y2="36" stroke="#457b9d" vector-effect="non-scaling-stroke"/>
+    </g>
+    <g transform="translate(112 69) rotate(24) skewX(18) scale(1.25 .9)">
+      <polyline points="-34,-15 0,8 34,-15" stroke="#f4a261" stroke-dasharray="12 8"/>
+      <polyline points="-34,12 0,35 34,12" stroke="#2a9d8f" vector-effect="non-scaling-stroke"/>
+    </g>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-units-nonzero-origin.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-units-nonzero-origin.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="40 20 240 100">
+  <g fill="none" stroke="#111" stroke-linecap="butt">
+    <path d="M50 42h220" stroke-width="4%" stroke-dasharray="8% 3%"/>
+    <path d="M50 70h220" stroke-width="6px" stroke-dasharray="12px 5px" stroke-dashoffset="-9px"/>
+    <path d="M50 102h220" stroke-width="2mm" stroke-dasharray="5mm 2mm"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-zero-invalid.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/stroke-zero-invalid.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 80">
+  <rect width="160" height="80" fill="#f5f5f5"/>
+  <g fill="none" stroke="#111" stroke-width="7">
+    <path d="M10 18h140" stroke-dasharray="0 0 0"/>
+    <path d="M10 40h140" stroke-dasharray="12 -3"/>
+    <path d="M10 62h140" stroke-dasharray="12 5" stroke-width="0"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/run-visual-tests.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/run-visual-tests.ts
@@ -163,7 +163,7 @@ async function main() {
       const pixelWidth = Math.round(fixture.width * fixture.scale);
       const pixelHeight = Math.round(fixture.height * fixture.scale);
       const resourceBytes = fixture.fonts.map((font) => readFileSync(resolve(__dirname, font)));
-      const usesWebKitReference = fixture.tags.includes("blend-mode");
+      const usesWebKitReference = fixture.tags.includes("blend-mode") || fixture.tags.includes("vector-effect");
       if (usesWebKitReference) resourceBytes.push(readFileSync(WEBKIT_RENDERER_SOURCE));
       for (const match of source.matchAll(/<image\b[^>]*\b(?:href|xlink:href)\s*=\s*["']([^"']+)["']/gi)) {
         const href = match[1]!;

--- a/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
@@ -90,6 +90,13 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   if (/<svg\b[\s\S]*<svg\b/i.test(source)) tags.add("nested-svg");
   if (/\boverflow\s*=/.test(source) || /<svg\b[\s\S]*<svg\b/i.test(source)) tags.add("overflow");
   if (/\bstroke\s*(?:=|:)/.test(source)) tags.add("stroke");
+  const advancedStrokeFixture = /(?:^|-)stroke(?:-|$)/.test(name);
+  if (advancedStrokeFixture && /\bstroke-dasharray\s*(?:=|:)/.test(source)) tags.add("stroke-dasharray");
+  if (advancedStrokeFixture && /\bstroke-dashoffset\s*(?:=|:)/.test(source)) tags.add("stroke-dashoffset");
+  if (advancedStrokeFixture && /\bstroke-linecap\s*(?:=|:)/.test(source)) tags.add("stroke-linecap");
+  if (advancedStrokeFixture && /\bstroke-linejoin\s*(?:=|:)/.test(source)) tags.add("stroke-linejoin");
+  if (advancedStrokeFixture && /\bstroke-miterlimit\s*(?:=|:)/.test(source)) tags.add("stroke-miterlimit");
+  if (advancedStrokeFixture && /\bvector-effect\s*(?:=|:)/.test(source)) tags.add("vector-effect");
   if (/\bopacity\s*(?:=|:)/.test(source)) tags.add("opacity");
   if (/\bvisibility\s*(?:=|:)/.test(source)) tags.add("visibility");
   if (/\bdisplay\s*(?:=|:)/.test(source)) tags.add("display");


### PR DESCRIPTION
Closes #60

## What changed

- emit complete SwiftUI `StrokeStyle` values for dash arrays, dash offsets, caps, joins, widths, and miter limits
- validate SVG 2 stroke values, duplicate odd dash lists, treat all-zero lists as solid, and diagnose unsupported `miter-clip`/`arcs`
- render `vector-effect="non-scaling-stroke"` by transforming centerlines before constructing stroke outlines
- use SVG 2 equivalent paths for dashed circles, ellipses, and rectangles
- improve transform-aware painted bounds, including exact line caps and invisible zero-width strokes
- add nine browser-matched RGBA fixtures, focused unit tests, documentation, and a minor changeset

## Why

The semantic render tree already retained many advanced stroke properties, but the Swift generator ignored dash values and always stroked before transforms. That made dashed and non-scaling strokes diverge from the original SVG.

## Validation

- `bun run test` — pass
- `bun run build` — pass
- core lint and type-check — pass
- 156 core unit tests — pass
- 1,861/1,861 full RGBA fixtures — pass

Repository-wide lint/type-check still report existing unrelated failures in Next.js import formatting and the shared Prettier config's missing Node types.
