### PR TITLE
Add static SVG accessibility and switch semantics

### DIFF
--- a/.changeset/static-svg-accessibility-switch.md
+++ b/.changeset/static-svg-accessibility-switch.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Preserve SVG-AAM accessibility semantics in generated SwiftUI and resolve switch and conditional-processing attributes deterministically through an explicit static environment.

--- a/packages/svg-to-swiftui-core/CHANGELOG.md
+++ b/packages/svg-to-swiftui-core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Minor Changes
 
+- Preserve SVG accessibility names, descriptions, hidden state, and roles in generated SwiftUI, and add deterministic static `<switch>`/conditional processing through an explicit environment.
 - Add secure async `<foreignObject>` snapshot rendering, deterministic artifacts, diagnostics, compositing, and accessibility metadata.
 - Add static `<image>` rendering for PNG, JPEG, WebP, first-frame GIF, and recursively scoped SVG resources.
 - Add deterministic embedded/local/custom resource policies, sync and async conversion APIs, structured diagnostics, traversal/cycle protection, and configurable byte/pixel/count/depth limits.

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -140,6 +140,26 @@ Snapshots preserve transparent backgrounds, exact x/y/width/height, transforms, 
 
 Normal `convertAsync()` embeds PNG bytes. For large snapshots, use `convertAsyncWithArtifacts()` and `foreignObjects.inlineByteLimit`; its result contains Swift source plus deterministic content-addressed PNG assets for the generated app target.
 
+### Accessibility and conditional processing
+
+Static accessibility follows SVG-AAM naming precedence for `aria-labelledby`, `aria-label`, `<title>`, `<desc>`, and meaningful text. Multiple ID references, inherited `aria-hidden`, roles, and `lang`/`xml:lang` localized descriptive elements are resolved onto the closest generated SwiftUI view. Names use `.accessibilityLabel`, descriptions use `.accessibilityHint`, and recognized roles add matching traits. Named document/group containers retain their accessible children. Accessibility metadata automatically selects the `View` backend so the single-shape fast path cannot discard it. Broken or cyclic ARIA references produce structured diagnostics; `<title>`, `<desc>`, and `<metadata>` never draw pixels.
+
+`<switch>` and conditional attributes use an explicit static environment instead of the machine locale:
+
+```ts
+convert(svg, {
+  staticEnvironment: {
+    preferredLanguages: ["lt-LT", "en"],
+    accessibilityLocale: "lt-LT",
+    supportedExtensions: ["https://example.com/svg/extension"],
+    svgVersion: "1.1",
+    supportedFeatures: ["http://www.w3.org/TR/SVG11/feature#Shape"],
+  },
+});
+```
+
+Children are checked in document order. `requiredExtensions` requires every listed identifier, and `systemLanguage` uses BCP 47 prefix matching. Unknown extensions and SVG 1.1 features are unsupported. SVG 2 treats obsolete `requiredFeatures` as non-blocking and reports a diagnostic. Conditional attributes outside `<switch>` also suppress unmatched content, including referenced resources.
+
 ## Before we start
 
 This package is written for JavaScript projects, so it's only meant to be used in a Node.js projects. If you just need to convert an SVG to SwiftUI Shape you should use [this tool](https://github.com/bring-shrubbery/SVG-to-SwiftUI).

