### PR TITLE
Implement full SVG marker rendering

### DIFF
--- a/.changeset/static-svg-markers.md
+++ b/.changeset/static-svg-markers.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Render complete SVG marker shadow trees for marker-start, marker-mid, and marker-end with spec-accurate vertex tangents, orientation, units, reference points, viewBox mapping, overflow, context paint, paint order, effects, diagnostics, and painted bounds.

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -33,17 +33,23 @@ SVG presentation defaults include SVG 2 properties such as `paint-order`, `mask`
 
 ### Painter order and compositing
 
-Rendered children keep SVG document order. `display: none` removes a subtree, while `visibility: hidden` can be overridden by a visible descendant. Fill, stroke, and marker phases use the computed `paint-order`; marker rendering will be added by the marker feature.
+Rendered children keep SVG document order. `display: none` removes a subtree, while `visibility: hidden` can be overridden by a visible descendant. Fill, stroke, and marker phases use the computed `paint-order`.
 
 Element and group `opacity` are applied once after their children have been painted into an isolated SwiftUI compositing group. Fill and stroke opacity remain independent. The generator intentionally keeps zero-opacity content in its semantic render tree and uses `.compositingGroup()` instead of rasterizing with `.drawingGroup()`.
 
-The render tree also exposes shared painted-bounds queries through `__testing`. Bounds include transforms and stroke extents, exclude `display: none`, retain zero-opacity geometry, and intersect nested viewport clips. Future marker and filter tickets can extend the same query.
+The render tree also exposes shared painted-bounds queries through `__testing`. Bounds include transforms, stroke extents, and marker shadow content; exclude `display: none`; retain zero-opacity geometry; and intersect nested viewport clips. The filter ticket can extend the same query.
 
 ### Advanced strokes
 
 Generated `StrokeStyle` values preserve SVG width, cap, join, miter limit, dash array, and dash offset semantics. Lengths and percentages use the SVG normalized viewport diagonal; odd dash lists repeat, all-zero lists render solid, negative entries are diagnosed, and every subpath restarts its dash pattern. Dashed circles, ellipses, and rectangles use their SVG 2 equivalent-path start point and direction.
 
 `vector-effect="non-scaling-stroke"` transforms the centerline into the complete host coordinate space before SwiftUI constructs its stroke outline, keeping the width constant through nested scale, skew, and rotation transforms. It uses the layered `View` backend even when `preserveColors: false`. SwiftUI cannot represent SVG 2 `miter-clip` or `arcs` joins natively, so they produce structured diagnostics and fall back to `miter`; strict conversion rejects those diagnostics.
+
+### Markers
+
+`marker-start`, `marker-mid`, and `marker-end` resolve typed `<marker>` resources and render their complete child trees at SVG vertices. Placement supports lines, curves, arcs, closed and multiple subpaths, coincident segments, tangent bisectors, `auto`, `auto-start-reverse`, explicit angle units, both `markerUnits` modes, reference points, viewBox mapping, overflow clipping, and transformed hosts/content.
+
+Marker content supports groups, `use`, gradients, patterns, opacity, and solid `context-fill`/`context-stroke` paints. Markers follow `paint-order`, share their host shape's clipping, masking, and opacity, and contribute to painted bounds. Missing, wrong-type, cyclic, and invalid marker references produce structured diagnostics and fail strict conversion.
 
 ### Clipping paths
 
@@ -99,7 +105,7 @@ You can run the tests by running following command:
 
 ### Visual regression tests
 