--- a/packages/svg-to-swiftui-core/src/renderTree/accessibility.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/accessibility.ts
@@ -1,0 +1,228 @@
+import type { ElementNode, Node } from "svg-parser";
+import type { ResolvedStaticEnvironment } from "./conditionalProcessing";
+import { languagePreferenceMatches } from "./conditionalProcessing";
+import type { AccessibilityMetadata, RenderDiagnostic, SourceLocation } from "./types";
+
+interface AccessibilityResources {
+  definitions: Map<string, ElementNode>;
+  parents: Map<ElementNode, ElementNode>;
+}
+
+function sourceLocation(element: ElementNode): SourceLocation {
+  const id = element.properties?.id;
+  return { element: element.tagName ?? "unknown", ...(id === undefined ? {} : { id: String(id) }) };
+}
+
+function attribute(element: ElementNode, name: string): { present: boolean; value: string } {
+  const entry = Object.entries(element.properties ?? {}).find(([key]) => key.toLowerCase() === name.toLowerCase());
+  return entry ? { present: true, value: String(entry[1] ?? "") } : { present: false, value: "" };
+}
+
+function childElements(element: ElementNode): ElementNode[] {
+  return element.children.filter(
+    (child): child is ElementNode => typeof child !== "string" && child.type === "element",
+  );
+}
+
+function decoded(value: string): string {
+  const named: Record<string, string> = { amp: "&", apos: "'", gt: ">", lt: "<", quot: '"', nbsp: " " };
+  return value
+    .replace(/&#x([\da-f]+);/gi, (_match, code: string) => String.fromCodePoint(Number.parseInt(code, 16)))
+    .replace(/&#(\d+);/g, (_match, code: string) => String.fromCodePoint(Number.parseInt(code, 10)))
+    .replace(/&([a-z]+);/gi, (match, name: string) => named[name.toLowerCase()] ?? match);
+}
+
+function normalizedText(value: string): string {
+  return decoded(value).replace(/\s+/g, " ").trim();
+}
+
+function nodeText(node: Node | string): string {
+  if (typeof node === "string") return node;
+  if (node.type === "text") return String(node.value ?? "");
+  if (node.type !== "element") return "";
+  const tag = (node.tagName ?? "").toLowerCase();
+  if (["title", "desc", "script", "style", "metadata"].includes(tag)) return "";
+  return node.children.map(nodeText).join(" ");
+}
+
+function subtreeText(element: ElementNode): string {
+  return normalizedText(element.children.map(nodeText).join(" "));
+}
+
+/** Computes SVG-AAM name/description metadata once for every renderable source element. */
+export class SVGAccessibilityResolver {
+  private readonly cache = new Map<ElementNode, AccessibilityMetadata | undefined>();
+  private readonly diagnosed = new Set<string>();
+  private readonly languagePreferences: readonly string[];
+
+  constructor(
+    private readonly resources: AccessibilityResources,
+    environment: ResolvedStaticEnvironment,
+    private readonly diagnostics: RenderDiagnostic[],
+  ) {
+    this.languagePreferences = [
+      ...(environment.accessibilityLocale ? [environment.accessibilityLocale] : []),
+      ...environment.preferredLanguages.filter(
+        (language) => language.toLowerCase() !== environment.accessibilityLocale?.toLowerCase(),
+      ),
+    ];
+  }
+
+  private diagnose(element: ElementNode, code: string, message: string): void {
+    const source = sourceLocation(element);
+    const key = `${code}:${source.element}:${source.id ?? ""}:${message}`;
+    if (this.diagnosed.has(key)) return;
+    this.diagnosed.add(key);
+    this.diagnostics.push({ code, message, severity: "warning", source });
+  }
+
+  private effectiveLanguage(element: ElementNode): string {
+    let current: ElementNode | undefined = element;
+    while (current) {
+      const xml = attribute(current, "xml:lang");
+      if (xml.present) return xml.value.trim();
+      const plain = attribute(current, "lang");
+      if (plain.present) return plain.value.trim();
+      current = this.resources.parents.get(current);
+    }
+    return "";
+  }
+
+  private selectedDescription(element: ElementNode, tag: "title" | "desc"): ElementNode | undefined {
+    const candidates = childElements(element).filter((child) => child.tagName?.toLowerCase() === tag);
+    if (this.languagePreferences.length === 0) return candidates[0];
+    for (const preference of this.languagePreferences) {
+      const exact = candidates.find(
+        (candidate) => this.effectiveLanguage(candidate).toLowerCase() === preference.trim().toLowerCase(),
+      );
+      if (exact) return exact;
+      const regional = candidates.find((candidate) =>
+        languagePreferenceMatches(preference, this.effectiveLanguage(candidate)),
+      );
+      if (regional) return regional;
+      const generic = candidates.find((candidate) =>
+        languagePreferenceMatches(this.effectiveLanguage(candidate), preference),
+      );
+      if (generic) return generic;
+    }
+    return candidates.find((candidate) => this.effectiveLanguage(candidate) === "") ?? candidates[0];
+  }
+
+  private hidden(element: ElementNode): boolean {
+    let current: ElementNode | undefined = element;
+    while (current) {
+      if (attribute(current, "aria-hidden").value.trim().toLowerCase() === "true") return true;
+      current = this.resources.parents.get(current);
+    }
+    return false;
+  }
+
+  private fallbackName(element: ElementNode): string {
+    const ariaLabel = normalizedText(attribute(element, "aria-label").value);
+    if (ariaLabel) return ariaLabel;
+    const title = this.selectedDescription(element, "title");
+    const titleText = title ? subtreeText(title) : "";
+    return titleText || subtreeText(element);
+  }
+
+  private referencedName(element: ElementNode, owner: ElementNode, stack: ElementNode[]): string {
+    if (stack.includes(element)) {
+      this.diagnose(owner, "cyclic-accessibility-reference", "A cyclic ARIA ID reference was ignored.");
+      return "";
+    }
+    const labelledBy = attribute(element, "aria-labelledby");
+    if (labelledBy.present && labelledBy.value.trim()) {
+      const nested = this.referenceText(element, "aria-labelledby", owner, [...stack, element]);
+      if (nested) return nested;
+    }
+    return this.fallbackName(element);
+  }
+
+  private referenceText(
+    element: ElementNode,
+    attributeName: "aria-labelledby" | "aria-describedby",
+    owner = element,
+    stack: ElementNode[] = [element],
+  ): string {
+    const raw = attribute(element, attributeName).value;
+    const values: string[] = [];
+    for (const id of raw.trim().split(/\s+/).filter(Boolean)) {
+      const target = this.resources.definitions.get(id);
+      if (!target) {
+        this.diagnose(element, "broken-accessibility-reference", `${attributeName} references missing element #${id}.`);
+        continue;
+      }
+      if (target === element) {
+        const fallback = this.fallbackName(target);
+        if (fallback) values.push(fallback);
+        continue;
+      }
+      const value = this.referencedName(target, owner, stack);
+      if (value) values.push(value);
+    }
+    return normalizedText(values.join(" "));
+  }
+
+  resolve(element: ElementNode): AccessibilityMetadata | undefined {
+    if (this.cache.has(element)) return this.cache.get(element);
+
+    const hidden = this.hidden(element);
+    const roleValue = attribute(element, "role").value.trim().split(/\s+/)[0]?.toLowerCase();
+    const labelledBy = attribute(element, "aria-labelledby");
+    const ariaLabel = normalizedText(attribute(element, "aria-label").value);
+    const title = this.selectedDescription(element, "title");
+    const titleText = title ? subtreeText(title) : "";
+    const tag = (element.tagName ?? "").toLowerCase();
+    const meaningfulText = tag === "text" ? subtreeText(element) : "";
+
+    let label = labelledBy.present ? this.referenceText(element, "aria-labelledby") : "";
+    let labelSource: "labelledby" | "label" | "title" | "text" | undefined = label ? "labelledby" : undefined;
+    if (!label && ariaLabel) {
+      label = ariaLabel;
+      labelSource = "label";
+    }
+    if (!label && titleText) {
+      label = titleText;
+      labelSource = "title";
+    }
+    if (!label && meaningfulText) {
+      label = meaningfulText;
+      labelSource = "text";
+    }
+
+    const describedBy = attribute(element, "aria-describedby");
+    let description = describedBy.present ? this.referenceText(element, "aria-describedby") : "";
+    if (!description) {
+      const desc = this.selectedDescription(element, "desc");
+      description = desc ? subtreeText(desc) : "";
+    }
+    if (!description && meaningfulText && labelSource !== "text") description = meaningfulText;
+    if (!description && titleText && (labelSource === "labelledby" || labelSource === "label")) description = titleText;
+
+    let role = roleValue;
+    if (!role && tag === "a" && (attribute(element, "href").present || attribute(element, "xlink:href").present))
+      role = "link";
+    if (!role && (label || description)) {
+      if (tag === "svg") role = "graphics-document";
+      else if (tag === "g" || tag === "switch" || tag === "use") role = "graphics-object";
+      else if (
+        ["path", "circle", "ellipse", "rect", "line", "polyline", "polygon", "image", "foreignobject"].includes(tag)
+      )
+        role = "graphics-symbol";
+      else if (tag === "text") role = "text";
+    }
+
+    const selectedLanguage =
+      label || description ? (title ? this.effectiveLanguage(title) : this.effectiveLanguage(element)) : "";
+    const metadata: AccessibilityMetadata = {
+      ...(label ? { label } : {}),
+      ...(description ? { description } : {}),
+      ...(hidden ? { hidden: true } : {}),
+      ...(role ? { role } : {}),
+      ...(selectedLanguage ? { language: selectedLanguage } : {}),
+    };
+    const result = Object.keys(metadata).length > 0 ? metadata : undefined;
+    this.cache.set(element, result);
+    return result;
+  }
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -24,7 +24,9 @@ import { type AffineTransform, IDENTITY_TRANSFORM, multiplyTransforms, parseTran
 import type { SVGElementProperties, ViewBoxData } from "../types";
 import { getSVGElement, resolveSVGProperties } from "../utils";
 import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio, parseViewBox, viewBoxTransform } from "../viewports";
+import { SVGAccessibilityResolver } from "./accessibility";
 import { resolveClipPathInstance, resolveClipPathResources } from "./clips";
+import { SVGConditionalProcessor } from "./conditionalProcessing";
 import { resolvePaintServers } from "./gradients";
 import { markerVertices, orientedMarkerAngle, resolveMarkerResources } from "./markers";
 import { resolveMaskInstance, resolveMaskResources } from "./masks";
@@ -70,6 +72,9 @@ interface BuildContext {
   activeReferences: Set<string>;
   styleResolver: SVGStyleResolver;
   config: InternalGeneratorConfig;
+  conditional: SVGConditionalProcessor;
+  accessibility: SVGAccessibilityResolver;
+  includeAccessibility: boolean;
 }
 
 const GEOMETRY_ELEMENTS = new Set(["path", "circle", "ellipse", "rect", "line", "polyline", "polygon"]);
@@ -112,6 +117,11 @@ function addDiagnostic(
     source: sourceLocation(element),
     ...(css ? { css } : {}),
   });
+}
+
+function semanticProperties(element: ElementNode, context: BuildContext) {
+  const accessibility = context.includeAccessibility ? context.accessibility.resolve(element) : undefined;
+  return accessibility ? { accessibility } : {};
 }
 
 function parsePaint(value: unknown, currentColor: string): Paint {
@@ -1496,6 +1506,7 @@ function buildText(
       rootViewport: { ...coordinate.rootViewport },
       fontMetrics: { ...resolved.fontMetrics },
     },
+    ...semanticProperties(element, context),
   };
 }
 