-The macOS visual harness compiles the generated declaration with real SwiftUI and compares its full transparent RGBA output against the original SVG. It uses resvg for the general corpus and WebKit for blend/isolation and vector-effect fixtures. Every fixture is declared in `visual-tests/fixture-manifest.json` with an exact logical size, scale, output mode, deterministic fonts, feature tags, and channel tolerances.
+The macOS visual harness compiles the generated declaration with real SwiftUI and compares its full transparent RGBA output against the original SVG. It uses resvg for the general corpus, WebKit for blend/isolation and vector-effect fixtures, and Firefox for SVG marker fixtures including context paint. Every fixture is declared in `visual-tests/fixture-manifest.json` with an exact logical size, scale, output mode, deterministic fonts, feature tags, and channel tolerances.
 
 ```sh
 bun run visual-test                              # full macOS corpus
@@ -147,6 +153,7 @@ The default antialiasing allowance is 24/255 per channel, at most 3% pixels outs
 - [x] Pattern fills and strokes, inheritance, coordinate systems, transforms, viewBox behavior, and vector tiling
 - [x] SVG clipping paths, clip rules, coordinate systems, transforms, unions, and nested intersections
 - [x] SVG masks, Level 1 blend modes, group compositing, and isolation
+- [x] SVG markers, vertex placement, orientation, units, context paint, viewports, and painter order
 - [x] Embedded CSS cascade, custom properties, and computed presentation styles
 - [ ] SVG `<text>` element
 - [ ] Automatic animation support

--- a/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
@@ -323,6 +323,7 @@ export function renderNodeBounds(node: RenderNode, parent = IDENTITY_TRANSFORM):
   if (node.type === "shape") {
     if (hidden(node.style.visibility)) return undefined;
     let painted = transformedShapeBounds(node, transform);
+    if (node.markers) painted = union(painted, renderNodesBounds(node.markers, transform));
     if (node.clipPath) {
       const clip = clipPathInstanceBounds(node.clipPath, transform);
       painted = clip ? intersect(painted, clip) : undefined;

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -16,12 +16,16 @@ import type { SVGElementProperties, ViewBoxData } from "../types";
 import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio, parseViewBox, viewBoxTransform } from "../viewports";
 import { resolveClipPathInstance, resolveClipPathResources } from "./clips";
 import { resolvePaintServers } from "./gradients";
+import { markerVertices, orientedMarkerAngle, resolveMarkerResources } from "./markers";
 import { resolveMaskInstance, resolveMaskResources } from "./masks";
 import { resolvePatternPaintServers } from "./patterns";
 import type {
   ComputedStyle,
   CSSDiagnosticContext,
   Geometry,
+  MarkerRefCoordinate,
+  MarkerReference,
+  MarkerResource,
   Paint,
   PaintOrderPhase,
   PatternPaint,
@@ -93,6 +97,8 @@ function addDiagnostic(
 function parsePaint(value: unknown, currentColor: string): Paint {
   const normalized = String(value ?? "none").trim();
   if (normalized.toLowerCase() === "none") return { type: "none" };
+  if (normalized.toLowerCase() === "context-fill") return { type: "context", source: "fill" };
+  if (normalized.toLowerCase() === "context-stroke") return { type: "context", source: "stroke" };
   if (normalized.toLowerCase() === "currentcolor") return { type: "solid", value: currentColor };
   const reference = /^url\(\s*#([^\s)]+)\s*\)(?:\s+(.+))?$/i.exec(normalized);
   if (reference) {
@@ -104,6 +110,27 @@ function parsePaint(value: unknown, currentColor: string): Paint {
     };
   }
   return { type: "solid", value: normalized };
+}
+
+function computedMarkerReference(
+  value: unknown,
+  property: "marker-start" | "marker-mid" | "marker-end",
+  element: ElementNode,
+  context: BuildContext,
+  css?: CSSDiagnosticContext,
+): MarkerReference | undefined {
+  const normalized = String(value ?? "none").trim();
+  if (normalized.toLowerCase() === "none") return undefined;
+  const local = /^url\(\s*["']?#([^\s)"']+)["']?\s*\)$/i.exec(normalized);
+  if (local) return { id: local[1]!, invalid: false };
+  addDiagnostic(
+    context,
+    element,
+    /^url\(/i.test(normalized) ? "external-marker-reference" : "invalid-marker-reference",
+    `Only one local ${property} reference of the form url(#id) is supported; received '${normalized}'.`,
+    css,
+  );
+  return { invalid: true };
 }
 
 function lengthValue(
@@ -458,9 +485,32 @@ function computeStyle(
   }
   const mask = computedMask(effective.mask, element, context, provenance.mask);
   const clipPath = computedClipPath(effective["clip-path"], element, context, provenance["clip-path"]);
+  const markerStart = computedMarkerReference(
+    effective["marker-start"],
+    "marker-start",
+    element,
+    context,
+    provenance["marker-start"],
+  );
+  const markerMid = computedMarkerReference(
+    effective["marker-mid"],
+    "marker-mid",
+    element,
+    context,
+    provenance["marker-mid"],
+  );
+  const markerEnd = computedMarkerReference(
+    effective["marker-end"],
+    "marker-end",
+    element,
+    context,
+    provenance["marker-end"],
+  );
+  const fill = parsePaint(effective.fill ?? "black", color);
 
   return {
-    fill: parsePaint(isLine ? "none" : (effective.fill ?? "black"), color),
+    fill: isLine ? { type: "none" } : fill,
+    ...(isLine ? { contextFill: fill } : {}),
     stroke: parsePaint(effective.stroke ?? "none", color),
     color,
     opacity: computedOpacity(effective.opacity, "opacity", element, context, provenance.opacity),
@@ -478,6 +528,9 @@ function computeStyle(
       context,
       provenance["stroke-opacity"],
     ),
+    ...(markerStart ? { markerStart } : {}),
+    ...(markerMid ? { markerMid } : {}),
+    ...(markerEnd ? { markerEnd } : {}),
     paintOrder: computedPaintOrder(effective["paint-order"], element, context, provenance["paint-order"]),
     fillRule: fillRule === "evenodd" ? "evenodd" : "nonzero",
     clipRule: clipRule === "evenodd" ? "evenodd" : "nonzero",
@@ -683,6 +736,7 @@ function createRegistry(root: ElementNode): ResourceRegistry {
     masks: new Map(),
     maskElements: new Map(),
     markers: new Map(),
+    markerElements: new Map(),
     filters: new Map(),
     views: new Map(),
   };
@@ -697,7 +751,7 @@ function createRegistry(root: ElementNode): ResourceRegistry {
         registry.paintElements.set(id, element);
       if (element.tagName === "clipPath") registry.clipElements.set(id, element);
       if (element.tagName === "mask") registry.maskElements.set(id, element);
-      if (element.tagName === "marker") registry.markers.set(id, element);
+      if (element.tagName === "marker") registry.markerElements.set(id, element);
       if (element.tagName === "filter") registry.filters.set(id, element);
     }
     for (const child of element.children) {
@@ -1102,6 +1156,13 @@ export function buildRenderDocument(
     resolved.effective,
     diagnostics,
   );
+  resources.markers = resolveMarkerResources(
+    svg,
+    resources.markerElements,
+    styleResolver,
+    resolved.effective,
+    diagnostics,
+  );
   const rootTransform = multiplyTransforms(computedTransform(svg, resolved, context), properties.viewBoxTransform);
   const childCoordinate = { ...coordinate, fontMetrics: resolved.fontMetrics };
   const root: RenderGroup = {
@@ -1119,6 +1180,293 @@ export function buildRenderDocument(
     },
   };
   const children: RenderNode[] = [root];
+
+  function diagnoseMarkerOnce(node: RenderNode, code: string, message: string): void {
+    if (
+      diagnostics.some(
+        (item) =>
+          item.code === code &&
+          item.source.element === node.source.element &&
+          item.source.id === node.source.id &&
+          item.message === message,
+      )
+    )
+      return;
+    diagnostics.push({ code, message, severity: "warning", source: node.source });
+  }
+
+  const translation = (x: number, y: number): AffineTransform => ({ a: 1, b: 0, c: 0, d: 1, e: x, f: y });
+  const scaling = (value: number): AffineTransform => ({ a: value, b: 0, c: 0, d: value, e: 0, f: 0 });
+  const rotation = (degrees: number): AffineTransform => {
+    const radians = (degrees * Math.PI) / 180;
+    return { a: Math.cos(radians), b: Math.sin(radians), c: -Math.sin(radians), d: Math.cos(radians), e: 0, f: 0 };
+  };
+  const transformedPoint = (matrix: AffineTransform, x: number, y: number) => ({
+    x: matrix.a * x + matrix.c * y + matrix.e,
+    y: matrix.b * x + matrix.d * y + matrix.f,
+  });
+
+  function markerLength(
+    resource: MarkerResource,
+    shape: RenderShape,
+    axis: "horizontal" | "vertical",
+    fontMetrics: FontMetrics,
+  ): number {
+    const value = axis === "horizontal" ? resource.markerWidth : resource.markerHeight;
+    const result = resolveSVGLength(
+      value,
+      lengthContext(
+        shape.paintContext.viewport,
+        shape.paintContext.rootViewport,
+        axis === "horizontal" ? "viewport-width" : "viewport-height",
+        axis,
+        fontMetrics,
+      ),
+    );
+    return typeof result === "number" ? result : 0;
+  }
+
+  function markerReferenceCoordinate(
+    coordinateValue: MarkerRefCoordinate,
+    axis: "horizontal" | "vertical",
+    resource: MarkerResource,
+    viewport: { width: number; height: number },
+    shape: RenderShape,
+    fontMetrics: FontMetrics,
+  ): number {
+    const source = resource.viewBox
+      ? axis === "horizontal"
+        ? { origin: resource.viewBox.x, size: resource.viewBox.width }
+        : { origin: resource.viewBox.y, size: resource.viewBox.height }
+      : { origin: 0, size: axis === "horizontal" ? viewport.width : viewport.height };
+    if (coordinateValue.type === "keyword") {
+      const ratio = coordinateValue.value === "min" ? 0 : coordinateValue.value === "center" ? 0.5 : 1;
+      return source.origin + source.size * ratio;
+    }
+    const result = resolveSVGLength(
+      coordinateValue.value,
+      lengthContext(
+        { width: source.size, height: source.size },
+        shape.paintContext.rootViewport,
+        source.size,
+        axis,
+        fontMetrics,
+      ),
+    );
+    const resolvedValue = typeof result === "number" ? result : 0;
+    return coordinateValue.value.unit === "%" ? source.origin + resolvedValue : resolvedValue;
+  }
+
+  function resolveContextPaint(paint: Paint, shape: RenderShape): Paint {
+    if (paint.type !== "context") return paint;
+    const resolvedPaint = paint.source === "fill" ? (shape.style.contextFill ?? shape.style.fill) : shape.style.stroke;
+    return resolvedPaint.type === "context" ? { type: "none" } : resolvedPaint;
+  }
+
+  function resolveContextPaints(nodes: RenderNode[], shape: RenderShape): void {
+    for (const node of nodes) {
+      node.style = {
+        ...node.style,
+        fill: resolveContextPaint(node.style.fill, shape),
+        stroke: resolveContextPaint(node.style.stroke, shape),
+      };
+      if (node.type === "group") resolveContextPaints(node.children, shape);
+    }
+  }
+
+  function buildMarkerInstance(
+    resource: MarkerResource,
+    shape: RenderShape,
+    kind: "start" | "mid" | "end",
+    vertex: ReturnType<typeof markerVertices>[number],
+    stack: string[],
+  ): RenderGroup | undefined {
+    const effective = { ...resource.presentation } as Presentation;
+    const markerFontCoordinate: CoordinateContext = {
+      viewport: { ...shape.paintContext.viewport },
+      rootViewport: { ...shape.paintContext.rootViewport },
+      fontMetrics: { ...shape.paintContext.fontMetrics },
+    };
+    const fontMetrics = computedFontMetrics(
+      { "font-size": shape.paintContext.fontMetrics.fontSize },
+      effective,
+      resource.provenance,
+      markerFontCoordinate,
+      resource.element,
+      context,
+    );
+    const width = markerLength(resource, shape, "horizontal", fontMetrics);
+    const height = markerLength(resource, shape, "vertical", fontMetrics);
+    if (width <= 0 || height <= 0 || resource.viewBox?.width === 0 || resource.viewBox?.height === 0) return undefined;
+
+    const viewport = { width, height };
+    const contentViewport = resource.viewBox
+      ? { width: resource.viewBox.width, height: resource.viewBox.height }
+      : viewport;
+    const markerCoordinate: CoordinateContext = {
+      viewport: contentViewport,
+      rootViewport: { ...shape.paintContext.rootViewport },
+      fontMetrics,
+    };
+    const resourceStyle = computeStyle(
+      effective,
+      resource.provenance,
+      markerCoordinate,
+      fontMetrics,
+      resource.element,
+      context,
+    );
+    const markerContext: BuildContext = {
+      ...context,
+      activeReferences: new Set(context.activeReferences).add(resource.id),
+    };
+    const built: RenderNode[] = [];
+    for (const content of resource.contentElements) {
+      try {
+        built.push(...buildNode(content, effective, markerCoordinate, markerContext));
+      } catch (error) {
+        diagnoseMarkerOnce(
+          shape,
+          "invalid-marker-content-reference",
+          `Marker #${resource.id} content could not be resolved: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+    resolveContextPaints(built, shape);
+    materializeMarkers(built, [...stack, resource.id]);
+
+    const markerViewport = { x: 0, y: 0, width, height };
+    const boxTransform = viewBoxTransform(resource.viewBox, markerViewport, resource.preserveAspectRatio);
+    const ref = transformedPoint(
+      boxTransform,
+      markerReferenceCoordinate(resource.refX, "horizontal", resource, viewport, shape, fontMetrics),
+      markerReferenceCoordinate(resource.refY, "vertical", resource, viewport, shape, fontMetrics),
+    );
+    const angle = orientedMarkerAngle(resource.orient, kind, vertex.angle);
+    const unitScale = resource.units === "strokeWidth" ? shape.style.strokeStyle.width : 1;
+    const placement = [
+      translation(vertex.x, vertex.y),
+      rotation(angle),
+      scaling(unitScale),
+      translation(-ref.x, -ref.y),
+    ].reduce(multiplyTransforms);
+    const group: RenderGroup = {
+      type: "group",
+      children: built,
+      // display on the marker element is forced to none only for direct rendering;
+      // referenced shadow content still consumes all other computed properties.
+      style: { ...resourceStyle, display: "inline" },
+      transform: multiplyTransforms(placement, boxTransform),
+      source: resource.source,
+      paintContext: {
+        viewport: { ...contentViewport },
+        rootViewport: { ...shape.paintContext.rootViewport },
+        fontMetrics: { ...fontMetrics },
+      },
+      markerPlacement: {
+        kind,
+        x: vertex.x,
+        y: vertex.y,
+        angle,
+        unitScale,
+        refX: ref.x,
+        refY: ref.y,
+        viewBoxTransform: boxTransform,
+      },
+      viewport: {
+        rect: markerViewport,
+        ...(resource.viewBox ? { viewBox: resource.viewBox } : {}),
+        preserveAspectRatio: resource.preserveAspectRatio,
+        overflow: resource.overflow,
+        clip: resource.overflow !== "visible",
+        zeroSized: false,
+        clipTransform: placement,
+      },
+    };
+    if (resource.children.length === 0) resource.children = built;
+    return group;
+  }
+
+  function materializeMarkers(nodes: RenderNode[], stack: string[] = []): void {
+    for (const node of nodes) {
+      if (node.type === "group") {
+        materializeMarkers(node.children, stack);
+        continue;
+      }
+      if (node.type !== "shape") continue;
+      let vertices: ReturnType<typeof markerVertices>;
+      try {
+        vertices = markerVertices(node.geometry);
+      } catch (error) {
+        diagnoseMarkerOnce(
+          node,
+          "invalid-marker-geometry",
+          `Marker vertices could not be computed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        continue;
+      }
+      if (vertices.length === 0) continue;
+
+      const requests: Array<{
+        kind: "start" | "mid" | "end";
+        reference: MarkerReference | undefined;
+        vertex: (typeof vertices)[number];
+      }> = [];
+      if (vertices.length === 1) {
+        requests.push(
+          { kind: "start", reference: node.style.markerStart, vertex: vertices[0]! },
+          { kind: "end", reference: node.style.markerEnd, vertex: vertices[0]! },
+        );
+      } else {
+        requests.push({ kind: "start", reference: node.style.markerStart, vertex: vertices[0]! });
+        for (let index = 1; index < vertices.length - 1; index++)
+          requests.push({ kind: "mid", reference: node.style.markerMid, vertex: vertices[index]! });
+        requests.push({
+          kind: "end",
+          reference: node.style.markerEnd,
+          vertex: vertices[vertices.length - 1]!,
+        });
+      }
+
+      const instances: RenderGroup[] = [];
+      for (const request of requests) {
+        const reference = request.reference;
+        if (!reference || reference.invalid || !reference.id) continue;
+        const id = reference.id;
+        const resource = resources.markers.get(id);
+        if (!resource) {
+          const target = resources.definitions.get(id);
+          diagnoseMarkerOnce(
+            node,
+            target ? "wrong-marker-resource-type" : "missing-marker-resource",
+            target
+              ? `Marker reference #${id} targets <${target.tagName}> instead of a marker.`
+              : `Marker reference #${id} does not resolve to a local marker resource.`,
+          );
+          continue;
+        }
+        if (stack.includes(id)) {
+          const cycle = [...stack.slice(stack.indexOf(id)), id];
+          diagnoseMarkerOnce(
+            node,
+            "cyclic-marker-reference",
+            `Marker cycle detected: ${cycle.map((item) => `#${item}`).join(" -> ")}.`,
+          );
+          continue;
+        }
+        const instance = buildMarkerInstance(resource, node, request.kind, request.vertex, stack);
+        if (instance) instances.push(instance);
+      }
+      if (instances.length > 0) {
+        node.markers = instances;
+        for (const instance of instances) {
+          const resource = resources.markers.get(instance.source.id ?? "");
+          if (resource) resource.instances.set(node, [...(resource.instances.get(node) ?? []), instance]);
+        }
+      }
+    }
+  }
+  materializeMarkers(children);
 
   function diagnosePatternOnce(pattern: PatternPaint, code: string, message: string): void {
     if (diagnostics.some((item) => item.code === code && item.source.id === pattern.id && item.message === message))
@@ -1157,6 +1505,7 @@ export function buildRenderDocument(
         );
       }
     }
+    materializeMarkers(built);
     return built;
   }
 
@@ -1185,6 +1534,7 @@ export function buildRenderDocument(
           continue;
         }
         if (node.type !== "shape") continue;
+        if (node.markers) visit(node.markers);
         for (const paint of [node.style.fill, node.style.stroke]) {
           if (paint.type !== "reference") continue;
           const dependency = resources.paints.get(paint.id);
@@ -1202,6 +1552,7 @@ export function buildRenderDocument(
         continue;
       }
       if (node.type !== "shape") continue;
+      if (node.markers) materializeReferencedPatterns(node.markers);
       for (const paint of [node.style.fill, node.style.stroke]) {
         if (paint.type !== "reference") continue;
         const pattern = resources.paints.get(paint.id);
@@ -1236,6 +1587,7 @@ export function buildRenderDocument(
   function materializeClipPaths(nodes: RenderNode[], stack: string[] = []): void {
     for (const node of nodes) {
       if (node.type === "group") materializeClipPaths(node.children, stack);
+      else if (node.type === "shape" && node.markers) materializeClipPaths(node.markers, stack);
       const reference = node.style.clipPath;
       if (!reference || reference.invalid || !reference.id) continue;
       const id = reference.id;
@@ -1319,6 +1671,7 @@ export function buildRenderDocument(
           fontMetrics: { ...fontMetrics },
         },
       };
+      materializeMarkers([rootGroup]);
       materializeClipPaths([rootGroup], [...stack, id]);
       const instance = resolveClipPathInstance(resource, node, [rootGroup]);
       if (instance.invalid && resource.units === "objectBoundingBox")
@@ -1357,6 +1710,7 @@ export function buildRenderDocument(
   function materializeMasks(nodes: RenderNode[], stack: string[] = []): void {
     for (const node of nodes) {
       if (node.type === "group") materializeMasks(node.children, stack);
+      else if (node.type === "shape" && node.markers) materializeMasks(node.markers, stack);
       const reference = node.style.mask;
       if (!reference || reference.invalid || !reference.id) continue;
       const id = reference.id;
@@ -1406,6 +1760,7 @@ export function buildRenderDocument(
           );
         }
       }
+      materializeMarkers(built);
       materializeReferencedPatterns(built);
       materializeClipPaths(built);
       materializeMasks(built, [...stack, id]);
@@ -1424,6 +1779,7 @@ export function buildRenderDocument(
         continue;
       }
       if (node.type !== "shape") continue;
+      if (node.markers) diagnosePaintReferences(node.markers);
       for (const paint of [node.style.fill, node.style.stroke]) {
         if (paint.type !== "reference") continue;
         const server = resources.paints.get(paint.id);

--- a/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
@@ -25,6 +25,7 @@ function collectVisiblePaints(nodes: RenderNode[], paints: VisiblePaint[] = []):
     if (node.style.stroke.type !== "none") {
       paints.push({ paint: node.style.stroke, opacity: node.style.strokeOpacity });
     }
+    if (node.markers) collectVisiblePaints(node.markers, paints);
   }
   return paints;
 }
@@ -34,13 +35,16 @@ function containsGeneralViewContent(nodes: RenderNode[]): boolean {
     (node) =>
       node.type === "text" ||
       node.type === "image" ||
+      (node.type === "shape" && node.markers !== undefined && containsGeneralViewContent(node.markers)) ||
       (node.type === "group" && containsGeneralViewContent(node.children)),
   );
 }
 
 function containsViewportClip(nodes: RenderNode[]): boolean {
   return nodes.some(
-    (node) => node.type === "group" && (node.viewport?.clip === true || containsViewportClip(node.children)),
+    (node) =>
+      (node.type === "shape" && node.markers !== undefined && containsViewportClip(node.markers)) ||
+      (node.type === "group" && (node.viewport?.clip === true || containsViewportClip(node.children))),
   );
 }
 
@@ -57,7 +61,10 @@ function containsIndependentCompositing(nodes: RenderNode[]): boolean {
       node.style.blendMode !== "normal"
     )
       return true;
-    return node.type === "group" && containsIndependentCompositing(node.children);
+    return (
+      (node.type === "shape" && node.markers !== undefined && containsIndependentCompositing(node.markers)) ||
+      (node.type === "group" && containsIndependentCompositing(node.children))
+    );
   });
 }
 
@@ -67,7 +74,16 @@ function containsNonScalingStroke(nodes: RenderNode[]): boolean {
       (node.type === "shape" &&
         node.style.stroke.type !== "none" &&
         node.style.strokeStyle.vectorEffect === "non-scaling-stroke") ||
+      (node.type === "shape" && node.markers !== undefined && containsNonScalingStroke(node.markers)) ||
       (node.type === "group" && containsNonScalingStroke(node.children)),
+  );
+}
+
+function containsMarkers(nodes: RenderNode[]): boolean {
+  return nodes.some(
+    (node) =>
+      (node.type === "shape" && (node.markers?.length ?? 0) > 0) ||
+      (node.type === "group" && containsMarkers(node.children)),
   );
 }
 
@@ -101,6 +117,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   const needsIndependentCompositing =
     containsIndependentCompositing(document.children) || paints.some(({ paint }) => hasIntrinsicAlpha(paint));
   const needsNonScalingStroke = containsNonScalingStroke(document.children);
+  const needsMarkers = containsMarkers(document.children);
 
   if (
     config.preserveColors === false &&
@@ -108,6 +125,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
     !hasPaintServer &&
     !needsIndependentCompositing &&
     !needsNonScalingStroke &&
+    !needsMarkers &&
     !containsGeneralViewContent(document.children)
   ) {
     return {
@@ -123,6 +141,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   if (hasPatternPaint) reasons.push("document uses an SVG pattern paint server");
   if (needsIndependentCompositing) reasons.push("document uses independent paint or group opacity");
   if (needsNonScalingStroke) reasons.push("document uses non-scaling stroke geometry");
+  if (needsMarkers) reasons.push("document uses SVG marker shadow content");
 
   const colors = paints.map(({ paint, opacity }) => {
     if (paint.type === "reference") {

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -120,7 +120,9 @@ function createOptions(
 function hasFill(nodes: RenderNode[]): boolean {
   return nodes.some(
     (node) =>
-      (node.type === "shape" && node.style.fill.type !== "none") || (node.type === "group" && hasFill(node.children)),
+      (node.type === "shape" &&
+        (node.style.fill.type !== "none" || (node.markers !== undefined && hasFill(node.markers)))) ||
+      (node.type === "group" && hasFill(node.children)),
   );
 }
 
@@ -128,6 +130,7 @@ function hasStroke(nodes: RenderNode[]): boolean {
   return nodes.some(
     (node) =>
       (node.type === "shape" && node.style.stroke.type !== "none") ||
+      (node.type === "shape" && node.markers !== undefined && hasStroke(node.markers)) ||
       (node.type === "group" && hasStroke(node.children)),
   );
 }
@@ -135,6 +138,7 @@ function hasStroke(nodes: RenderNode[]): boolean {
 function paintValue(paint: Paint): string {
   if (paint.type === "none") return "none";
   if (paint.type === "solid") return paint.value;
+  if (paint.type === "context") return `context-${paint.source}`;
   return paint.fallback ?? `url(#${paint.id})`;
 }
 
@@ -576,6 +580,9 @@ function buildViewNodes(
       }
       if (kind === "stroke" && node.style.stroke.type !== "none") {
         addLayer("stroke", node.style.stroke, node.style.strokeOpacity);
+      }
+      if (kind === "markers" && node.markers && node.markers.length > 0) {
+        paints.push(...buildViewNodes(node.markers, context, [...ancestorTransforms, node.transform]));
       }
     }
     if (paints.length > 0) {

--- a/packages/svg-to-swiftui-core/src/renderTree/markers.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/markers.ts
@@ -1,0 +1,498 @@
+import type { ElementNode } from "svg-parser";
+import { SVGPathData } from "svg-pathdata";
+import { type ParsedSVGLength, parseSVGLength, SVGLengthError } from "../lengths";
+import type { Presentation, StyleResolution, SVGStyleResolver } from "../styleCascade";
+import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio, parseViewBox } from "../viewports";
+import type {
+  Geometry,
+  MarkerOrient,
+  MarkerRefCoordinate,
+  MarkerResource,
+  MarkerUnits,
+  RenderDiagnostic,
+  SourceLocation,
+} from "./types";
+
+type PathCommand = InstanceType<typeof SVGPathData>["commands"][number];
+
+export interface MarkerVertex {
+  x: number;
+  y: number;
+  /** Automatic orientation in SVG user-space degrees. */
+  angle: number;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface Segment {
+  start: Point;
+  end: Point;
+  nonZero: boolean;
+  rawStart?: Point;
+  rawEnd?: Point;
+  startDirection?: Point;
+  endDirection?: Point;
+}
+
+interface Subpath {
+  vertices: Point[];
+  segments: Segment[];
+  closed: boolean;
+}
+
+const DESCRIPTIVE_ELEMENTS = new Set(["desc", "metadata", "title"]);
+const EPSILON = 1e-12;
+
+function sourceLocation(element: ElementNode): SourceLocation {
+  const id = element.properties?.id;
+  return { element: element.tagName ?? "unknown", ...(id === undefined ? {} : { id: String(id) }) };
+}
+
+function diagnostic(diagnostics: RenderDiagnostic[], element: ElementNode, code: string, message: string): void {
+  diagnostics.push({ code, message, severity: "warning", source: sourceLocation(element) });
+}
+
+function children(element: ElementNode): ElementNode[] {
+  return element.children.filter(
+    (child): child is ElementNode => typeof child !== "string" && child.type === "element",
+  );
+}
+
+function containsMarker(element: ElementNode): boolean {
+  return element.tagName === "marker" || children(element).some(containsMarker);
+}
+
+function parsedLength(
+  raw: unknown,
+  fallback: string,
+  label: string,
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+): ParsedSVGLength {
+  try {
+    const parsed = parseSVGLength(raw ?? fallback);
+    if (parsed.kind !== "length") throw new SVGLengthError("invalid-marker-length", `${label} requires a length.`);
+    return parsed;
+  } catch (error) {
+    diagnostic(
+      diagnostics,
+      element,
+      error instanceof SVGLengthError ? error.code : "invalid-marker-length",
+      `Invalid ${label}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return parseSVGLength(fallback) as ParsedSVGLength;
+  }
+}
+
+function refCoordinate(
+  raw: unknown,
+  axis: "x" | "y",
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+): MarkerRefCoordinate {
+  const normalized = String(raw ?? "0")
+    .trim()
+    .toLowerCase();
+  const keywords =
+    axis === "x"
+      ? ({ left: "min", center: "center", right: "max" } as const)
+      : ({ top: "min", center: "center", bottom: "max" } as const);
+  if (normalized in keywords) return { type: "keyword", value: keywords[normalized as keyof typeof keywords]! };
+  return { type: "length", value: parsedLength(raw, "0", `marker ref${axis.toUpperCase()}`, element, diagnostics) };
+}
+
+function markerUnits(raw: unknown, element: ElementNode, diagnostics: RenderDiagnostic[]): MarkerUnits {
+  const value = String(raw ?? "strokeWidth");
+  if (value === "strokeWidth" || value === "userSpaceOnUse") return value;
+  diagnostic(diagnostics, element, "invalid-marker-units", `Invalid markerUnits '${value}'.`);
+  return "strokeWidth";
+}
+
+function markerOrient(raw: unknown, element: ElementNode, diagnostics: RenderDiagnostic[]): MarkerOrient {
+  const normalized = String(raw ?? "0")
+    .trim()
+    .toLowerCase();
+  if (normalized === "auto" || normalized === "auto-start-reverse") return { type: normalized };
+  const match = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?)(deg|rad|grad|turn)?$/i.exec(normalized);
+  if (!match) {
+    diagnostic(diagnostics, element, "invalid-marker-orient", `Invalid marker orient '${normalized}'.`);
+    return { type: "angle", degrees: 0 };
+  }
+  const value = Number(match[1]);
+  const degrees =
+    match[2] === "rad"
+      ? (value * 180) / Math.PI
+      : match[2] === "grad"
+        ? value * 0.9
+        : match[2] === "turn"
+          ? value * 360
+          : value;
+  return { type: "angle", degrees };
+}
+
+/** Resolve typed marker definitions while retaining their original cascade and shadow content. */
+export function resolveMarkerResources(
+  root: ElementNode,
+  markerElements: Map<string, ElementNode>,
+  styleResolver: SVGStyleResolver,
+  rootPresentation: Presentation,
+  diagnostics: RenderDiagnostic[],
+): Map<string, MarkerResource> {
+  const resolutions = new Map<ElementNode, StyleResolution>();
+  const walk = (element: ElementNode, inherited: Presentation): void => {
+    for (const child of children(element)) {
+      if (!containsMarker(child)) continue;
+      const resolved = styleResolver.resolve(child, inherited);
+      resolutions.set(child, resolved);
+      walk(child, resolved.values);
+    }
+  };
+  walk(root, rootPresentation);
+
+  const resources = new Map<string, MarkerResource>();
+  for (const [id, element] of markerElements) {
+    const resolved = resolutions.get(element);
+    const markerWidth = parsedLength(element.properties?.markerWidth, "3", "markerWidth", element, diagnostics);
+    const markerHeight = parsedLength(element.properties?.markerHeight, "3", "markerHeight", element, diagnostics);
+    if (markerWidth.value < 0)
+      diagnostic(diagnostics, element, "negative-marker-width", "markerWidth cannot be negative.");
+    if (markerHeight.value < 0)
+      diagnostic(diagnostics, element, "negative-marker-height", "markerHeight cannot be negative.");
+
+    let viewBox: ReturnType<typeof parseViewBox>;
+    try {
+      viewBox = parseViewBox(element.properties?.viewBox);
+    } catch (error) {
+      diagnostic(
+        diagnostics,
+        element,
+        error instanceof SVGLengthError ? error.code : "invalid-marker-viewbox",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+
+    let preserveAspectRatio = DEFAULT_PRESERVE_ASPECT_RATIO;
+    try {
+      preserveAspectRatio = parsePreserveAspectRatio(element.properties?.preserveAspectRatio);
+    } catch (error) {
+      diagnostic(
+        diagnostics,
+        element,
+        error instanceof SVGLengthError ? error.code : "invalid-marker-preserve-aspect-ratio",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+
+    const authoredOverflow = resolved?.provenance.overflow ? resolved.values.overflow : "hidden";
+    resources.set(id, {
+      id,
+      markerWidth,
+      markerHeight,
+      refX: refCoordinate(element.properties?.refX, "x", element, diagnostics),
+      refY: refCoordinate(element.properties?.refY, "y", element, diagnostics),
+      units: markerUnits(element.properties?.markerUnits, element, diagnostics),
+      orient: markerOrient(element.properties?.orient, element, diagnostics),
+      ...(viewBox ? { viewBox } : {}),
+      preserveAspectRatio,
+      overflow: String(authoredOverflow ?? "hidden").toLowerCase(),
+      source: sourceLocation(element),
+      element,
+      contentElements: children(element).filter((child) => !DESCRIPTIVE_ELEMENTS.has(child.tagName ?? "")),
+      children: [],
+      instances: new Map(),
+      presentation: resolved?.values ?? rootPresentation,
+      provenance: resolved?.provenance ?? {},
+    });
+  }
+  return resources;
+}
+
+function samePoint(left: Point, right: Point): boolean {
+  return Math.abs(left.x - right.x) <= EPSILON && Math.abs(left.y - right.y) <= EPSILON;
+}
+
+function vector(from: Point, to: Point): Point | undefined {
+  const result = { x: to.x - from.x, y: to.y - from.y };
+  return Math.hypot(result.x, result.y) <= EPSILON ? undefined : result;
+}
+
+function normalized(value: Point | undefined): Point | undefined {
+  if (!value) return undefined;
+  const length = Math.hypot(value.x, value.y);
+  return length <= EPSILON ? undefined : { x: value.x / length, y: value.y / length };
+}
+
+function curveDirection(origin: Point, candidates: Point[]): Point | undefined {
+  for (const candidate of candidates) {
+    const result = normalized(vector(origin, candidate));
+    if (result) return result;
+  }
+  return undefined;
+}
+
+function lineSegment(start: Point, end: Point): Segment {
+  const direction = normalized(vector(start, end));
+  return { start, end, nonZero: !!direction, ...(direction ? { rawStart: direction, rawEnd: direction } : {}) };
+}
+
+function curveSegment(start: Point, end: Point, startControls: Point[], endControls: Point[]): Segment {
+  const rawStart = curveDirection(start, [...startControls, end]);
+  const reverseEnd = curveDirection(end, [...endControls, start]);
+  const rawEnd = reverseEnd ? { x: -reverseEnd.x, y: -reverseEnd.y } : undefined;
+  const nonZero =
+    !samePoint(start, end) || [...startControls, ...endControls].some((point) => !samePoint(start, point));
+  return { start, end, nonZero, ...(rawStart ? { rawStart } : {}), ...(rawEnd ? { rawEnd } : {}) };
+}
+
+function arcSegment(start: Point, command: Extract<PathCommand, { type: 512 }>): Segment | undefined {
+  const end = { x: command.x, y: command.y };
+  // SVG defines a same-endpoint arc as omitted, so it creates no marker vertex.
+  if (samePoint(start, end)) return undefined;
+  if (command.rX === 0 || command.rY === 0) return lineSegment(start, end);
+  const converted = new SVGPathData([
+    { type: SVGPathData.MOVE_TO, relative: false, x: start.x, y: start.y },
+    { ...command, relative: false },
+  ]).aToC().commands;
+  const curves = converted.filter(
+    (item): item is Extract<PathCommand, { type: 32 }> => item.type === SVGPathData.CURVE_TO,
+  );
+  if (curves.length === 0) return lineSegment(start, end);
+  const first = curves[0]!;
+  const last = curves[curves.length - 1]!;
+  return curveSegment(
+    start,
+    end,
+    [
+      { x: first.x1, y: first.y1 },
+      { x: first.x2, y: first.y2 },
+    ],
+    [
+      { x: last.x2, y: last.y2 },
+      { x: last.x1, y: last.y1 },
+    ],
+  );
+}
+
+function pathSubpaths(d: string): Subpath[] {
+  const commands = new SVGPathData(d).toAbs().normalizeST().commands;
+  const subpaths: Subpath[] = [];
+  let current: Subpath | undefined;
+  let point: Point = { x: 0, y: 0 };
+
+  const finish = () => {
+    if (current) subpaths.push(current);
+    current = undefined;
+  };
+  const append = (segment: Segment | undefined) => {
+    if (!current || !segment) return;
+    current.segments.push(segment);
+    current.vertices.push(segment.end);
+    point = segment.end;
+  };
+
+  for (const command of commands) {
+    if (command.type === SVGPathData.MOVE_TO) {
+      finish();
+      point = { x: command.x, y: command.y };
+      current = { vertices: [point], segments: [], closed: false };
+      continue;
+    }
+    if (!current) continue;
+    if (command.type === SVGPathData.CLOSE_PATH) {
+      append(lineSegment(point, current.vertices[0]!));
+      current.closed = true;
+      continue;
+    }
+    if (command.type === SVGPathData.LINE_TO) {
+      append(lineSegment(point, { x: command.x, y: command.y }));
+      continue;
+    }
+    if (command.type === SVGPathData.HORIZ_LINE_TO) {
+      append(lineSegment(point, { x: command.x, y: point.y }));
+      continue;
+    }
+    if (command.type === SVGPathData.VERT_LINE_TO) {
+      append(lineSegment(point, { x: point.x, y: command.y }));
+      continue;
+    }
+    if (command.type === SVGPathData.CURVE_TO) {
+      const end = { x: command.x, y: command.y };
+      append(
+        curveSegment(
+          point,
+          end,
+          [
+            { x: command.x1, y: command.y1 },
+            { x: command.x2, y: command.y2 },
+          ],
+          [
+            { x: command.x2, y: command.y2 },
+            { x: command.x1, y: command.y1 },
+          ],
+        ),
+      );
+      continue;
+    }
+    if (command.type === SVGPathData.QUAD_TO) {
+      const end = { x: command.x, y: command.y };
+      const control = { x: command.x1, y: command.y1 };
+      append(curveSegment(point, end, [control], [control]));
+      continue;
+    }
+    if (command.type === SVGPathData.ARC) append(arcSegment(point, command));
+  }
+  finish();
+  return subpaths;
+}
+
+function points(value: string): Point[] {
+  const values = value
+    .trim()
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .map(Number);
+  if (values.length < 2 || values.some((item) => !Number.isFinite(item))) return [];
+  const result: Point[] = [];
+  for (let index = 0; index + 1 < values.length; index += 2) result.push({ x: values[index]!, y: values[index + 1]! });
+  return result;
+}
+
+function polySubpath(value: string, closed: boolean): Subpath[] {
+  const vertices = points(value);
+  if (vertices.length === 0) return [];
+  const segments: Segment[] = [];
+  for (let index = 1; index < vertices.length; index++)
+    segments.push(lineSegment(vertices[index - 1]!, vertices[index]!));
+  const allVertices = [...vertices];
+  if (closed) {
+    const closing = lineSegment(vertices[vertices.length - 1]!, vertices[0]!);
+    segments.push(closing);
+    allVertices.push(closing.end);
+  }
+  return [{ vertices: allVertices, segments, closed }];
+}
+
+function equivalentClosedPath(d: string): Subpath[] {
+  const subpaths = pathSubpaths(d);
+  if (subpaths.length === 1) subpaths[0]!.closed = true;
+  return subpaths;
+}
+
+function geometrySubpaths(geometry: Geometry): Subpath[] {
+  switch (geometry.type) {
+    case "path":
+      return pathSubpaths(geometry.d);
+    case "line":
+      return polySubpath(`${geometry.x1},${geometry.y1} ${geometry.x2},${geometry.y2}`, false);
+    case "polyline":
+      return polySubpath(geometry.points, false);
+    case "polygon":
+      return polySubpath(geometry.points, true);
+    case "circle": {
+      if (geometry.r <= 0) return [];
+      const { cx, cy, r } = geometry;
+      return equivalentClosedPath(
+        `M${cx + r},${cy}A${r},${r} 0 0 0 ${cx},${cy + r}A${r},${r} 0 0 0 ${cx - r},${cy}` +
+          `A${r},${r} 0 0 0 ${cx},${cy - r}A${r},${r} 0 0 0 ${cx + r},${cy}`,
+      );
+    }
+    case "ellipse": {
+      if (geometry.rx <= 0 || geometry.ry <= 0) return [];
+      const { cx, cy, rx, ry } = geometry;
+      return equivalentClosedPath(
+        `M${cx + rx},${cy}A${rx},${ry} 0 0 0 ${cx},${cy + ry}A${rx},${ry} 0 0 0 ${cx - rx},${cy}` +
+          `A${rx},${ry} 0 0 0 ${cx},${cy - ry}A${rx},${ry} 0 0 0 ${cx + rx},${cy}`,
+      );
+    }
+    case "rect": {
+      if (geometry.width <= 0 || geometry.height <= 0) return [];
+      const { x, y, width, height } = geometry;
+      const rx = geometry.rx ?? 0;
+      const ry = geometry.ry ?? 0;
+      if (rx <= 0 || ry <= 0) return equivalentClosedPath(`M${x},${y}H${x + width}V${y + height}H${x}V${y}`);
+      return equivalentClosedPath(
+        `M${x + rx},${y}H${x + width - rx}A${rx},${ry} 0 0 1 ${x + width},${y + ry}` +
+          `V${y + height - ry}A${rx},${ry} 0 0 1 ${x + width - rx},${y + height}H${x + rx}` +
+          `A${rx},${ry} 0 0 1 ${x},${y + height - ry}V${y + ry}A${rx},${ry} 0 0 1 ${x + rx},${y}`,
+      );
+    }
+  }
+}
+
+function resolveSegmentDirections(subpaths: Subpath[]): void {
+  for (const { segments } of subpaths) {
+    const previousNonZero: Array<Segment | undefined> = [];
+    let previous: Segment | undefined;
+    for (const segment of segments) {
+      previousNonZero.push(previous);
+      if (segment.nonZero) previous = segment;
+    }
+    const nextNonZero: Array<Segment | undefined> = new Array(segments.length);
+    let next: Segment | undefined;
+    for (let index = segments.length - 1; index >= 0; index--) {
+      nextNonZero[index] = next;
+      if (segments[index]!.nonZero) next = segments[index];
+    }
+
+    for (const [index, segment] of segments.entries()) {
+      if (segment.nonZero) {
+        segment.startDirection = segment.rawStart ?? segment.rawEnd ?? { x: 1, y: 0 };
+        segment.endDirection = segment.rawEnd ?? segment.rawStart ?? { x: 1, y: 0 };
+        continue;
+      }
+      segment.startDirection = previousNonZero[index]?.endDirection ?? nextNonZero[index]?.rawStart ?? { x: 1, y: 0 };
+      segment.endDirection = nextNonZero[index]?.startDirection ??
+        nextNonZero[index]?.rawStart ??
+        previousNonZero[index]?.rawEnd ?? { x: 1, y: 0 };
+    }
+  }
+}
+
+function directionAngle(direction: Point | undefined): number {
+  return (Math.atan2(direction?.y ?? 0, direction?.x ?? 1) * 180) / Math.PI;
+}
+
+function bisectedAngle(incoming: Point | undefined, outgoing: Point | undefined): number {
+  const before = normalized(incoming) ?? { x: 1, y: 0 };
+  const after = normalized(outgoing) ?? { x: 1, y: 0 };
+  const sum = { x: before.x + after.x, y: before.y + after.y };
+  // At an exact 180-degree reversal the bisector sum is zero; SVG keeps the
+  // incoming direction rather than selecting an arbitrary perpendicular.
+  return directionAngle(Math.hypot(sum.x, sum.y) <= EPSILON ? before : sum);
+}
+
+/** Return every equivalent-path vertex and its spec-defined automatic marker orientation. */
+export function markerVertices(geometry: Geometry): MarkerVertex[] {
+  const subpaths = geometrySubpaths(geometry);
+  resolveSegmentDirections(subpaths);
+  return subpaths.flatMap((subpath) =>
+    subpath.vertices.map((vertex, index) => {
+      const first = index === 0;
+      const last = index === subpath.vertices.length - 1;
+      let angle: number;
+      if (!subpath.closed && first) angle = directionAngle(subpath.segments[0]?.startDirection);
+      else if (!subpath.closed && last)
+        angle = directionAngle(subpath.segments[subpath.segments.length - 1]?.endDirection);
+      else {
+        const incoming = first
+          ? subpath.segments[subpath.segments.length - 1]?.endDirection
+          : subpath.segments[index - 1]?.endDirection;
+        const outgoing = last ? subpath.segments[0]?.startDirection : subpath.segments[index]?.startDirection;
+        angle = bisectedAngle(incoming, outgoing);
+      }
+      return { ...vertex, angle };
+    }),
+  );
+}
+
+export function orientedMarkerAngle(
+  orient: MarkerOrient,
+  kind: "start" | "mid" | "end",
+  automaticAngle: number,
+): number {
+  if (orient.type === "angle") return orient.degrees;
+  return automaticAngle + (orient.type === "auto-start-reverse" && kind === "start" ? 180 : 0);
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -34,7 +34,8 @@ export interface RenderDiagnostic {
 export type Paint =
   | { type: "none" }
   | { type: "solid"; value: string }
-  | { type: "reference"; id: string; fallback?: string };
+  | { type: "reference"; id: string; fallback?: string }
+  | { type: "context"; source: "fill" | "stroke" };
 
 export type GradientUnits = "objectBoundingBox" | "userSpaceOnUse";
 export type GradientSpreadMethod = "pad" | "reflect" | "repeat";
@@ -212,14 +213,50 @@ export interface StrokeStyle {
 
 export type PaintOrderPhase = "fill" | "stroke" | "markers";
 
+export interface MarkerReference {
+  id?: string;
+  invalid: boolean;
+}
+
+export type MarkerUnits = "strokeWidth" | "userSpaceOnUse";
+export type MarkerOrient = { type: "auto" | "auto-start-reverse" } | { type: "angle"; degrees: number };
+export type MarkerRefCoordinate =
+  | { type: "length"; value: ParsedSVGLength }
+  | { type: "keyword"; value: "min" | "center" | "max" };
+
+export interface MarkerResource {
+  id: string;
+  markerWidth: ParsedSVGLength;
+  markerHeight: ParsedSVGLength;
+  refX: MarkerRefCoordinate;
+  refY: MarkerRefCoordinate;
+  units: MarkerUnits;
+  orient: MarkerOrient;
+  viewBox?: ViewBoxData;
+  preserveAspectRatio: PreserveAspectRatio;
+  overflow: string;
+  source: SourceLocation;
+  element: ElementNode;
+  contentElements: ElementNode[];
+  children: RenderNode[];
+  instances: Map<RenderShape, RenderGroup[]>;
+  presentation: Readonly<Record<string, string | number>>;
+  provenance: Readonly<Record<string, CSSDiagnosticContext>>;
+}
+
 /** Presentation properties after inheritance and inline-style precedence have been resolved. */
 export interface ComputedStyle {
   fill: Paint;
+  /** Authored fill retained for context-fill when the host geometry itself has no fill phase (for example line). */
+  contextFill?: Paint;
   stroke: Paint;
   color: string;
   opacity: number;
   fillOpacity: number;
   strokeOpacity: number;
+  markerStart?: MarkerReference;
+  markerMid?: MarkerReference;
+  markerEnd?: MarkerReference;
   /** Complete SVG paint sequence after omitted phases are appended in default order. */
   paintOrder: readonly PaintOrderPhase[];
   fillRule: "nonzero" | "evenodd";
@@ -256,6 +293,19 @@ export interface RenderShape {
   paintContext: NodeCoordinateContext;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
+  /** Materialized marker shadow trees in SVG vertex order. */
+  markers?: RenderGroup[];
+}
+
+export interface MarkerPlacement {
+  kind: "start" | "mid" | "end";
+  x: number;
+  y: number;
+  angle: number;
+  unitScale: number;
+  refX: number;
+  refY: number;
+  viewBoxTransform: AffineTransform;
 }
 
 export interface RenderGroup {
@@ -267,6 +317,8 @@ export interface RenderGroup {
   paintContext: NodeCoordinateContext;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
+  /** Present only on a marker shadow-tree root. */
+  markerPlacement?: MarkerPlacement;
   /** True when this group came from a referenced definition. */
   referenceId?: string;
   /** Semantic viewport data retained for clipping and later coordinate-space consumers. */
@@ -320,7 +372,8 @@ export interface ResourceRegistry {
   clipElements: Map<string, ElementNode>;
   masks: Map<string, MaskResource>;
   maskElements: Map<string, ElementNode>;
-  markers: Map<string, ElementNode>;
+  markers: Map<string, MarkerResource>;
+  markerElements: Map<string, ElementNode>;
   filters: Map<string, ElementNode>;
   views: Map<string, ElementNode>;
 }

--- a/packages/svg-to-swiftui-core/src/tests/markers.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/markers.test.ts
@@ -1,0 +1,216 @@
+import { __testing, convert } from "../index";
+import { markerVertices } from "../renderTree/markers";
+import type { RenderGroup, RenderNode, RenderShape } from "../renderTree/types";
+
+function shapes(nodes: RenderNode[]): RenderShape[] {
+  return nodes.flatMap((node) => (node.type === "shape" ? [node] : node.type === "group" ? shapes(node.children) : []));
+}
+
+function markerRoots(shape: RenderShape): RenderGroup[] {
+  return shape.markers ?? [];
+}
+
+describe("SVG marker rendering", () => {
+  test("materializes start, mid, and end shadow trees with automatic bisector orientation", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 100"><defs>
+        <marker id="dot" markerWidth="10" markerHeight="10" refX="5" refY="5"
+          markerUnits="userSpaceOnUse" orient="auto"><circle cx="5" cy="5" r="4"/></marker>
+      </defs><polyline id="target" points="10,10 40,10 40,50" fill="none"
+        marker-start="url(#dot)" marker-mid="url(#dot)" marker-end="url(#dot)"/>
+      </svg>
+    `);
+    const target = shapes(document.children).find((shape) => shape.source.id === "target")!;
+    const markers = markerRoots(target);
+
+    expect(document.resources.markers.get("dot")).toMatchObject({
+      units: "userSpaceOnUse",
+      orient: { type: "auto" },
+      overflow: "hidden",
+    });
+    expect(markers.map((marker) => marker.markerPlacement?.kind)).toEqual(["start", "mid", "end"]);
+    expect(markers.map((marker) => marker.markerPlacement?.x)).toEqual([10, 40, 40]);
+    expect(markers.map((marker) => marker.markerPlacement?.y)).toEqual([10, 10, 50]);
+    expect(markers.map((marker) => marker.markerPlacement?.angle)).toEqual([0, 45, 90]);
+    expect(document.diagnostics).toEqual([]);
+  });
+
+  test("uses equivalent path vertices for basic shapes and every path subpath", () => {
+    expect(markerVertices({ type: "circle", cx: 10, cy: 10, r: 5 })).toHaveLength(5);
+    expect(markerVertices({ type: "ellipse", cx: 10, cy: 10, rx: 8, ry: 4 })).toHaveLength(5);
+    expect(markerVertices({ type: "rect", x: 0, y: 0, width: 20, height: 10 })).toHaveLength(5);
+    expect(markerVertices({ type: "rect", x: 0, y: 0, width: 20, height: 10, rx: 2, ry: 3 })).toHaveLength(9);
+    expect(markerVertices({ type: "polygon", points: "0,0 10,0 10,10" })).toHaveLength(4);
+
+    const vertices = markerVertices({ type: "path", d: "M0 0L10 0M20 20L20 30" });
+    expect(vertices.map(({ x, y, angle }) => [x, y, angle])).toEqual([
+      [0, 0, 0],
+      [10, 0, 0],
+      [20, 20, 90],
+      [20, 30, 90],
+    ]);
+  });
+
+  test("resolves coincident curve controls and zero-length segment directions", () => {
+    const vertices = markerVertices({
+      type: "path",
+      d: "M0 0 C0 0 10 0 10 0 L10 0 L10 10",
+    });
+    expect(vertices).toHaveLength(4);
+    expect(vertices[0]!.angle).toBeCloseTo(0);
+    expect(vertices[1]!.angle).toBeCloseTo(0);
+    expect(vertices[2]!.angle).toBeCloseTo(90);
+    expect(vertices[3]!.angle).toBeCloseTo(90);
+
+    const arc = markerVertices({ type: "path", d: "M10 20 A10 10 0 0 1 20 30" });
+    expect(arc[0]!.angle).toBeCloseTo(0);
+    expect(arc[1]!.angle).toBeCloseTo(90);
+
+    const independentSubpaths = markerVertices({ type: "path", d: "M0 0V10M20 20L20 20H30" });
+    expect(independentSubpaths[2]!.angle).toBeCloseTo(0);
+    expect(independentSubpaths[3]!.angle).toBeCloseTo(0);
+  });
+
+  test("keeps the incoming direction at an exact 180-degree reversal", () => {
+    const vertices = markerVertices({ type: "polyline", points: "0,0 10,0 0,0" });
+    expect(vertices[1]!.angle).toBeCloseTo(0);
+  });
+
+  test("supports auto-start-reverse and explicit deg, rad, grad, and turn angles", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 20"><defs>
+        <marker id="auto" orient="auto-start-reverse"><path d="M0 0h3"/></marker>
+        <marker id="rad" orient="1.5707963267948966rad"><path d="M0 0h3"/></marker>
+        <marker id="grad" orient="100grad"><path d="M0 0h3"/></marker>
+        <marker id="turn" orient=".25turn"><path d="M0 0h3"/></marker>
+      </defs>
+      <line id="auto-line" x1="10" y1="10" x2="20" y2="10" marker-start="url(#auto)"/>
+      <line id="rad-line" x1="30" y1="10" x2="40" y2="10" marker-end="url(#rad)"/>
+      <line id="grad-line" x1="50" y1="10" x2="60" y2="10" marker-end="url(#grad)"/>
+      <line id="turn-line" x1="70" y1="10" x2="80" y2="10" marker-end="url(#turn)"/>
+      </svg>
+    `);
+    const angles = shapes(document.children).map((shape) => markerRoots(shape)[0]!.markerPlacement!.angle);
+    expect(angles[0]).toBeCloseTo(180);
+    expect(angles.slice(1)).toEqual([90, 90, 90]);
+  });
+
+  test("maps ref points through viewBox and clips to the marker viewport", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 100"><defs>
+        <marker id="m" markerWidth="20" markerHeight="10" viewBox="0 0 10 10"
+          refX="50%" refY="50%" preserveAspectRatio="xMidYMid meet"
+          markerUnits="userSpaceOnUse"><rect width="10" height="10"/></marker>
+        <marker id="keywords" viewBox="-5 -10 10 20" refX="right" refY="bottom"/>
+      </defs><line id="target" x1="10" y1="50" x2="50" y2="50" marker-end="url(#m)"/></svg>
+    `);
+    const marker = markerRoots(shapes(document.children).find((shape) => shape.source.id === "target")!)[0]!;
+    const matrix = marker.transform;
+    const mappedReference = { x: matrix.a * 5 + matrix.c * 5 + matrix.e, y: matrix.b * 5 + matrix.d * 5 + matrix.f };
+
+    expect(mappedReference.x).toBeCloseTo(50);
+    expect(mappedReference.y).toBeCloseTo(50);
+    expect(marker.viewport).toMatchObject({
+      rect: { x: 0, y: 0, width: 20, height: 10 },
+      clip: true,
+      preserveAspectRatio: { align: "xMidYMid", meetOrSlice: "meet" },
+    });
+    expect(marker.markerPlacement).toMatchObject({ refX: 10, refY: 5 });
+    expect(document.resources.markers.get("keywords")).toMatchObject({
+      refX: { type: "keyword", value: "max" },
+      refY: { type: "keyword", value: "max" },
+    });
+  });
+
+  test("resolves marker dimensions against the marker's computed font size", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 30"><defs>
+        <marker id="em" markerWidth="2em" markerHeight="1em" font-size="5"
+          markerUnits="userSpaceOnUse"><rect width="10" height="5"/></marker>
+      </defs><line x1="10" y1="15" x2="90" y2="15" marker-end="url(#em)"/></svg>
+    `);
+    expect(markerRoots(shapes(document.children)[0]!)[0]!.viewport?.rect).toEqual({
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 5,
+    });
+  });
+
+  test("resolves context fill and stroke without inheriting unrelated host styles", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 30"><defs>
+        <marker id="m" markerWidth="10" markerHeight="10" refX="5" refY="5" markerUnits="userSpaceOnUse">
+          <circle id="context" cx="5" cy="5" r="4" fill="context-stroke" stroke="context-fill"/>
+          <circle id="explicit" cx="5" cy="5" r="2" fill="green"/>
+        </marker>
+      </defs><line id="target" x1="10" y1="15" x2="90" y2="15" fill="red" stroke="blue"
+        stroke-width="4" opacity=".5" marker-end="url(#m)"/></svg>
+    `);
+    const content = shapes(markerRoots(shapes(document.children).find((shape) => shape.source.id === "target")!));
+    expect(content.find((shape) => shape.source.id === "context")?.style).toMatchObject({
+      fill: { type: "solid", value: "blue" },
+      stroke: { type: "solid", value: "red" },
+      opacity: 1,
+    });
+    expect(content.find((shape) => shape.source.id === "explicit")?.style.fill).toEqual({
+      type: "solid",
+      value: "green",
+    });
+  });
+
+  test("reports missing, wrong-type, malformed, and cyclic marker references", () => {
+    const source = `
+      <svg viewBox="0 0 100 30"><defs>
+        <path id="wrong" d="M0 0h1"/>
+        <marker id="cycle"><path d="M0 0h3" marker-end="url(#cycle)"/></marker>
+      </defs>
+      <line x1="0" y1="5" x2="10" y2="5" marker-end="url(#missing)"/>
+      <line x1="0" y1="15" x2="10" y2="15" marker-end="url(#wrong)"/>
+      <line x1="0" y1="25" x2="10" y2="25" marker-start="https://example.test/m.svg#x" marker-end="url(#cycle)"/>
+      </svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(document.diagnostics.map(({ code }) => code)).toEqual(
+      expect.arrayContaining([
+        "missing-marker-resource",
+        "wrong-marker-resource-type",
+        "invalid-marker-reference",
+        "cyclic-marker-reference",
+      ]),
+    );
+    expect(() => convert(source, { strict: true })).toThrow("Marker reference");
+  });
+
+  test("includes marker paint in paint-order, opacity, capability analysis, and painted bounds", () => {
+    const source = `
+      <svg viewBox="0 0 100 100"><defs>
+        <marker id="m" markerWidth="10" markerHeight="10" refX="5" refY="5" markerUnits="userSpaceOnUse">
+          <rect width="10" height="10" fill="#00ff00"/>
+        </marker>
+      </defs><line id="target" x1="20" y1="50" x2="80" y2="50" opacity=".4"
+        paint-order="markers stroke fill" marker-end="url(#m)"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    const target = shapes(document.children).find((shape) => shape.source.id === "target")!;
+    const output = convert(source);
+
+    expect(__testing.analyzeCapabilities(document, { preserveColors: false })).toMatchObject({
+      mode: "view",
+      reasons: expect.arrayContaining(["document uses SVG marker shadow content"]),
+    });
+    expect(__testing.renderNodeBounds(target)).toEqual({ x: 75, y: 45, width: 10, height: 10 });
+    expect(output).toContain("Color(red: 0, green: 1, blue: 0)");
+    expect(output).toContain(".opacity(0.4)");
+  });
+
+  test("does not render zero-sized markers and diagnoses negative marker dimensions", () => {
+    const source = `<svg viewBox="0 0 20 20"><defs>
+      <marker id="zero" markerWidth="0"><rect width="3" height="3"/></marker>
+      <marker id="negative" markerHeight="-1"><rect width="3" height="3"/></marker>
+    </defs><line x1="0" y1="10" x2="20" y2="10" marker-start="url(#zero)" marker-end="url(#negative)"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(shapes(document.children)[0]!.markers).toBeUndefined();
+    expect(document.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "negative-marker-height" })]),
+    );
+  });
+});

--- a/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
@@ -10883,6 +10883,218 @@
       "expectedMode": "shape",
       "tags": ["circle", "geometry", "line", "lucide", "realistic", "shape", "stroke"]
     },
+    "marker-context-paint": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "context-paint",
+        "geometry",
+        "marker",
+        "marker-end",
+        "marker-mid",
+        "marker-orient",
+        "marker-start",
+        "marker-units",
+        "overflow",
+        "path",
+        "rect",
+        "stroke",
+        "view"
+      ]
+    },
+    "marker-curves-arcs-subpaths": {
+      "width": 128,
+      "height": 74,
+      "expectedMode": "view",
+      "tags": [
+        "geometry",
+        "marker",
+        "marker-end",
+        "marker-mid",
+        "marker-orient",
+        "marker-start",
+        "marker-units",
+        "overflow",
+        "path",
+        "rect",
+        "stroke",
+        "view"
+      ]
+    },
+    "marker-invalid-references": {
+      "width": 128,
+      "height": 59,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "geometry",
+        "marker",
+        "marker-end",
+        "marker-mid",
+        "marker-start",
+        "marker-units",
+        "path",
+        "polyline",
+        "rect",
+        "stroke",
+        "view"
+      ]
+    },
+    "marker-orientation-angles": {
+      "width": 128,
+      "height": 67,
+      "expectedMode": "view",
+      "tags": [
+        "geometry",
+        "marker",
+        "marker-end",
+        "marker-orient",
+        "marker-start",
+        "marker-units",
+        "overflow",
+        "path",
+        "rect",
+        "stroke",
+        "view"
+      ]
+    },
+    "marker-paint-order-opacity": {
+      "width": 128,
+      "height": 57,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "geometry",
+        "marker",
+        "marker-end",
+        "marker-mid",
+        "marker-orient",
+        "marker-start",
+        "marker-units",
+        "opacity",
+        "overflow",
+        "paint-order",
+        "polygon",
+        "rect",
+        "stroke",
+        "view"
+      ]
+    },
+    "marker-primitives": {
+      "width": 128,
+      "height": 75,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "geometry",
+        "line",
+        "marker",
+        "marker-end",
+        "marker-mid",
+        "marker-orient",
+        "marker-start",
+        "marker-units",
+        "overflow",
+        "path",
+        "polygon",
+        "polyline",
+        "rect",
+        "stroke",
+        "view"
+      ]
+    },
+    "marker-resource-content": {
+      "width": 128,
+      "height": 69,
+      "expectedMode": "view",
+      "tags": [
+        "g",
+        "geometry",
+        "linearGradient",
+        "marker",
+        "marker-end",
+        "marker-mid",
+        "marker-orient",
+        "marker-start",
+        "marker-units",
+        "overflow",
+        "path",
+        "pattern",
+        "pattern-units",
+        "polygon",
+        "polyline",
+        "rect",
+        "stop",
+        "stroke",
+        "transform",
+        "use",
+        "view"
+      ]
+    },
+    "marker-transforms-overflow": {
+      "width": 128,
+      "height": 74,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "g",
+        "geometry",
+        "marker",
+        "marker-end",
+        "marker-mid",
+        "marker-orient",
+        "marker-start",
+        "marker-units",
+        "overflow",
+        "path",
+        "polyline",
+        "rect",
+        "stroke",
+        "transform",
+        "view"
+      ]
+    },
+    "marker-units-ref-points": {
+      "width": 128,
+      "height": 74,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "geometry",
+        "marker",
+        "marker-end",
+        "marker-orient",
+        "marker-start",
+        "marker-units",
+        "opacity",
+        "overflow",
+        "path",
+        "rect",
+        "stroke",
+        "view"
+      ]
+    },
+    "marker-viewbox-preserve-aspect": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "g",
+        "geometry",
+        "marker",
+        "marker-end",
+        "marker-units",
+        "path",
+        "preserve-aspect-ratio",
+        "rect",
+        "stroke",
+        "use",
+        "view"
+      ]
+    },
     "mask-alpha-luminance-primary": {
       "width": 128,
       "height": 64,

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-context-paint.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-context-paint.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 130">
+  <rect width="260" height="130" fill="#f1f5f9"/>
+  <defs>
+    <marker id="context" viewBox="0 0 14 14" refX="7" refY="7" markerWidth="16" markerHeight="16" markerUnits="userSpaceOnUse" orient="auto" overflow="visible">
+      <path d="M1 7L7 1L13 7L7 13Z" fill="context-stroke" stroke="context-fill" stroke-width="2"/>
+      <circle cx="7" cy="7" r="2" fill="#fff"/>
+    </marker>
+  </defs>
+  <path d="M20 28H110" fill="#fde68a" stroke="#dc2626" stroke-width="5" marker-start="url(#context)" marker-end="url(#context)"/>
+  <path d="M150 28H240" fill="#bfdbfe" stroke="#2563eb" stroke-width="5" marker-start="url(#context)" marker-end="url(#context)"/>
+  <path d="M20 82Q65 120 110 82" fill="#dcfce7" stroke="#16a34a" stroke-width="4" marker-start="url(#context)" marker-mid="url(#context)" marker-end="url(#context)"/>
+  <path d="M150 82Q195 44 240 82" fill="#fae8ff" stroke="#a21caf" stroke-width="4" marker-start="url(#context)" marker-mid="url(#context)" marker-end="url(#context)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-curves-arcs-subpaths.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-curves-arcs-subpaths.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 150">
+  <rect width="260" height="150" fill="#fff7ed"/>
+  <defs>
+    <marker id="diamond" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto" overflow="visible">
+      <path d="M5 0L10 5L5 10L0 5Z" fill="#f97316" stroke="#7c2d12"/>
+    </marker>
+  </defs>
+  <path d="M12 42 C28 4 58 4 74 42 Q94 82 114 42 A24 16 0 0 1 158 42 L190 18 L228 42"
+    fill="none" stroke="#9a3412" stroke-width="3" marker-start="url(#diamond)" marker-mid="url(#diamond)" marker-end="url(#diamond)"/>
+  <path d="M18 105 L18 105 C18 105 46 76 70 105 L70 105 L104 105 M132 105 A18 18 0 1 0 168 105 M190 105 H230 H190"
+    fill="none" stroke="#0f766e" stroke-width="3" marker-start="url(#diamond)" marker-mid="url(#diamond)" marker-end="url(#diamond)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-invalid-references.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-invalid-references.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 110">
+  <rect width="240" height="110" fill="#fef2f2"/>
+  <defs>
+    <path id="wrong" d="M0 0h5"/>
+    <marker id="cycle" markerWidth="8" markerHeight="8"><path d="M0 0L8 4L0 8Z" fill="#dc2626" marker-end="url(#cycle)"/></marker>
+    <marker id="valid" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="10" markerHeight="10" markerUnits="userSpaceOnUse"><circle cx="5" cy="5" r="4" fill="#16a34a"/></marker>
+  </defs>
+  <path d="M15 25H225" stroke="#991b1b" stroke-width="4" marker-start="url(#missing)" marker-mid="url(#wrong)" marker-end="url(#cycle)"/>
+  <polyline points="15,60 80,90 150,60 225,90" fill="none" stroke="#166534" stroke-width="4" marker-start="url(#valid)" marker-mid="url(#missing)" marker-end="url(#valid)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-orientation-angles.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-orientation-angles.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 125">
+  <rect width="240" height="125" fill="#f5f3ff"/>
+  <defs>
+    <marker id="auto-reverse" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="12" markerHeight="12" markerUnits="userSpaceOnUse" orient="auto-start-reverse" overflow="visible"><path d="M1 1L9 5L1 9Z" fill="#7c3aed"/></marker>
+    <marker id="deg" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="12" markerHeight="12" markerUnits="userSpaceOnUse" orient="45deg" overflow="visible"><path d="M1 1L9 5L1 9Z" fill="#dc2626"/></marker>
+    <marker id="rad" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="12" markerHeight="12" markerUnits="userSpaceOnUse" orient="1.5707963267948966rad" overflow="visible"><path d="M1 1L9 5L1 9Z" fill="#ea580c"/></marker>
+    <marker id="grad" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="12" markerHeight="12" markerUnits="userSpaceOnUse" orient="100grad" overflow="visible"><path d="M1 1L9 5L1 9Z" fill="#0891b2"/></marker>
+    <marker id="turn" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="12" markerHeight="12" markerUnits="userSpaceOnUse" orient=".75turn" overflow="visible"><path d="M1 1L9 5L1 9Z" fill="#16a34a"/></marker>
+  </defs>
+  <path d="M20 25H105" stroke="#4c1d95" stroke-width="3" marker-start="url(#auto-reverse)" marker-end="url(#auto-reverse)"/>
+  <path d="M135 25H220" stroke="#991b1b" stroke-width="3" marker-start="url(#deg)" marker-end="url(#deg)"/>
+  <path d="M35 70H95" stroke="#9a3412" stroke-width="3" marker-start="url(#rad)" marker-end="url(#rad)"/>
+  <path d="M120 70H180" stroke="#155e75" stroke-width="3" marker-start="url(#grad)" marker-end="url(#grad)"/>
+  <path d="M65 108H175" stroke="#166534" stroke-width="3" marker-start="url(#turn)" marker-end="url(#turn)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-paint-order-opacity.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-paint-order-opacity.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 270 120">
+  <rect width="270" height="120" fill="#f8fafc"/>
+  <defs>
+    <marker id="large" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="24" markerHeight="24" markerUnits="userSpaceOnUse" orient="auto" overflow="visible">
+      <circle cx="5" cy="5" r="5" fill="#f59e0b" fill-opacity=".7" stroke="#78350f" stroke-width="1.5"/>
+    </marker>
+  </defs>
+  <polygon points="20,25 70,15 95,55 55,85 15,60" fill="#60a5fa" stroke="#1e3a8a" stroke-width="10" opacity=".8" marker-start="url(#large)" marker-mid="url(#large)" marker-end="url(#large)"/>
+  <polygon points="105,25 155,15 180,55 140,85 100,60" fill="#60a5fa" stroke="#1e3a8a" stroke-width="10" opacity=".8" paint-order="markers fill stroke" marker-start="url(#large)" marker-mid="url(#large)" marker-end="url(#large)"/>
+  <polygon points="190,25 240,15 265,55 225,85 185,60" fill="#60a5fa" stroke="#1e3a8a" stroke-width="10" opacity=".8" paint-order="stroke markers fill" marker-start="url(#large)" marker-mid="url(#large)" marker-end="url(#large)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-primitives.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-primitives.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 140">
+  <rect width="240" height="140" fill="#f8fafc"/>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="9" markerHeight="9" markerUnits="userSpaceOnUse" orient="auto" overflow="visible">
+      <path d="M1 1L9 5L1 9Z" fill="#ef4444" stroke="#7f1d1d" stroke-width="1"/>
+    </marker>
+    <marker id="dot" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="8" markerHeight="8" markerUnits="userSpaceOnUse">
+      <circle cx="5" cy="5" r="4" fill="#22c55e" stroke="#14532d"/>
+    </marker>
+  </defs>
+  <line x1="15" y1="20" x2="105" y2="20" stroke="#1e3a8a" stroke-width="3" marker-start="url(#arrow)"/>
+  <line x1="135" y1="20" x2="225" y2="20" stroke="#1e3a8a" stroke-width="3" marker-end="url(#arrow)"/>
+  <polyline points="15,55 55,38 95,55" fill="none" stroke="#2563eb" stroke-width="3" marker-mid="url(#dot)"/>
+  <polygon points="135,55 180,35 225,55 205,85 155,85" fill="#bfdbfe" stroke="#1d4ed8" stroke-width="3" marker-start="url(#arrow)" marker-mid="url(#dot)" marker-end="url(#arrow)"/>
+  <path d="M77 108A22 22 0 0 1 55 130A22 22 0 0 1 33 108A22 22 0 0 1 55 86A22 22 0 0 1 77 108Z" fill="none" stroke="#7c3aed" stroke-width="2" marker-start="url(#arrow)" marker-mid="url(#dot)" marker-end="url(#arrow)"/>
+  <path d="M149 94H206A9 9 0 0 1 215 103V115A9 9 0 0 1 206 124H149A9 9 0 0 1 140 115V103A9 9 0 0 1 149 94Z" fill="none" stroke="#0891b2" stroke-width="2" marker-start="url(#arrow)" marker-mid="url(#dot)" marker-end="url(#arrow)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-resource-content.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-resource-content.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 140">
+  <rect width="260" height="140" fill="#f0fdf4"/>
+  <defs>
+    <linearGradient id="marker-gradient" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#facc15"/><stop offset="1" stop-color="#dc2626"/></linearGradient>
+    <pattern id="marker-pattern" width="4" height="4" patternUnits="userSpaceOnUse"><rect width="2" height="4" fill="#0ea5e9"/><rect x="2" width="2" height="4" fill="#e0f2fe"/></pattern>
+    <path id="petal" d="M5 1C8 1 9 4 5 7C1 4 2 1 5 1Z"/>
+    <marker id="resource" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="18" markerHeight="18" markerUnits="userSpaceOnUse" orient="auto" overflow="visible">
+      <g stroke="#713f12" stroke-width=".6"><use href="#petal" fill="url(#marker-gradient)"/><use href="#petal" fill="url(#marker-pattern)" transform="rotate(180 5 5)"/></g>
+    </marker>
+  </defs>
+  <path d="M20 35C70 5 100 65 130 35S205 5 240 35" fill="none" stroke="#166534" stroke-width="4" marker-start="url(#resource)" marker-mid="url(#resource)" marker-end="url(#resource)"/>
+  <polygon points="35,100 80,75 125,100 80,125" fill="#bbf7d0" stroke="#15803d" stroke-width="3" marker-start="url(#resource)" marker-mid="url(#resource)" marker-end="url(#resource)"/>
+  <polyline points="155,115 180,78 210,118 240,82" fill="none" stroke="#0369a1" stroke-width="3" marker-start="url(#resource)" marker-mid="url(#resource)" marker-end="url(#resource)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-transforms-overflow.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-transforms-overflow.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 150">
+  <rect width="260" height="150" fill="#fff7ed"/>
+  <defs>
+    <marker id="hidden" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="18" markerHeight="18" markerUnits="userSpaceOnUse" orient="auto">
+      <g transform="rotate(20 5 5)"><rect x="-4" y="2" width="18" height="6" fill="#dc2626"/><circle cx="5" cy="5" r="3" fill="#fef2f2"/></g>
+    </marker>
+    <marker id="visible" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="18" markerHeight="18" markerUnits="userSpaceOnUse" orient="auto" overflow="visible">
+      <g transform="rotate(20 5 5)"><rect x="-4" y="2" width="18" height="6" fill="#2563eb"/><circle cx="5" cy="5" r="3" fill="#eff6ff"/></g>
+    </marker>
+  </defs>
+  <g transform="translate(30 5) rotate(12 90 45) scale(1.15 .8)">
+    <path d="M5 45C45 5 100 85 145 45" fill="none" stroke="#9a3412" stroke-width="4" marker-start="url(#hidden)" marker-mid="url(#hidden)" marker-end="url(#hidden)"/>
+  </g>
+  <g transform="translate(15 70) skewX(-12)">
+    <polyline points="20,35 80,8 140,35 200,8" fill="none" stroke="#1e40af" stroke-width="4" marker-start="url(#visible)" marker-mid="url(#visible)" marker-end="url(#visible)"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-units-ref-points.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-units-ref-points.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 150">
+  <rect width="260" height="150" fill="#ecfeff"/>
+  <defs>
+    <marker id="stroke" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="4" markerHeight="4" markerUnits="strokeWidth" orient="auto" overflow="visible"><path d="M0 1L10 5L0 9Z" fill="#0e7490" opacity=".8"/></marker>
+    <marker id="user" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="16" markerHeight="16" markerUnits="userSpaceOnUse" orient="auto" overflow="visible"><path d="M0 1L10 5L0 9Z" fill="#c2410c" opacity=".8"/></marker>
+    <marker id="left" viewBox="-5 -5 10 10" refX="-5" refY="-5" markerWidth="18" markerHeight="18" markerUnits="userSpaceOnUse" overflow="visible"><circle cx="0" cy="0" r="4" fill="#7c3aed"/></marker>
+    <marker id="center" viewBox="-5 -5 10 10" refX="0" refY="0" markerWidth="18" markerHeight="18" markerUnits="userSpaceOnUse" overflow="visible"><circle cx="0" cy="0" r="4" fill="#16a34a"/></marker>
+  </defs>
+  <path d="M20 25H115" stroke="#164e63" stroke-width="2" marker-end="url(#stroke)"/>
+  <path d="M145 25H240" stroke="#164e63" stroke-width="7" marker-end="url(#stroke)"/>
+  <path d="M20 72H115" stroke="#9a3412" stroke-width="2" marker-end="url(#user)"/>
+  <path d="M145 72H240" stroke="#9a3412" stroke-width="7" marker-end="url(#user)"/>
+  <path d="M30 122H100" stroke="#4c1d95" stroke-width="2" marker-start="url(#left)"/>
+  <path d="M160 122H230" stroke="#166534" stroke-width="2" marker-start="url(#center)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-viewbox-preserve-aspect.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/marker-viewbox-preserve-aspect.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 150">
+  <rect width="300" height="150" fill="#f8fafc"/>
+  <defs>
+    <g id="content"><rect width="10" height="20" fill="#dbeafe"/><circle cx="2" cy="3" r="2" fill="#dc2626"/><path d="M1 18L9 12" stroke="#1d4ed8" stroke-width="1.5"/></g>
+    <marker id="none" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="none"><use href="#content"/></marker>
+    <marker id="xmin-ymin" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="xMinYMin meet"><use href="#content"/></marker>
+    <marker id="xmid-ymin" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="xMidYMin meet"><use href="#content"/></marker>
+    <marker id="xmax-ymin" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="xMaxYMin meet"><use href="#content"/></marker>
+    <marker id="xmin-ymid" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="xMinYMid meet"><use href="#content"/></marker>
+    <marker id="xmid-ymid" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="xMidYMid meet"><use href="#content"/></marker>
+    <marker id="xmax-ymid" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="xMaxYMid meet"><use href="#content"/></marker>
+    <marker id="xmin-ymax" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="xMinYMax meet"><use href="#content"/></marker>
+    <marker id="xmid-ymax" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="xMidYMax meet"><use href="#content"/></marker>
+    <marker id="xmax-ymax" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="xMaxYMax meet"><use href="#content"/></marker>
+    <marker id="slice" viewBox="0 0 10 20" refX="5" refY="10" markerWidth="24" markerHeight="18" markerUnits="userSpaceOnUse" preserveAspectRatio="xMidYMid slice"><use href="#content"/></marker>
+  </defs>
+  <g fill="none" stroke="#64748b">
+    <path d="M30 28h1" marker-end="url(#none)"/><path d="M90 28h1" marker-end="url(#xmin-ymin)"/><path d="M150 28h1" marker-end="url(#xmid-ymin)"/><path d="M210 28h1" marker-end="url(#xmax-ymin)"/>
+    <path d="M30 75h1" marker-end="url(#xmin-ymid)"/><path d="M90 75h1" marker-end="url(#xmid-ymid)"/><path d="M150 75h1" marker-end="url(#xmax-ymid)"/><path d="M210 75h1" marker-end="url(#slice)"/>
+    <path d="M50 122h1" marker-end="url(#xmin-ymax)"/><path d="M120 122h1" marker-end="url(#xmid-ymax)"/><path d="M190 122h1" marker-end="url(#xmax-ymax)"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/run-visual-tests.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/run-visual-tests.ts
@@ -2,9 +2,9 @@
 /** Full-color SVG-to-SwiftUI visual regression runner. */
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { Resvg } from "@resvg/resvg-js";
 import { convert } from "../src/index";
 import { type BatchTestItem, type BatchTestResult, runBatchVisualTest } from "./batch-render";
@@ -16,6 +16,12 @@ const REFERENCE_CACHE_PATH = resolve(RENDERS_DIR, ".reference-cache.json");
 const REFERENCE_RENDERER_VERSION = "rgba-resvg-v1";
 const WEBKIT_RENDERER_SOURCE = resolve(__dirname, "webkit-reference-render.swift");
 const WEBKIT_RENDERER_BINARY = resolve(RENDERS_DIR, ".cache", "webkit-reference-render");
+const FIREFOX_RENDERER_BINARY = [
+  process.env.FIREFOX_BIN,
+  "/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox",
+  "/Applications/Firefox.app/Contents/MacOS/firefox",
+].find((candidate): candidate is string => !!candidate && existsSync(candidate));
+const FIREFOX_REFERENCE_VERSION = "rgba-firefox-developer-edition-v1";
 let webKitRendererReady = false;
 
 function ensureWebKitRenderer(): void {
@@ -45,6 +51,36 @@ function renderWebKitReference(
     WEBKIT_RENDERER_BINARY,
     [inputPath, outputPath, String(width), String(height), String(pixelWidth), String(pixelHeight)],
     { stdio: "pipe" },
+  );
+}
+
+function renderFirefoxReference(
+  source: string,
+  name: string,
+  outputPath: string,
+  pixelWidth: number,
+  pixelHeight: number,
+): void {
+  if (!FIREFOX_RENDERER_BINARY)
+    throw new Error("Firefox reference renderer was not found. Set FIREFOX_BIN to its executable path.");
+  const cacheDirectory = resolve(RENDERS_DIR, ".cache");
+  const inputPath = resolve(cacheDirectory, `${name}-firefox-source.svg`);
+  const profilePath = resolve(cacheDirectory, "firefox-profile");
+  mkdirSync(profilePath, { recursive: true });
+  writeFileSync(inputPath, withPixelViewport(source, pixelWidth, pixelHeight));
+  if (existsSync(outputPath)) unlinkSync(outputPath);
+  execFileSync(
+    FIREFOX_RENDERER_BINARY,
+    [
+      "--headless",
+      "--no-remote",
+      "--profile",
+      profilePath,
+      `--screenshot=${outputPath}`,
+      `--window-size=${pixelWidth},${pixelHeight}`,
+      pathToFileURL(inputPath).href,
+    ],
+    { stdio: "pipe", timeout: 15_000 },
   );
 }
 
@@ -163,7 +199,9 @@ async function main() {
       const pixelWidth = Math.round(fixture.width * fixture.scale);
       const pixelHeight = Math.round(fixture.height * fixture.scale);
       const resourceBytes = fixture.fonts.map((font) => readFileSync(resolve(__dirname, font)));
-      const usesWebKitReference = fixture.tags.includes("blend-mode") || fixture.tags.includes("vector-effect");
+      const usesFirefoxReference = fixture.tags.includes("marker");
+      const usesWebKitReference =
+        !usesFirefoxReference && (fixture.tags.includes("blend-mode") || fixture.tags.includes("vector-effect"));
       if (usesWebKitReference) resourceBytes.push(readFileSync(WEBKIT_RENDERER_SOURCE));
       for (const match of source.matchAll(/<image\b[^>]*\b(?:href|xlink:href)\s*=\s*["']([^"']+)["']/gi)) {
         const href = match[1]!;
@@ -172,7 +210,11 @@ async function main() {
       const referenceHash = hash(
         source,
         JSON.stringify({
-          renderer: usesWebKitReference ? "rgba-webkit-v2" : REFERENCE_RENDERER_VERSION,
+          renderer: usesFirefoxReference
+            ? FIREFOX_REFERENCE_VERSION
+            : usesWebKitReference
+              ? "rgba-webkit-v2"
+              : REFERENCE_RENDERER_VERSION,
           pixelWidth,
           pixelHeight,
           background: fixture.background,
@@ -183,7 +225,9 @@ async function main() {
       if (!fresh && referenceCache[fixture.name]?.hash === referenceHash && existsSync(referencePath)) {
         referenceCacheHits++;
       } else {
-        if (usesWebKitReference) {
+        if (usesFirefoxReference) {
+          renderFirefoxReference(source, fixture.name, referencePath, pixelWidth, pixelHeight);
+        } else if (usesWebKitReference) {
           renderWebKitReference(
             source,
             fixture.name,

--- a/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/update-manifest.ts
@@ -58,6 +58,7 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   if (name.startsWith("gradient-")) tags.add("gradient");
   if (name.startsWith("pattern-")) tags.add("pattern");
   if (name.startsWith("mask-")) tags.add("mask");
+  if (name.startsWith("marker-")) tags.add("marker");
   if (name.startsWith("clip-")) tags.add("clip-path");
   if (name.startsWith("blend-")) tags.add("blend-mode");
   if (name.startsWith("viewport-")) tags.add("viewport");
@@ -76,6 +77,7 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
     "stop",
     "pattern",
     "mask",
+    "marker",
     "clipPath",
     "use",
     "symbol",
@@ -101,6 +103,12 @@ function tagsFor(name: string, source: string, expectedMode: "shape" | "view"): 
   if (/\bvisibility\s*(?:=|:)/.test(source)) tags.add("visibility");
   if (/\bdisplay\s*(?:=|:)/.test(source)) tags.add("display");
   if (/\bpaint-order\s*(?:=|:)/.test(source)) tags.add("paint-order");
+  if (/\bmarker-start\s*(?:=|:)/.test(source)) tags.add("marker-start");
+  if (/\bmarker-mid\s*(?:=|:)/.test(source)) tags.add("marker-mid");
+  if (/\bmarker-end\s*(?:=|:)/.test(source)) tags.add("marker-end");
+  if (/\bmarkerUnits\s*=/.test(source)) tags.add("marker-units");
+  if (/\borient\s*=/.test(source)) tags.add("marker-orient");
+  if (/\bcontext-(?:fill|stroke)\b/.test(source)) tags.add("context-paint");
   if (/\bgradientUnits\s*=/.test(source)) tags.add("gradient-units");
   if (/\bgradientTransform\s*=/.test(source)) tags.add("gradient-transform");
   if (/\bspreadMethod\s*=/.test(source)) tags.add("gradient-spread");


### PR DESCRIPTION
Closes #61

## What changed

- add typed marker resources and local reference diagnostics
- materialize complete marker shadow trees for start, mid, and end vertices
- implement line, curve, arc, zero-length, closed-path, and multi-subpath tangent orientation
- support auto, auto-start-reverse, angle units, marker units, ref points, viewBox mapping, overflow, and context paint
- integrate markers with paint order, host opacity/clipping/masking, capability analysis, and painted bounds
- add Firefox-backed SVG 2 marker references plus 10 deterministic RGBA fixtures

## Validation

- `bun run test` — 183 tests passed across the core and CLI suites
- `bun run build`
- core lint and typecheck
- visual manifest verification — 1,871 fixtures
- full macOS RGBA suite — 1,871 passed, 0 failed