@@ -1695,6 +1706,7 @@ function buildImage(
       rootViewport: { ...coordinate.rootViewport },
       fontMetrics: { ...resolved.fontMetrics },
     },
+    ...semanticProperties(element, context),
   };
 }
 
@@ -1708,6 +1720,12 @@ function buildForeignObject(
   const key = foreignObjectKey(element, context.resources.parents);
   const snapshot = foreignObjectSnapshotDocument(element, context.resources.parents, viewport, resolved.effective);
   const prepared = context.config.__foreignObjectSnapshots?.get(key);
+  const accessibility = context.includeAccessibility
+    ? (context.accessibility.resolve(element) ??
+      (snapshot.accessibilityLabel
+        ? { label: snapshot.accessibilityLabel, role: "graphics-symbol" as const }
+        : undefined))
+    : undefined;
 
   if (!context.config.__preparingForeignObjects && viewport.width > 0 && viewport.height > 0) {
     if (prepared) {
@@ -1751,6 +1769,7 @@ function buildForeignObject(
       rootViewport: { ...coordinate.rootViewport },
       fontMetrics: { ...resolved.fontMetrics },
     },
+    ...(accessibility ? { accessibility } : {}),
   };
 }
 
@@ -1844,6 +1863,7 @@ function buildGroup(
       rootViewport: { ...coordinate.rootViewport },
       fontMetrics: { ...resolved.fontMetrics },
     },
+    ...semanticProperties(element, context),
     ...(referenceId ? { referenceId } : {}),
   };
 }
@@ -1880,6 +1900,7 @@ function buildNestedSVG(
       rootViewport: { ...coordinate.rootViewport },
       fontMetrics: { ...resolved.fontMetrics },
     },
+    ...semanticProperties(element, context),
     viewport: {
       rect,
       ...(viewBox ? { viewBox } : {}),
@@ -1941,6 +1962,7 @@ function buildViewportUse(
       rootViewport: { ...childCoordinate.rootViewport },
       fontMetrics: { ...referencedResolved.fontMetrics },
     },
+    ...semanticProperties(referenced, childContext),
     referenceId: id,
   };
   return {
@@ -1954,6 +1976,7 @@ function buildViewportUse(
       rootViewport: { ...coordinate.rootViewport },
       fontMetrics: { ...useResolved.fontMetrics },
     },
+    ...semanticProperties(use, context),
     referenceId: id,
     viewport: {
       rect,
@@ -2006,6 +2029,7 @@ function buildUse(
         rootViewport: { ...coordinate.rootViewport },
         fontMetrics: { ...resolved.fontMetrics },
       },
+      ...semanticProperties(element, context),
       referenceId: id,
     },
   ];
@@ -2019,11 +2043,14 @@ function buildNode(
 ): RenderNode[] {
   const tag = element.tagName ?? "unknown";
   if (NON_RENDERING_ELEMENTS.has(tag)) return [];
+  if (!context.conditional.matches(element)) return [];
   if (tag === "use") return buildUse(element, inherited, coordinate, context);
   if (tag === "svg") return [buildNestedSVG(element, inherited, coordinate, context)];
   if (tag === "switch") {
-    const first = childElements(element)[0];
-    return [buildGroup(element, inherited, coordinate, context, undefined, first ? [first] : [])];
+    const selected = childElements(element).find(
+      (child) => !NON_RENDERING_ELEMENTS.has(child.tagName ?? "unknown") && context.conditional.matches(child),
+    );
+    return [buildGroup(element, inherited, coordinate, context, undefined, selected ? [selected] : [])];
   }
   if (CONTAINER_ELEMENTS.has(tag)) return [buildGroup(element, inherited, coordinate, context)];
 
@@ -2044,6 +2071,7 @@ function buildNode(
               rootViewport: { ...coordinate.rootViewport },
               fontMetrics: { ...resolved.fontMetrics },
             },
+            ...semanticProperties(element, context),
           },
         ]
       : [];
@@ -2071,7 +2099,26 @@ export function buildRenderDocument(
   const resources = createRegistry(svg);
   const diagnostics = [...initialDiagnostics];
   const styleResolver = new SVGStyleResolver(svg, diagnostics);
-  const context: BuildContext = { resources, diagnostics, activeReferences: new Set(), styleResolver, config };
+  const conditional = new SVGConditionalProcessor(config.staticEnvironment, diagnostics);
+  const accessibility = new SVGAccessibilityResolver(resources, conditional.environment, diagnostics);
+  const context: BuildContext = {
+    resources,
+    diagnostics,
+    activeReferences: new Set(),
+    styleResolver,
+    config,
+    conditional,
+    accessibility,
+    includeAccessibility: true,
+  };
+  const diagnoseDynamicContent = (element: ElementNode): void => {
+    const tag = (element.tagName ?? "").toLowerCase();
+    if (tag === "script")
+      addDiagnostic(context, element, "unsupported-script", "SVG scripts are not executed by the static renderer.");
+    if (tag === "foreignobject") return;
+    for (const child of childElements(element)) diagnoseDynamicContent(child);
+  };
+  diagnoseDynamicContent(svg);
   const coordinate: CoordinateContext = {
     viewport: properties.userViewport,
     rootViewport: { width: properties.width, height: properties.height },
@@ -2115,9 +2162,10 @@ export function buildRenderDocument(
   const childCoordinate = { ...coordinate, fontMetrics: resolved.fontMetrics };
   const root: RenderGroup = {
     type: "group",
-    children: properties.zeroSized
-      ? []
-      : childElements(svg).flatMap((child) => buildNode(child, resolved.effective, childCoordinate, context)),
+    children:
+      properties.zeroSized || !conditional.matches(svg)
+        ? []
+        : childElements(svg).flatMap((child) => buildNode(child, resolved.effective, childCoordinate, context)),
     style: resolved.style,
     transform: rootTransform,
     source: sourceLocation(svg),
@@ -2126,6 +2174,7 @@ export function buildRenderDocument(
       rootViewport: { ...coordinate.rootViewport },
       fontMetrics: { ...resolved.fontMetrics },
     },
+    ...semanticProperties(svg, context),
   };
   const children: RenderNode[] = [root];
 
@@ -2267,6 +2316,7 @@ export function buildRenderDocument(
     const markerContext: BuildContext = {
       ...context,
       activeReferences: new Set(context.activeReferences).add(resource.id),
+      includeAccessibility: false,
     };
     const built: RenderNode[] = [];
     for (const content of resource.contentElements) {
@@ -2436,6 +2486,7 @@ export function buildRenderDocument(
     const patternContext: BuildContext = {
       ...context,
       activeReferences: new Set(context.activeReferences).add(pattern.id),
+      includeAccessibility: false,
     };
     const built: RenderNode[] = [];
     for (const content of pattern.contentElements) {
@@ -2592,6 +2643,7 @@ export function buildRenderDocument(
       const clipContext: BuildContext = {
         ...context,
         activeReferences: new Set(context.activeReferences).add(resource.id),
+        includeAccessibility: false,
       };
       const built: RenderNode[] = [];
       for (const content of resource.contentElements) {
@@ -2695,6 +2747,7 @@ export function buildRenderDocument(
       const maskContext: BuildContext = {
         ...context,
         activeReferences: new Set(context.activeReferences).add(resource.id),
+        includeAccessibility: false,
       };
       const built: RenderNode[] = [];
       for (const content of resource.contentElements) {

--- a/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
@@ -41,6 +41,15 @@ function containsGeneralViewContent(nodes: RenderNode[]): boolean {
   );
 }
 
+function containsAccessibility(nodes: RenderNode[]): boolean {
+  return nodes.some(
+    (node) =>
+      node.accessibility !== undefined ||
+      (node.type === "shape" && node.markers !== undefined && containsAccessibility(node.markers)) ||
+      (node.type === "group" && containsAccessibility(node.children)),
+  );
+}
+
 function containsViewportClip(nodes: RenderNode[]): boolean {
   return nodes.some(
     (node) =>
@@ -119,6 +128,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
     containsIndependentCompositing(document.children) || paints.some(({ paint }) => hasIntrinsicAlpha(paint));
   const needsNonScalingStroke = containsNonScalingStroke(document.children);
   const needsMarkers = containsMarkers(document.children);
+  const needsAccessibility = containsAccessibility(document.children);
 
   if (
     config.preserveColors === false &&
@@ -127,6 +137,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
     !needsIndependentCompositing &&
     !needsNonScalingStroke &&
     !needsMarkers &&
+    !needsAccessibility &&
     !containsGeneralViewContent(document.children)
   ) {
     return {
@@ -137,6 +148,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   }
 
   if (containsGeneralViewContent(document.children)) reasons.push("document contains non-geometry view content");
+  if (needsAccessibility) reasons.push("document contains static accessibility semantics");
   if (needsViewportClip) reasons.push("document contains a clipped nested viewport");
   if (hasGradientPaint) reasons.push("document uses an SVG gradient paint server");
   if (hasPatternPaint) reasons.push("document uses an SVG pattern paint server");

--- a/packages/svg-to-swiftui-core/src/renderTree/conditionalProcessing.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/conditionalProcessing.ts
@@ -1,0 +1,108 @@
+import type { ElementNode } from "svg-parser";
+import type { StaticEnvironment } from "../types";
+import type { RenderDiagnostic, SourceLocation } from "./types";
+
+export interface ResolvedStaticEnvironment {
+  preferredLanguages: readonly string[];
+  supportedExtensions: ReadonlySet<string>;
+  svgVersion: "1.1" | "2";
+  supportedFeatures: ReadonlySet<string>;
+  accessibilityLocale?: string;
+}
+
+function normalizedLanguage(value: string): string {
+  return value.trim().replace(/_/g, "-").toLowerCase();
+}
+
+/** SVG systemLanguage uses a preference-as-prefix comparison, not the host locale. */
+export function languagePreferenceMatches(preference: string, authoredLanguage: string): boolean {
+  const preferred = normalizedLanguage(preference);
+  const authored = normalizedLanguage(authoredLanguage);
+  return preferred !== "" && (authored === preferred || authored.startsWith(`${preferred}-`));
+}
+
+export function resolveStaticEnvironment(environment: StaticEnvironment = {}): ResolvedStaticEnvironment {
+  const accessibilityLocale = environment.accessibilityLocale?.trim();
+  return {
+    preferredLanguages: (environment.preferredLanguages ?? [])
+      .map(String)
+      .map((value) => value.trim())
+      .filter(Boolean),
+    supportedExtensions: new Set((environment.supportedExtensions ?? []).map(String)),
+    svgVersion: environment.svgVersion ?? "2",
+    supportedFeatures: new Set((environment.supportedFeatures ?? []).map(String)),
+    ...(accessibilityLocale ? { accessibilityLocale } : {}),
+  };
+}
+
+function sourceLocation(element: ElementNode): SourceLocation {
+  const id = element.properties?.id;
+  return { element: element.tagName ?? "unknown", ...(id === undefined ? {} : { id: String(id) }) };
+}
+
+function attribute(element: ElementNode, name: string): { present: boolean; value: string } {
+  const entry = Object.entries(element.properties ?? {}).find(([key]) => key.toLowerCase() === name.toLowerCase());
+  return entry ? { present: true, value: String(entry[1] ?? "") } : { present: false, value: "" };
+}
+
+/** Evaluates static conditional attributes without consulting the developer machine. */
+export class SVGConditionalProcessor {
+  readonly environment: ResolvedStaticEnvironment;
+  private readonly diagnosed = new WeakMap<ElementNode, Set<string>>();
+
+  constructor(
+    environment: StaticEnvironment | undefined,
+    private readonly diagnostics: RenderDiagnostic[],
+  ) {
+    this.environment = resolveStaticEnvironment(environment);
+  }
+
+  private diagnose(element: ElementNode, code: string, message: string): void {
+    const codes = this.diagnosed.get(element) ?? new Set<string>();
+    if (codes.has(code)) return;
+    codes.add(code);
+    this.diagnosed.set(element, codes);
+    this.diagnostics.push({ code, message, severity: "warning", source: sourceLocation(element) });
+  }
+
+  matches(element: ElementNode): boolean {
+    const extensions = attribute(element, "requiredExtensions");
+    if (extensions.present) {
+      const tokens = extensions.value.trim().split(/\s+/).filter(Boolean);
+      if (tokens.length === 0 || !tokens.every((token) => this.environment.supportedExtensions.has(token)))
+        return false;
+    }
+
+    const language = attribute(element, "systemLanguage");
+    if (language.present) {
+      const authored = language.value
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+      if (
+        authored.length === 0 ||
+        !this.environment.preferredLanguages.some((preference) =>
+          authored.some((candidate) => languagePreferenceMatches(preference, candidate)),
+        )
+      )
+        return false;
+    }
+
+    const features = attribute(element, "requiredFeatures");
+    if (features.present) {
+      if (this.environment.svgVersion === "2") {
+        this.diagnose(
+          element,
+          "obsolete-required-features",
+          "requiredFeatures was removed from SVG 2 and is ignored; use requiredExtensions or configure SVG 1.1 compatibility.",
+        );
+      } else {
+        const tokens = features.value.trim().split(/\s+/).filter(Boolean);
+        if (tokens.length === 0 || !tokens.every((token) => this.environment.supportedFeatures.has(token)))
+          return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -10,6 +10,7 @@ import { renderNodeBounds } from "./bounds";
 import { type ResolvedGradient, resolveGradientForShape } from "./gradients";
 import { type ResolvedPattern, resolvePatternForShape } from "./patterns";
 import type {
+  AccessibilityMetadata,
   ClipPathInstance,
   ComputedStyle,
   Geometry,
@@ -77,6 +78,7 @@ type GeneratedViewNode =
       clipPath?: GeneratedClipPath;
       mask?: GeneratedMask;
       tileContained?: boolean;
+      accessibility?: AccessibilityMetadata;
     };
 
 interface GeneratedMask {
@@ -478,6 +480,7 @@ function buildViewNodes(
           ...(viewportClip ? { viewportClip } : {}),
           ...(clipPath ? { clipPath } : {}),
           ...(mask ? { mask } : {}),
+          ...(node.accessibility ? { accessibility: node.accessibility } : {}),
         });
       }
       continue;
@@ -503,6 +506,7 @@ function buildViewNodes(
         blendMode: node.style.blendMode,
         ...(clipPath ? { clipPath } : {}),
         ...(mask ? { mask } : {}),
+        ...(node.accessibility ? { accessibility: node.accessibility } : {}),
       });
       continue;
     }
@@ -560,6 +564,7 @@ function buildViewNodes(
         blendMode: node.style.blendMode,
         ...(clipPath ? { clipPath } : {}),
         ...(mask ? { mask } : {}),
+        ...(node.accessibility ? { accessibility: node.accessibility } : {}),
       });
       continue;
     }
@@ -704,6 +709,7 @@ function buildViewNodes(
         blendMode: node.style.blendMode,
         ...(clipPath ? { clipPath } : {}),
         ...(mask ? { mask } : {}),
+        ...(node.accessibility ? { accessibility: node.accessibility } : {}),
       });
     }
   }
@@ -845,8 +851,6 @@ function createTextHelper(
     `${i4}graphics.restoreGState()`,
     `${i3}}`,
     `${i2}}`,
-    `${i2}.accessibilityElement(children: .ignore)`,
-    `${i2}.accessibilityLabel(${swiftString(helper.node.text)})`,
     `${indentation}}`,
     "",
     `${indentation}private struct SVGTextColor { let red: CGFloat; let green: CGFloat; let blue: CGFloat; let alpha: CGFloat }`,
@@ -1523,6 +1527,37 @@ function renderPatternCommands(
   return lines;
 }
 
+function accessibilityTrait(role: string | undefined): string | undefined {
+  if (!role) return undefined;
+  if (["img", "graphics-document", "graphics-object", "graphics-symbol"].includes(role)) return "isImage";
+  if (role === "button") return "isButton";
+  if (role === "link") return "isLink";
+  if (role === "heading") return "isHeader";
+  if (role === "text") return "isStaticText";
+  return undefined;
+}
+
+function appendAccessibilityModifiers(
+  lines: string[],
+  accessibility: AccessibilityMetadata | undefined,
+  prefix: string,
+): void {
+  if (!accessibility) return;
+  if (accessibility.hidden) {
+    lines.push(`${prefix}.accessibilityHidden(true)`);
+    return;
+  }
+  const presentation = accessibility.role === "none" || accessibility.role === "presentation";
+  const semanticContainer = accessibility.role === "graphics-document" || accessibility.role === "graphics-object";
+  if ((accessibility.label || accessibility.description) && !semanticContainer)
+    lines.push(`${prefix}.accessibilityElement(children: .ignore)`);
+  else if (accessibility.role && !presentation) lines.push(`${prefix}.accessibilityElement(children: .contain)`);
+  if (accessibility.label) lines.push(`${prefix}.accessibilityLabel(${swiftString(accessibility.label)})`);
+  if (accessibility.description) lines.push(`${prefix}.accessibilityHint(${swiftString(accessibility.description)})`);
+  const trait = presentation ? undefined : accessibilityTrait(accessibility.role);
+  if (trait) lines.push(`${prefix}.accessibilityAddTraits(.${trait})`);
+}
+
 function renderViewNode(node: GeneratedViewNode, level: number, indentation: string): string[] {
   const prefix = indentation.repeat(level);
   if (node.type === "text" || node.type === "image") return [`${prefix}${node.helper}()`];
@@ -1634,6 +1669,7 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
   }
   if (node.opacity !== 1) lines.push(`${prefix}.opacity(${swiftNumber(node.opacity)})`);
   if (node.blendMode !== "normal") lines.push(`${prefix}.blendMode(.${swiftBlendMode(node.blendMode)})`);
+  appendAccessibilityModifiers(lines, node.accessibility, prefix);
   return lines;
 }
 
@@ -1731,12 +1767,6 @@ function createImageHelper(
       `${i4}context.draw(image, in: CGRect(x: 0, y: 0, width: ${formatNumber(intrinsic.width)}, height: ${formatNumber(intrinsic.height)}))`,
       `${i3}}`,
       `${i2}}`,
-    );
-  }
-  if (node.type === "foreignObject" && node.accessibilityLabel) {
-    body.push(
-      `${i2}.accessibilityElement(children: .ignore)`,
-      `${i2}.accessibilityLabel(${swiftString(node.accessibilityLabel)})`,
     );
   }
   body.push(`${indentation}}`);

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -30,6 +30,15 @@ export interface RenderDiagnostic {
   css?: CSSDiagnosticContext;
 }
 
+/** Static accessibility semantics mapped onto the closest generated SwiftUI view. */
+export interface AccessibilityMetadata {
+  label?: string;
+  description?: string;
+  hidden?: boolean;
+  role?: string;
+  language?: string;
+}
+
 /** SVG paint is deliberately semantic; Swift source is only introduced by the generator. */
 export type Paint =
   | { type: "none" }
@@ -291,6 +300,7 @@ export interface RenderShape {
   source: SourceLocation;
   /** Coordinate context at the referencing element, retained for user-space paint percentages. */
   paintContext: NodeCoordinateContext;
+  accessibility?: AccessibilityMetadata;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
   /** Materialized marker shadow trees in SVG vertex order. */
@@ -315,6 +325,7 @@ export interface RenderGroup {
   transform: AffineTransform;
   source: SourceLocation;
   paintContext: NodeCoordinateContext;
+  accessibility?: AccessibilityMetadata;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
   /** Present only on a marker shadow-tree root. */
@@ -343,6 +354,7 @@ export interface RenderText {
   transform: AffineTransform;
   source: SourceLocation;
   paintContext: NodeCoordinateContext;
+  accessibility?: AccessibilityMetadata;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
 }
@@ -450,6 +462,7 @@ export interface RenderImage {
   transform: AffineTransform;
   source: SourceLocation;
   paintContext: NodeCoordinateContext;
+  accessibility?: AccessibilityMetadata;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
 }
@@ -477,6 +490,7 @@ export interface RenderForeignObject {
   transform: AffineTransform;
   source: SourceLocation;
   paintContext: NodeCoordinateContext;
+  accessibility?: AccessibilityMetadata;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
 }

--- a/packages/svg-to-swiftui-core/src/tests/accessibilityConditionals.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/accessibilityConditionals.test.ts
@@ -1,0 +1,187 @@
+import { __testing, convert, convertWithDiagnostics, type StaticEnvironment } from "../index";
+import type { RenderNode } from "../renderTree/types";
+
+function flatten(nodes: RenderNode[]): RenderNode[] {
+  return nodes.flatMap((node) => (node.type === "group" ? [node, ...flatten(node.children)] : [node]));
+}
+
+function document(source: string, staticEnvironment?: StaticEnvironment) {
+  return __testing.parseRenderDocument(source, { staticEnvironment });
+}
+
+function node(source: string, id: string, staticEnvironment?: StaticEnvironment): RenderNode | undefined {
+  return flatten(document(source, staticEnvironment).children).find((candidate) => candidate.source.id === id);
+}
+
+describe("static SVG accessibility semantics", () => {
+  test("maps title and desc onto a generated View without rendering metadata", () => {
+    const source = `<svg viewBox="0 0 10 10"><title>Unicode ✓ icon</title><desc> A  concise\n description </desc><metadata>do-not-render-metadata</metadata><rect width="10" height="10"/></svg>`;
+    const output = convert(source);
+
+    expect(output).toContain("struct MyCustomShape: View");
+    expect(output).toContain('.accessibilityLabel("Unicode ✓ icon")');
+    expect(output).toContain('.accessibilityHint("A concise description")');
+    expect(output).toContain(".accessibilityElement(children: .contain)");
+    expect(output).toContain(".accessibilityAddTraits(.isImage)");
+    expect(output).not.toContain("do-not-render-metadata");
+  });
+
+  test("uses ARIA precedence and concatenates multiple labelled references", () => {
+    const source = `
+      <svg viewBox="0 0 10 10"><defs>
+        <g id="first"><title>Primary</title></g>
+        <text id="second">status ✓</text>
+        <desc id="details">Detailed explanation</desc>
+      </defs>
+      <rect id="target" width="10" height="10" aria-labelledby="first second" aria-label="Ignored"
+        aria-describedby="details"><title>Fallback title</title><desc>Fallback desc</desc></rect></svg>
+    `;
+
+    expect(node(source, "target")?.accessibility).toMatchObject({
+      label: "Primary status ✓",
+      description: "Detailed explanation",
+      role: "graphics-symbol",
+    });
+  });
+
+  test("keeps group and child semantics on their closest generated views", () => {
+    const output = convert(`
+      <svg viewBox="0 0 10 10"><g><title>Controls</title>
+        <rect width="5" height="10"><title>Decrease</title></rect>
+        <rect x="5" width="5" height="10" role="button" aria-label="Increase"/>
+      </g></svg>
+    `);
+
+    expect(output).toContain('.accessibilityLabel("Controls")');
+    expect(output).toContain('.accessibilityLabel("Decrease")');
+    expect(output).toContain('.accessibilityLabel("Increase")');
+    expect(output).toContain(".accessibilityAddTraits(.isButton)");
+  });
+
+  test("honors aria-hidden ancestry and selects localized descriptive siblings", () => {
+    const source = `
+      <svg viewBox="0 0 10 10"><g aria-hidden="true"><rect id="hidden" width="2" height="2" aria-hidden="false"><title>Hidden</title></rect></g>
+      <rect id="localized" width="10" height="10"><title lang="en">Favorite</title><title xml:lang="lt">Mėgstamiausia</title>
+        <desc lang="en">English detail</desc><desc xml:lang="lt">Lietuviškas aprašas</desc></rect></svg>
+    `;
+
+    expect(node(source, "hidden")?.accessibility).toMatchObject({ hidden: true });
+    expect(
+      node(source, "localized", { preferredLanguages: ["en"], accessibilityLocale: "lt-LT" })?.accessibility,
+    ).toMatchObject({ label: "Mėgstamiausia", description: "Lietuviškas aprašas", language: "lt" });
+    const output = convert(source, { staticEnvironment: { preferredLanguages: ["lt"] } });
+    expect(output).toContain(".accessibilityHidden(true)");
+    expect(output).toContain('.accessibilityLabel("Mėgstamiausia")');
+  });
+
+  test("diagnoses broken and cyclic ARIA ID references without crashing", () => {
+    const result = convertWithDiagnostics(`
+      <svg viewBox="0 0 10 10"><g id="a" aria-labelledby="b"><title>Alpha</title><rect width="2" height="2"/></g>
+        <g id="b" aria-labelledby="a missing"><title>Beta</title><rect x="2" width="2" height="2"/></g></svg>
+    `);
+
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(
+      expect.arrayContaining(["broken-accessibility-reference", "cyclic-accessibility-reference"]),
+    );
+    expect(result.swift).toContain("struct MyCustomShape: View");
+  });
+
+  test("uses meaningful text as the text element's accessible name", () => {
+    expect(convert(`<svg viewBox="0 0 20 10"><text x="1" y="8"> Hello <tspan>world</tspan> </text></svg>`)).toContain(
+      '.accessibilityLabel("Hello world")',
+    );
+    expect(
+      node(
+        `<svg viewBox="0 0 20 10"><text id="labelled" aria-label="Override"><title>Tooltip</title>Visible</text></svg>`,
+        "labelled",
+      )?.accessibility,
+    ).toMatchObject({ label: "Override", description: "Visible" });
+  });
+});
+
+describe("static SVG conditional processing", () => {
+  const switchSource = `
+    <svg viewBox="0 0 10 10"><switch>
+      <rect id="extension" width="1" height="1" requiredExtensions="https://example.test/a https://example.test/b"/>
+      <circle id="language" cx="2" cy="2" r="2" systemLanguage="en-US, de"/>
+      <path id="fallback" d="M0 0h3v3z"/>
+    </switch></svg>
+  `;
+
+  test("selects the first matching child, a later language match, or the fallback", () => {
+    expect(
+      node(switchSource, "extension", {
+        supportedExtensions: ["https://example.test/a", "https://example.test/b"],
+      }),
+    ).toBeDefined();
+    expect(node(switchSource, "language", { preferredLanguages: ["en"] })).toBeDefined();
+    expect(node(switchSource, "fallback")).toBeDefined();
+  });
+
+  test("requires every extension and renders nothing when no child matches", () => {
+    expect(node(switchSource, "extension", { supportedExtensions: ["https://example.test/a"] })).toBeUndefined();
+    const noMatch = document(
+      `<svg viewBox="0 0 10 10"><switch><rect id="one" requiredExtensions="x"/><circle id="two" systemLanguage="fr"/></switch></svg>`,
+      { preferredLanguages: ["en"] },
+    );
+    const switchNode = flatten(noMatch.children).find((candidate) => candidate.source.element === "switch");
+    expect(switchNode?.type === "group" ? switchNode.children : undefined).toEqual([]);
+  });
+
+  test.each([
+    [["en"], "en-US", true],
+    [["en-US"], "en", false],
+    [["lt", "de"], "fr, de-DE", true],
+    [[], "en", false],
+  ] as const)("matches language preferences %p against %s", (preferredLanguages, systemLanguage, expected) => {
+    const source = `<svg viewBox="0 0 10 10"><rect id="target" width="10" height="10" systemLanguage="${systemLanguage}"/></svg>`;
+    expect(node(source, "target", { preferredLanguages })).toEqual(expected ? expect.anything() : undefined);
+  });
+
+  test("selects display-none children without falling through", () => {
+    const selected = document(`
+      <svg viewBox="0 0 10 10"><switch><rect id="selected" display="none" width="5" height="5"/>
+        <circle id="not-selected" r="4"/></switch></svg>
+    `);
+    expect(
+      node(
+        `<svg viewBox="0 0 10 10"><switch><rect id="selected" display="none"/><circle id="not-selected"/></switch></svg>`,
+        "selected",
+      ),
+    ).toBeDefined();
+    expect(flatten(selected.children).some((candidate) => candidate.source.id === "not-selected")).toBe(false);
+  });
+
+  test("uses explicit SVG 1.1 feature support and documents SVG 2 legacy behavior", () => {
+    const source = `<svg viewBox="0 0 10 10"><switch><rect id="feature" width="2" height="2" requiredFeatures="feature:a"/><circle id="fallback" r="2"/></switch></svg>`;
+    expect(node(source, "fallback", { svgVersion: "1.1" })).toBeDefined();
+    expect(node(source, "feature", { svgVersion: "1.1", supportedFeatures: ["feature:a"] })).toBeDefined();
+    const svg2 = convertWithDiagnostics(source);
+    expect(svg2.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "obsolete-required-features" })]),
+    );
+    expect(node(source, "feature")).toBeDefined();
+  });
+
+  test("applies conditionals outside switch and inside referenced use content", () => {
+    const source = `
+      <svg viewBox="0 0 10 10"><defs><g id="asset"><rect id="referenced" width="4" height="4" requiredExtensions="asset:v1"/></g></defs>
+        <use id="host" href="#asset"/><circle id="outside" r="2" systemLanguage="fr"/>
+        <use id="suppressed-use" href="#asset" requiredExtensions="missing"/>
+      </svg>
+    `;
+    const resolved = document(source, { preferredLanguages: ["en"], supportedExtensions: ["asset:v1"] });
+    const ids = flatten(resolved.children).map((candidate) => candidate.source.id);
+    expect(ids).toContain("referenced");
+    expect(ids).not.toContain("outside");
+    expect(ids).not.toContain("suppressed-use");
+  });
+
+  test("keeps scripts non-visual and makes static conformance observable", () => {
+    const source = `<svg viewBox="0 0 10 10"><script>bad()</script><metadata>data</metadata><rect width="10" height="10"/></svg>`;
+    expect(convertWithDiagnostics(source).diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "unsupported-script" })]),
+    );
+    expect(() => convert(source, { strict: true })).toThrow("scripts are not executed");
+  });
+});

--- a/packages/svg-to-swiftui-core/src/types.ts
+++ b/packages/svg-to-swiftui-core/src/types.ts
@@ -28,6 +28,21 @@ export interface SwiftUIGeneratorConfig {
   foreignObjectRenderer?: ForeignObjectRenderer;
   /** Bounded rasterization and artifact behavior for static <foreignObject> snapshots. */
   foreignObjects?: ForeignObjectConfiguration;
+  /** Deterministic language and capability inputs used by static SVG semantics. */
+  staticEnvironment?: StaticEnvironment;
+}
+
+export interface StaticEnvironment {
+  /** Ordered BCP 47 language preferences. No host-machine locale is read when omitted. */
+  preferredLanguages?: readonly string[];
+  /** Extension URL identifiers supported by the generated static environment. */
+  supportedExtensions?: readonly string[];
+  /** SVG language version used for legacy requiredFeatures policy. Defaults to SVG 2. */
+  svgVersion?: "1.1" | "2";
+  /** Explicitly supported SVG 1.1 requiredFeatures identifiers. */
+  supportedFeatures?: readonly string[];
+  /** Highest-priority locale for selecting accessible title/desc alternatives. */
+  accessibilityLocale?: string;
 }
 
 export interface ForeignObjectConfiguration {

--- a/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
@@ -12,6 +12,25 @@
     }
   },
   "fixtures": {
+    "accessibility-metadata-switch": {
+      "width": 128,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": [
+        "accessibility",
+        "circle",
+        "conditional-processing",
+        "desc",
+        "g",
+        "geometry",
+        "metadata",
+        "path",
+        "rect",
+        "switch",
+        "title",
+        "view"
+      ]
+    },
     "arc-elliptical": {
       "width": 128,
       "height": 128,
@@ -11613,8 +11632,18 @@
     "structure-switch-link": {
       "width": 128,
       "height": 85,
-      "expectedMode": "shape",
-      "tags": ["circle", "geometry", "path", "rect", "shape", "structure", "switch"]
+      "expectedMode": "view",
+      "tags": [
+        "accessibility",
+        "circle",
+        "conditional-processing",
+        "geometry",
+        "path",
+        "rect",
+        "structure",
+        "switch",
+        "view"
+      ]
     },
     "structure-symbol-use": {
       "width": 128,

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/accessibility-metadata-switch.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/accessibility-metadata-switch.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 80" xml:lang="en">
+  <title>Accessible landscape card</title>
+  <desc>A blue sky above green hills and a yellow sun.</desc>
+  <metadata>Non-visual fixture metadata</metadata>
+  <switch>
+    <g role="img" aria-label="Landscape artwork">
+      <rect width="128" height="80" rx="10" fill="#dbeafe" />
+      <circle cx="98" cy="22" r="12" fill="#facc15" />
+      <path d="M0 64L38 30L72 58L94 42L128 70V80H0Z" fill="#22c55e" />
+      <path d="M0 71L42 48L78 68L105 55L128 67V80H0Z" fill="#15803d" />
+    </g>
+    <rect width="128" height="80" fill="#dc2626" />
+  </switch>
+</svg>


### PR DESCRIPTION
Closes #66.

## What changed

- resolve SVG-AAM names/descriptions from ARIA, title/desc, meaningful text, language, roles, and hidden state
- preserve semantics on the closest generated SwiftUI view, including shape-fast-path promotion
- add deterministic `StaticEnvironment` handling for `systemLanguage`, `requiredExtensions`, and SVG 1.1 `requiredFeatures`
- complete first-matching-child `<switch>` behavior and conditional suppression outside `<switch>`
- diagnose broken/cyclic accessibility references, legacy SVG 2 features, and static scripts
- document the API and add a minor changeset

## Validation

- `bun run --filter svg-to-swiftui-core test` — 220 passed
- `bun run --filter svg-to-swiftui-core lint`
- `bun run --filter svg-to-swiftui-core format`
- `bun run --filter svg-to-swiftui-core typecheck`
- `bun run --filter svg-to-swiftui-core visual-test:verify` — 1,888 fixtures
- fresh real-SwiftUI RGBA comparisons for `accessibility-metadata-switch` and `structure-switch-link`
- `bun run test`
- `bun run build`

Repo-wide lint/typecheck retain unrelated baseline failures in existing Next.js formatting and the shared Prettier config's missing Node types.
