### PR TITLE
[Static SVG] Add filter graph common primitives

### DIFF
--- a/.changeset/static-svg-filter-graph-common-primitives.md
+++ b/.changeset/static-svg-filter-graph-common-primitives.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Add typed SVG filter graphs and a generated premultiplied RGBA runtime for Gaussian blur, offset, flood, merge, and drop-shadow primitives.

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -65,6 +65,12 @@ Luminance masks use an offscreen `Canvas` color matrix with the SVG luminance co
 
 All Compositing Level 1 `mix-blend-mode` values map to native SwiftUI blend modes: `normal`, `multiply`, `screen`, `overlay`, `darken`, `lighten`, `color-dodge`, `color-burn`, `hard-light`, `soft-light`, `difference`, `exclusion`, `hue`, `saturation`, `color`, and `luminosity`. `isolation: isolate`, masks, non-normal blending, and group opacity create explicit compositing boundaries. The generated backend requires SwiftUI `Canvas` support (iOS 15, macOS 12, tvOS 15, and watchOS 8 or newer); no older-platform fallback is emitted.
 
+### Static filter graphs
+
+Local `filter: url(#id)` references resolve into typed, target-specific directed graphs. The common runtime supports `feGaussianBlur`, `feOffset`, `feFlood`, `feMerge`/`feMergeNode`, and `feDropShadow`, including named `result` branches, default inputs, `SourceGraphic`, `SourceAlpha`, `FillPaint`, `StrokePaint`, href inheritance, both filter/primitive unit systems, primitive subregions, filter-region clipping, transforms, and `sRGB`/`linearRGB` processing. Unsupported background inputs resolve to transparent black with a diagnostic.
+
+Generated Swift uses the same deterministic premultiplied-RGBA image-buffer runtime as the visual regression host. Source vector commands are rasterized only at app render time and at the active display scale; conversion never snapshots the full SVG. Filters run before viewport/clip paths, masks, element opacity, and blending, and their regions contribute to reported painted bounds. Unsupported primitives remain typed pass-through graph nodes with diagnostics until their dedicated tickets land.
+
 ### Linear and radial gradients
 
 `linearGradient`, `radialGradient`, and `stop` definitions are resolved as typed paint resources for fills and strokes. The resolver supports `objectBoundingBox` and `userSpaceOnUse`, percentage or length coordinates, `gradientTransform`, `pad`/`reflect`/`repeat`, `href` and `xlink:href` inheritance, local stop replacement, focal circles, CSS-styled stops, `currentColor`, alpha, and fallback paints.
@@ -136,7 +142,7 @@ const swift = await convertAsync(svg, {
 
 The core builds an isolated document, removes scripts, event handlers, navigation, active embeds, imports, keyframes, and unsafe URL schemes, adds a CSP/reset, and carries inherited SVG font/color/text styles into the foreign viewport. The official adapter additionally disables JavaScript and service workers and blocks every browser request unless `resources` resolves it. Approved images, fonts, and CSS use the same byte/count policy as SVG images.
 
-Snapshots preserve transparent backgrounds, exact x/y/width/height, transforms, viewport clipping, opacity, clip paths, masks, blend modes, and a text/ARIA accessibility label. SVG filters are retained but diagnosed until the filter runtime in issues #67–#71 is complete. Without an adapter, permissive conversion emits a typed omission diagnostic; strict conversion fails. Content is static at the requested bounded scale (default 1, default maximum 4, hard maximum 8), not infinitely scalable HTML.
+Snapshots preserve transparent backgrounds, exact x/y/width/height, transforms, viewport clipping, opacity, clip paths, masks, filters, blend modes, and a text/ARIA accessibility label. Without an adapter, permissive conversion emits a typed omission diagnostic; strict conversion fails. Content is static at the requested bounded scale (default 1, default maximum 4, hard maximum 8), not infinitely scalable HTML.
 
 Normal `convertAsync()` embeds PNG bytes. For large snapshots, use `convertAsyncWithArtifacts()` and `foreignObjects.inlineByteLimit`; its result contains Swift source plus deterministic content-addressed PNG assets for the generated app target.
 

--- a/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/bounds.ts
@@ -329,6 +329,16 @@ export function renderNodeBounds(node: RenderNode, parent = IDENTITY_TRANSFORM):
     if (hidden(node.style.visibility)) return undefined;
     let painted = transformedShapeBounds(node, transform);
     if (node.markers) painted = union(painted, renderNodesBounds(node.markers, transform));
+    if (node.filter)
+      painted = node.filter.invalid
+        ? undefined
+        : transformedRect(
+            node.filter.region.x,
+            node.filter.region.y,
+            node.filter.region.width,
+            node.filter.region.height,
+            transform,
+          );
     if (node.clipPath) {
       const clip = clipPathInstanceBounds(node.clipPath, transform);
       painted = clip ? intersect(painted, clip) : undefined;
@@ -337,6 +347,16 @@ export function renderNodeBounds(node: RenderNode, parent = IDENTITY_TRANSFORM):
   }
   if (node.type === "group") {
     let bounds = renderNodesBounds(node.children, transform);
+    if (node.filter)
+      bounds = node.filter.invalid
+        ? undefined
+        : transformedRect(
+            node.filter.region.x,
+            node.filter.region.y,
+            node.filter.region.width,
+            node.filter.region.height,
+            transform,
+          );
     if (node.viewport?.clip) {
       const clip = node.viewport.rect;
       const clipTransform = multiplyTransforms(parent, node.viewport.clipTransform);
@@ -358,6 +378,16 @@ export function renderNodeBounds(node: RenderNode, parent = IDENTITY_TRANSFORM):
       node.viewport.height,
       transform,
     );
+    if (node.filter)
+      bounds = node.filter.invalid
+        ? undefined
+        : transformedRect(
+            node.filter.region.x,
+            node.filter.region.y,
+            node.filter.region.width,
+            node.filter.region.height,
+            transform,
+          );
     if (node.clipPath) {
       const clip = clipPathInstanceBounds(node.clipPath, transform);
       bounds = clip ? intersect(bounds, clip) : undefined;

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -27,6 +27,7 @@ import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio, parseViewBox, 
 import { SVGAccessibilityResolver } from "./accessibility";
 import { resolveClipPathInstance, resolveClipPathResources } from "./clips";
 import { SVGConditionalProcessor } from "./conditionalProcessing";
+import { resolveFilterInstance, resolveFilterResources } from "./filters";
 import { resolvePaintServers } from "./gradients";
 import { markerVertices, orientedMarkerAngle, resolveMarkerResources } from "./markers";
 import { resolveMaskInstance, resolveMaskResources } from "./masks";
@@ -420,6 +421,21 @@ function computedMask(value: unknown, element: ElementNode, context: BuildContex
   return { invalid: true };
 }
 
+function computedFilter(value: unknown, element: ElementNode, context: BuildContext, css?: CSSDiagnosticContext) {
+  const normalized = String(value ?? "none").trim();
+  if (normalized.toLowerCase() === "none") return undefined;
+  const local = /^url\(\s*["']?#([^\s)"']+)["']?\s*\)$/i.exec(normalized);
+  if (local) return { id: local[1]!, invalid: false };
+  addDiagnostic(
+    context,
+    element,
+    /^url\(/i.test(normalized) ? "external-filter-reference" : "invalid-filter-reference",
+    `Only one local filter reference of the form url(#id) is supported; received '${normalized}'.`,
+    css,
+  );
+  return { invalid: true };
+}
+
 function computedClipPath(value: unknown, element: ElementNode, context: BuildContext, css?: CSSDiagnosticContext) {
   const normalized = String(value ?? "none").trim();
   if (normalized.toLowerCase() === "none") return undefined;
@@ -514,6 +530,7 @@ function computeStyle(
     }
   }
   const mask = computedMask(effective.mask, element, context, provenance.mask);
+  const filter = computedFilter(effective.filter, element, context, provenance.filter);
   const clipPath = computedClipPath(effective["clip-path"], element, context, provenance["clip-path"]);
   const markerStart = computedMarkerReference(
     effective["marker-start"],
@@ -572,6 +589,7 @@ function computeStyle(
       .toLowerCase(),
     ...(clipPath ? { clipPath } : {}),
     ...(mask ? { mask } : {}),
+    ...(filter ? { filter } : {}),
     blendMode: computedBlendMode(effective["mix-blend-mode"], element, context, provenance["mix-blend-mode"]),
     isolation: isolationValue === "isolate" ? "isolate" : "auto",
     strokeStyle: {
@@ -769,6 +787,7 @@ function createRegistry(root: ElementNode): ResourceRegistry {
     markers: new Map(),
     markerElements: new Map(),
     filters: new Map(),
+    filterElements: new Map(),
     views: new Map(),
   };
   function visit(element: ElementNode): void {
@@ -783,7 +802,7 @@ function createRegistry(root: ElementNode): ResourceRegistry {
       if (element.tagName === "clipPath") registry.clipElements.set(id, element);
       if (element.tagName === "mask") registry.maskElements.set(id, element);
       if (element.tagName === "marker") registry.markerElements.set(id, element);
-      if (element.tagName === "filter") registry.filters.set(id, element);
+      if (element.tagName === "filter") registry.filterElements.set(id, element);
     }
     for (const child of element.children) {
       if (typeof child !== "string" && child.type === "element") {
@@ -1741,16 +1760,6 @@ function buildForeignObject(
     }
   }
 
-  const filter = String(resolved.effective.filter ?? "none").trim();
-  if (!context.config.__preparingForeignObjects && filter.toLowerCase() !== "none")
-    addDiagnostic(
-      context,
-      element,
-      "foreign-object-filter-deferred",
-      `foreignObject filter '${filter}' is retained for the filter runtime in issues #67-#71 but is not applied yet.`,
-      resolved.provenance.filter,
-    );
-
   return {
     type: "foreignObject",
     key,
@@ -1759,7 +1768,6 @@ function buildForeignObject(
     ...(snapshot.accessibilityLabel ? { accessibilityLabel: snapshot.accessibilityLabel } : {}),
     snapshotScale: prepared?.scale ?? context.config.foreignObjects?.scale ?? 1,
     ...(prepared?.resource ? { resource: prepared.resource } : {}),
-    filter,
     attributes: { ...(element.properties ?? {}) } as Record<string, string | number>,
     style: resolved.style,
     transform: computedTransform(element, resolved, context),
@@ -2154,6 +2162,14 @@ export function buildRenderDocument(
   resources.markers = resolveMarkerResources(
     svg,
     resources.markerElements,
+    styleResolver,
+    resolved.effective,
+    diagnostics,
+  );
+  resources.filters = resolveFilterResources(
+    svg,
+    resources.filterElements,
+    resources.definitions,
     styleResolver,
     resolved.effective,
     diagnostics,
@@ -2772,6 +2788,60 @@ export function buildRenderDocument(
     }
   }
   materializeMasks(children);
+
+  function diagnoseFilterOnce(node: RenderNode, code: string, message: string): void {
+    if (
+      diagnostics.some(
+        (item) =>
+          item.code === code &&
+          item.source.element === node.source.element &&
+          item.source.id === node.source.id &&
+          item.message === message,
+      )
+    )
+      return;
+    diagnostics.push({ code, message, severity: "warning", source: node.source });
+  }
+
+  const filteredNodes = new Set<RenderNode>();
+  function materializeFilters(nodes: RenderNode[]): void {
+    for (const node of nodes) {
+      if (filteredNodes.has(node)) continue;
+      filteredNodes.add(node);
+      if (node.type === "group") materializeFilters(node.children);
+      else if (node.type === "shape" && node.markers) materializeFilters(node.markers);
+      if (node.mask) materializeFilters(node.mask.children);
+      const reference = node.style.filter;
+      if (!reference || reference.invalid || !reference.id) continue;
+      const id = reference.id;
+      const resource = resources.filters.get(id);
+      if (!resource) {
+        const target = resources.definitions.get(id);
+        diagnoseFilterOnce(
+          node,
+          target ? "wrong-filter-resource-type" : "missing-filter-resource",
+          target
+            ? `Filter reference #${id} targets <${target.tagName}> instead of a filter; no filter was applied.`
+            : `Filter reference #${id} does not resolve to a local filter; no filter was applied.`,
+        );
+        continue;
+      }
+      const instance = resolveFilterInstance(resource, node);
+      if (instance.invalid)
+        diagnoseFilterOnce(
+          node,
+          "invalid-filter-region",
+          `Filter #${id} cannot render with an empty region or object bounding box.`,
+        );
+      resource.instances.set(node, instance);
+      node.filter = instance;
+    }
+  }
+  materializeFilters(children);
+  for (const paint of resources.paints.values()) {
+    if (paint.type !== "pattern") continue;
+    for (const instance of paint.instances.values()) materializeFilters(instance.children);
+  }
 
   function diagnosePaintReferences(nodes: RenderNode[]): void {
     for (const node of nodes) {

--- a/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
@@ -68,6 +68,7 @@ function containsIndependentCompositing(nodes: RenderNode[]): boolean {
       node.style.isolation === "isolate" ||
       node.clipPath !== undefined ||
       node.style.mask !== undefined ||
+      node.filter !== undefined ||
       node.style.blendMode !== "normal"
     )
       return true;
@@ -94,6 +95,15 @@ function containsMarkers(nodes: RenderNode[]): boolean {
     (node) =>
       (node.type === "shape" && (node.markers?.length ?? 0) > 0) ||
       (node.type === "group" && containsMarkers(node.children)),
+  );
+}
+
+function containsFilters(nodes: RenderNode[]): boolean {
+  return nodes.some(
+    (node) =>
+      node.filter !== undefined ||
+      (node.type === "shape" && node.markers !== undefined && containsFilters(node.markers)) ||
+      (node.type === "group" && containsFilters(node.children)),
   );
 }
 
@@ -129,6 +139,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   const needsNonScalingStroke = containsNonScalingStroke(document.children);
   const needsMarkers = containsMarkers(document.children);
   const needsAccessibility = containsAccessibility(document.children);
+  const hasFilters = containsFilters(document.children);
 
   if (
     config.preserveColors === false &&
@@ -155,6 +166,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
   if (needsIndependentCompositing) reasons.push("document uses independent paint or group opacity");
   if (needsNonScalingStroke) reasons.push("document uses non-scaling stroke geometry");
   if (needsMarkers) reasons.push("document uses SVG marker shadow content");
+  if (hasFilters) reasons.push("document uses an SVG filter graph");
 
   const colors = paints.map(({ paint, opacity }) => {
     if (paint.type === "reference") {

--- a/packages/svg-to-swiftui-core/src/renderTree/filters.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/filters.ts
@@ -1,0 +1,585 @@
+import type { ElementNode } from "svg-parser";
+import { parseOpacity, parseRGBAColor, type RGBAColor } from "../colorUtils";
+import {
+  lengthContext,
+  type ParsedSVGLength,
+  parsePlainNumber,
+  parseSVGLength,
+  resolveSVGLength,
+  SVGLengthError,
+} from "../lengths";
+import type { Presentation, StyleResolution, SVGStyleResolver } from "../styleCascade";
+import { objectBoundingBox } from "./bounds";
+import type {
+  FilterColorInterpolation,
+  FilterInput,
+  FilterInstance,
+  FilterPrimitive,
+  FilterPrimitiveRegionSpec,
+  FilterPrimitiveSpec,
+  FilterResource,
+  FilterUnits,
+  Paint,
+  RenderBounds,
+  RenderDiagnostic,
+  RenderNode,
+  SourceLocation,
+} from "./types";
+
+const CLEAR: RGBAColor = { red: 0, green: 0, blue: 0, alpha: 0 };
+const RESERVED_INPUTS: Readonly<Record<string, FilterInput["type"]>> = {
+  SourceGraphic: "sourceGraphic",
+  SourceAlpha: "sourceAlpha",
+  BackgroundImage: "backgroundImage",
+  BackgroundAlpha: "backgroundAlpha",
+  FillPaint: "fillPaint",
+  StrokePaint: "strokePaint",
+};
+
+function sourceLocation(element: ElementNode): SourceLocation {
+  const id = element.properties?.id;
+  return { element: element.tagName ?? "unknown", ...(id === undefined ? {} : { id: String(id) }) };
+}
+
+function diagnostic(diagnostics: RenderDiagnostic[], element: ElementNode, code: string, message: string): void {
+  diagnostics.push({ code, message, severity: "warning", source: sourceLocation(element) });
+}
+
+function children(element: ElementNode): ElementNode[] {
+  return element.children.filter(
+    (child): child is ElementNode => typeof child !== "string" && child.type === "element",
+  );
+}
+
+function containsFilter(element: ElementNode): boolean {
+  return element.tagName?.toLowerCase() === "filter" || children(element).some(containsFilter);
+}
+
+function hasAttribute(element: ElementNode, name: string): boolean {
+  return Object.keys(element.properties ?? {}).some((key) => key.toLowerCase() === name.toLowerCase());
+}
+
+function attribute(element: ElementNode, name: string): unknown {
+  return Object.entries(element.properties ?? {}).find(([key]) => key.toLowerCase() === name.toLowerCase())?.[1];
+}
+
+function parsedLength(
+  raw: unknown,
+  fallback: string,
+  label: string,
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+): ParsedSVGLength {
+  try {
+    const parsed = parseSVGLength(raw ?? fallback);
+    if (parsed.kind !== "length") throw new SVGLengthError("invalid-filter-length", `${label} requires a length.`);
+    return parsed;
+  } catch (error) {
+    diagnostic(
+      diagnostics,
+      element,
+      error instanceof SVGLengthError ? error.code : "invalid-filter-length",
+      `Invalid ${label}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return parseSVGLength(fallback) as ParsedSVGLength;
+  }
+}
+
+function optionalLength(
+  element: ElementNode,
+  name: "x" | "y" | "width" | "height",
+  diagnostics: RenderDiagnostic[],
+): ParsedSVGLength | undefined {
+  if (!hasAttribute(element, name)) return undefined;
+  return parsedLength(
+    attribute(element, name),
+    name === "width" || name === "height" ? "100%" : "0%",
+    name,
+    element,
+    diagnostics,
+  );
+}
+
+function units(
+  raw: unknown,
+  fallback: FilterUnits,
+  label: "filterUnits" | "primitiveUnits",
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+): FilterUnits {
+  const value = String(raw ?? fallback).trim();
+  if (value === "objectBoundingBox" || value === "userSpaceOnUse") return value;
+  diagnostic(diagnostics, element, `invalid-${label}`, `Invalid ${label} '${value}'.`);
+  return fallback;
+}
+
+function colorInterpolation(
+  raw: unknown,
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+): FilterColorInterpolation {
+  const value = String(raw ?? "linearRGB").trim();
+  if (value === "sRGB" || value === "linearRGB") return value;
+  if (value === "auto") return "linearRGB";
+  diagnostic(
+    diagnostics,
+    element,
+    "invalid-color-interpolation-filters",
+    `Invalid color-interpolation-filters '${value}'; using linearRGB.`,
+  );
+  return "linearRGB";
+}
+
+function numberValue(element: ElementNode, name: string, fallback: number, diagnostics: RenderDiagnostic[]): number {
+  const raw = attribute(element, name);
+  if (raw === undefined || String(raw).trim() === "") return fallback;
+  try {
+    return parsePlainNumber(raw, name);
+  } catch (error) {
+    diagnostic(
+      diagnostics,
+      element,
+      `invalid-filter-${name.toLowerCase()}`,
+      error instanceof Error ? error.message : String(error),
+    );
+    return fallback;
+  }
+}
+
+function numberPair(
+  element: ElementNode,
+  name: string,
+  fallback: number,
+  diagnostics: RenderDiagnostic[],
+): [number, number] {
+  const raw = attribute(element, name);
+  if (raw === undefined || String(raw).trim() === "") return [fallback, fallback];
+  const tokens = String(raw).trim().split(/\s+/);
+  if (tokens.length < 1 || tokens.length > 2) {
+    diagnostic(diagnostics, element, `invalid-filter-${name.toLowerCase()}`, `${name} requires one or two numbers.`);
+    return [fallback, fallback];
+  }
+  try {
+    const first = parsePlainNumber(tokens[0], name);
+    const second = tokens.length === 2 ? parsePlainNumber(tokens[1], name) : first;
+    if (first < 0 || second < 0) {
+      diagnostic(diagnostics, element, `negative-filter-${name.toLowerCase()}`, `${name} cannot be negative.`);
+      return [0, 0];
+    }
+    return [first, second];
+  } catch (error) {
+    diagnostic(
+      diagnostics,
+      element,
+      `invalid-filter-${name.toLowerCase()}`,
+      error instanceof Error ? error.message : String(error),
+    );
+    return [fallback, fallback];
+  }
+}
+
+function regionSpec(element: ElementNode, diagnostics: RenderDiagnostic[]): FilterPrimitiveRegionSpec {
+  const x = optionalLength(element, "x", diagnostics);
+  const y = optionalLength(element, "y", diagnostics);
+  const width = optionalLength(element, "width", diagnostics);
+  const height = optionalLength(element, "height", diagnostics);
+  return {
+    ...(x ? { x } : {}),
+    ...(y ? { y } : {}),
+    ...(width ? { width } : {}),
+    ...(height ? { height } : {}),
+  };
+}
+
+function floodColor(element: ElementNode, presentation: Presentation, diagnostics: RenderDiagnostic[]): RGBAColor {
+  const rawColor = String(presentation["flood-color"] ?? "black").trim();
+  const colorSource = rawColor.toLowerCase() === "currentcolor" ? String(presentation.color ?? "black") : rawColor;
+  const parsed = parseRGBAColor(colorSource);
+  if (!parsed) {
+    diagnostic(diagnostics, element, "invalid-flood-color", `Invalid flood-color '${rawColor}'; using black.`);
+  }
+  const color = parsed ?? { red: 0, green: 0, blue: 0, alpha: 1 };
+  const rawOpacity = presentation["flood-opacity"] ?? 1;
+  const opacitySource = String(rawOpacity).trim();
+  if (
+    opacitySource === "" ||
+    !Number.isFinite(Number(opacitySource.endsWith("%") ? opacitySource.slice(0, -1) : opacitySource))
+  ) {
+    diagnostic(diagnostics, element, "invalid-flood-opacity", `Invalid flood-opacity '${opacitySource}'; using 1.`);
+  }
+  return { ...color, alpha: color.alpha * parseOpacity(rawOpacity) };
+}
+
+function localHref(element: ElementNode, diagnostics: RenderDiagnostic[]): string | undefined {
+  const raw = attribute(element, "href") ?? attribute(element, "xlink:href");
+  if (raw === undefined || String(raw).trim() === "") return undefined;
+  const value = String(raw).trim();
+  const match = /^#([^\s]+)$/.exec(value);
+  if (match) return match[1];
+  diagnostic(
+    diagnostics,
+    element,
+    "external-filter-href",
+    `Only local filter href references are supported; received '${value}'.`,
+  );
+  return undefined;
+}
+
+function buildPrimitiveSpecs(
+  filter: ElementNode,
+  filterPresentation: Presentation,
+  styleResolver: SVGStyleResolver,
+  diagnostics: RenderDiagnostic[],
+): FilterPrimitiveSpec[] {
+  const specs: FilterPrimitiveSpec[] = [];
+  const named = new Map<string, number>();
+  const previousInput = (): FilterInput =>
+    specs.length === 0 ? { type: "sourceGraphic" } : { type: "result", index: specs.length - 1 };
+  const resolveInput = (element: ElementNode, raw: unknown): FilterInput => {
+    if (raw === undefined || String(raw).trim() === "") return previousInput();
+    const value = String(raw).trim();
+    const reserved = RESERVED_INPUTS[value];
+    if (reserved) {
+      if (reserved === "backgroundImage" || reserved === "backgroundAlpha")
+        diagnostic(
+          diagnostics,
+          element,
+          "unsupported-filter-background-input",
+          `${value} is unavailable in the current static compositing context and resolves to transparent black.`,
+        );
+      return { type: reserved } as FilterInput;
+    }
+    const index = named.get(value);
+    if (index !== undefined) return { type: "result", index };
+    diagnostic(
+      diagnostics,
+      element,
+      "unknown-filter-input",
+      `Filter input '${value}' does not name a preceding result; using the default input.`,
+    );
+    return previousInput();
+  };
+
+  for (const element of children(filter)) {
+    const tag = (element.tagName ?? "").toLowerCase();
+    if (["title", "desc", "metadata", "script", "animate", "set"].includes(tag)) continue;
+    if (!tag.startsWith("fe") || tag === "femergenode") continue;
+    const resolved = styleResolver.resolve(element, filterPresentation).values;
+    const input = resolveInput(element, attribute(element, "in"));
+    const input2 = hasAttribute(element, "in2") ? resolveInput(element, attribute(element, "in2")) : undefined;
+    const common = {
+      region: regionSpec(element, diagnostics),
+      colorInterpolation: colorInterpolation(resolved["color-interpolation-filters"], element, diagnostics),
+      source: sourceLocation(element),
+      ...(input2 ? { input2 } : {}),
+    };
+    let spec: FilterPrimitiveSpec;
+    if (tag === "fegaussianblur") {
+      const [stdDeviationX, stdDeviationY] = numberPair(element, "stdDeviation", 0, diagnostics);
+      const rawEdge = String(attribute(element, "edgeMode") ?? "none")
+        .trim()
+        .toLowerCase();
+      const edgeMode = rawEdge === "duplicate" || rawEdge === "wrap" || rawEdge === "none" ? rawEdge : "none";
+      if (edgeMode !== rawEdge)
+        diagnostic(diagnostics, element, "invalid-filter-edge-mode", `Invalid edgeMode '${rawEdge}'; using none.`);
+      spec = { type: "gaussianBlur", input, stdDeviationX, stdDeviationY, edgeMode, ...common };
+    } else if (tag === "feoffset") {
+      spec = {
+        type: "offset",
+        input,
+        dx: numberValue(element, "dx", 0, diagnostics),
+        dy: numberValue(element, "dy", 0, diagnostics),
+        ...common,
+      };
+    } else if (tag === "feflood") {
+      spec = { type: "flood", color: floodColor(element, resolved, diagnostics), ...common };
+    } else if (tag === "femerge") {
+      const inputs = children(element)
+        .filter((child) => child.tagName?.toLowerCase() === "femergenode")
+        .map((child) => resolveInput(child, attribute(child, "in")));
+      spec = { type: "merge", inputs, ...common };
+    } else if (tag === "fedropshadow") {
+      const [stdDeviationX, stdDeviationY] = numberPair(element, "stdDeviation", 2, diagnostics);
+      spec = {
+        type: "dropShadow",
+        input,
+        stdDeviationX,
+        stdDeviationY,
+        dx: numberValue(element, "dx", 2, diagnostics),
+        dy: numberValue(element, "dy", 2, diagnostics),
+        color: floodColor(element, resolved, diagnostics),
+        ...common,
+      };
+    } else {
+      diagnostic(
+        diagnostics,
+        element,
+        "unsupported-filter-primitive",
+        `<${element.tagName}> is retained as a pass-through operation until its filter primitive ticket lands.`,
+      );
+      spec = { type: "passthrough", input, element: element.tagName ?? "unknown", ...common };
+    }
+
+    const result = String(attribute(element, "result") ?? "").trim();
+    if (result) {
+      if (RESERVED_INPUTS[result])
+        diagnostic(diagnostics, element, "invalid-filter-result-name", `Filter result '${result}' is reserved.`);
+      if (named.has(result))
+        diagnostic(
+          diagnostics,
+          element,
+          "duplicate-filter-result",
+          `Filter result '${result}' is duplicated; later inputs use the closest preceding result.`,
+        );
+      spec.result = result;
+      named.set(result, specs.length);
+    }
+    specs.push(spec);
+  }
+  return specs;
+}
+
+/** Resolve local filter definitions, href inheritance, graph names, and primitive presentation. */
+export function resolveFilterResources(
+  root: ElementNode,
+  filterElements: Map<string, ElementNode>,
+  definitions: Map<string, ElementNode>,
+  styleResolver: SVGStyleResolver,
+  rootPresentation: Presentation,
+  diagnostics: RenderDiagnostic[],
+): Map<string, FilterResource> {
+  const resolutions = new Map<ElementNode, StyleResolution>();
+  const walk = (element: ElementNode, inherited: Presentation): void => {
+    for (const child of children(element)) {
+      if (!containsFilter(child)) continue;
+      const resolved = styleResolver.resolve(child, inherited);
+      resolutions.set(child, resolved);
+      walk(child, resolved.values);
+    }
+  };
+  walk(root, rootPresentation);
+
+  const resources = new Map<string, FilterResource>();
+  const resolving: string[] = [];
+  const resolveOne = (id: string): FilterResource | undefined => {
+    const cached = resources.get(id);
+    if (cached) return cached;
+    const element = filterElements.get(id);
+    if (!element) return undefined;
+    const cycleIndex = resolving.indexOf(id);
+    if (cycleIndex >= 0) {
+      const cycle = [...resolving.slice(cycleIndex), id];
+      diagnostic(
+        diagnostics,
+        element,
+        "cyclic-filter-reference",
+        `Filter href cycle detected: ${cycle.map((item) => `#${item}`).join(" -> ")}.`,
+      );
+      return undefined;
+    }
+    resolving.push(id);
+    const presentation = resolutions.get(element)?.values ?? rootPresentation;
+    const href = localHref(element, diagnostics);
+    let base: FilterResource | undefined;
+    if (href) {
+      const target = definitions.get(href);
+      if (!target || target.tagName?.toLowerCase() !== "filter") {
+        diagnostic(
+          diagnostics,
+          element,
+          target ? "wrong-filter-href-resource-type" : "missing-filter-href-resource",
+          target
+            ? `Filter href #${href} targets <${target.tagName}> instead of a filter.`
+            : `Filter href #${href} does not resolve to a local filter.`,
+        );
+      } else {
+        base = resolveOne(href);
+      }
+    }
+    const primitiveElements = children(element).filter((child) => (child.tagName ?? "").toLowerCase().startsWith("fe"));
+    const width = hasAttribute(element, "width")
+      ? parsedLength(attribute(element, "width"), "120%", "filter width", element, diagnostics)
+      : (base?.width ?? parsedLength(undefined, "120%", "filter width", element, diagnostics));
+    const height = hasAttribute(element, "height")
+      ? parsedLength(attribute(element, "height"), "120%", "filter height", element, diagnostics)
+      : (base?.height ?? parsedLength(undefined, "120%", "filter height", element, diagnostics));
+    if (width.value < 0) diagnostic(diagnostics, element, "negative-filter-width", "Filter width cannot be negative.");
+    if (height.value < 0)
+      diagnostic(diagnostics, element, "negative-filter-height", "Filter height cannot be negative.");
+    const resource: FilterResource = {
+      id,
+      x: hasAttribute(element, "x")
+        ? parsedLength(attribute(element, "x"), "-10%", "filter x", element, diagnostics)
+        : (base?.x ?? parsedLength(undefined, "-10%", "filter x", element, diagnostics)),
+      y: hasAttribute(element, "y")
+        ? parsedLength(attribute(element, "y"), "-10%", "filter y", element, diagnostics)
+        : (base?.y ?? parsedLength(undefined, "-10%", "filter y", element, diagnostics)),
+      width,
+      height,
+      units: hasAttribute(element, "filterUnits")
+        ? units(attribute(element, "filterUnits"), "objectBoundingBox", "filterUnits", element, diagnostics)
+        : (base?.units ?? "objectBoundingBox"),
+      primitiveUnits: hasAttribute(element, "primitiveUnits")
+        ? units(attribute(element, "primitiveUnits"), "userSpaceOnUse", "primitiveUnits", element, diagnostics)
+        : (base?.primitiveUnits ?? "userSpaceOnUse"),
+      colorInterpolation: colorInterpolation(presentation["color-interpolation-filters"], element, diagnostics),
+      ...(href ? { href } : {}),
+      source: sourceLocation(element),
+      element,
+      primitives:
+        primitiveElements.length > 0
+          ? buildPrimitiveSpecs(element, presentation, styleResolver, diagnostics)
+          : (base?.primitives ?? []),
+      instances: new Map(),
+      invalid: href !== undefined && (!base || base.invalid),
+    };
+    resources.set(id, resource);
+    resolving.pop();
+    return resource;
+  };
+  for (const id of filterElements.keys()) resolveOne(id);
+  return resources;
+}
+
+function resolvedLength(
+  value: ParsedSVGLength,
+  axis: "horizontal" | "vertical",
+  unitsValue: FilterUnits,
+  node: RenderNode,
+) {
+  const viewport = unitsValue === "objectBoundingBox" ? { width: 1, height: 1 } : node.paintContext.viewport;
+  const result = resolveSVGLength(
+    value,
+    lengthContext(
+      viewport,
+      node.paintContext.rootViewport,
+      axis === "horizontal" ? "viewport-width" : "viewport-height",
+      axis,
+      node.paintContext.fontMetrics,
+    ),
+  );
+  return typeof result === "number" ? result : 0;
+}
+
+function coordinate(
+  value: ParsedSVGLength,
+  axis: "horizontal" | "vertical",
+  unitsValue: FilterUnits,
+  node: RenderNode,
+  bounds: RenderBounds | undefined,
+  size = false,
+): number {
+  const resolved = resolvedLength(value, axis, unitsValue, node);
+  if (unitsValue !== "objectBoundingBox" || !bounds) return resolved;
+  const extent = axis === "horizontal" ? bounds.width : bounds.height;
+  if (size) return resolved * extent;
+  return (axis === "horizontal" ? bounds.x : bounds.y) + resolved * extent;
+}
+
+function intersect(left: RenderBounds, right: RenderBounds): RenderBounds {
+  const x = Math.max(left.x, right.x);
+  const y = Math.max(left.y, right.y);
+  const maxX = Math.min(left.x + left.width, right.x + right.width);
+  const maxY = Math.min(left.y + left.height, right.y + right.height);
+  return maxX <= x || maxY <= y ? { x, y, width: 0, height: 0 } : { x, y, width: maxX - x, height: maxY - y };
+}
+
+function union(bounds: RenderBounds[]): RenderBounds | undefined {
+  if (bounds.length === 0) return undefined;
+  const x = Math.min(...bounds.map((item) => item.x));
+  const y = Math.min(...bounds.map((item) => item.y));
+  const maxX = Math.max(...bounds.map((item) => item.x + item.width));
+  const maxY = Math.max(...bounds.map((item) => item.y + item.height));
+  return { x, y, width: maxX - x, height: maxY - y };
+}
+
+function inputRegion(input: FilterInput, previous: FilterPrimitive[], filterRegion: RenderBounds): RenderBounds {
+  return input.type === "result" ? (previous[input.index]?.subregion ?? filterRegion) : filterRegion;
+}
+
+function subregion(
+  spec: FilterPrimitiveSpec,
+  previous: FilterPrimitive[],
+  filterRegion: RenderBounds,
+  resource: FilterResource,
+  node: RenderNode,
+  bounds: RenderBounds | undefined,
+): RenderBounds {
+  const inputs = spec.type === "merge" ? spec.inputs : [spec.input, spec.input2].filter((input) => input !== undefined);
+  const defaults = union(inputs.map((input) => inputRegion(input, previous, filterRegion))) ?? filterRegion;
+  const x = spec.region.x ? coordinate(spec.region.x, "horizontal", resource.primitiveUnits, node, bounds) : defaults.x;
+  const y = spec.region.y ? coordinate(spec.region.y, "vertical", resource.primitiveUnits, node, bounds) : defaults.y;
+  const width = spec.region.width
+    ? coordinate(spec.region.width, "horizontal", resource.primitiveUnits, node, bounds, true)
+    : defaults.width;
+  const height = spec.region.height
+    ? coordinate(spec.region.height, "vertical", resource.primitiveUnits, node, bounds, true)
+    : defaults.height;
+  return intersect({ x, y, width: Math.max(0, width), height: Math.max(0, height) }, filterRegion);
+}
+
+function paintColor(paint: Paint, opacity: number): RGBAColor {
+  const source = paint.type === "solid" ? paint.value : paint.type === "reference" ? paint.fallback : undefined;
+  const color = source ? parseRGBAColor(source) : undefined;
+  return color ? { ...color, alpha: color.alpha * opacity } : CLEAR;
+}
+
+/** Resolve filter regions and primitive-unit parameters for one referencing render node. */
+export function resolveFilterInstance(resource: FilterResource, node: RenderNode): FilterInstance {
+  const bounds = objectBoundingBox(node);
+  const needsBounds = resource.units === "objectBoundingBox" || resource.primitiveUnits === "objectBoundingBox";
+  if (resource.invalid || (needsBounds && (!bounds || bounds.width === 0 || bounds.height === 0))) {
+    return {
+      resource,
+      region: { x: 0, y: 0, width: 0, height: 0 },
+      primitives: [],
+      fillPaint: CLEAR,
+      strokePaint: CLEAR,
+      invalid: true,
+    };
+  }
+  const region = {
+    x: coordinate(resource.x, "horizontal", resource.units, node, bounds),
+    y: coordinate(resource.y, "vertical", resource.units, node, bounds),
+    width: coordinate(resource.width, "horizontal", resource.units, node, bounds, true),
+    height: coordinate(resource.height, "vertical", resource.units, node, bounds, true),
+  };
+  const scaleX = resource.primitiveUnits === "objectBoundingBox" ? (bounds?.width ?? 0) : 1;
+  const scaleY = resource.primitiveUnits === "objectBoundingBox" ? (bounds?.height ?? 0) : 1;
+  const primitives: FilterPrimitive[] = [];
+  for (const spec of resource.primitives) {
+    const common = {
+      ...(spec.result ? { result: spec.result } : {}),
+      subregion: subregion(spec, primitives, region, resource, node, bounds),
+      colorInterpolation: spec.colorInterpolation,
+      source: spec.source,
+    };
+    if (spec.type === "gaussianBlur")
+      primitives.push({
+        ...spec,
+        stdDeviationX: spec.stdDeviationX * scaleX,
+        stdDeviationY: spec.stdDeviationY * scaleY,
+        ...common,
+      });
+    else if (spec.type === "offset")
+      primitives.push({ ...spec, dx: spec.dx * scaleX, dy: spec.dy * scaleY, ...common });
+    else if (spec.type === "dropShadow")
+      primitives.push({
+        ...spec,
+        stdDeviationX: spec.stdDeviationX * scaleX,
+        stdDeviationY: spec.stdDeviationY * scaleY,
+        dx: spec.dx * scaleX,
+        dy: spec.dy * scaleY,
+        ...common,
+      });
+    else primitives.push({ ...spec, ...common });
+  }
+  return {
+    resource,
+    region,
+    primitives,
+    fillPaint: paintColor(node.style.contextFill ?? node.style.fill, node.style.fillOpacity),
+    strokePaint: paintColor(node.style.stroke, node.style.strokeOpacity),
+    invalid: region.width <= 0 || region.height <= 0,
+  };
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -13,6 +13,9 @@ import type {
   AccessibilityMetadata,
   ClipPathInstance,
   ComputedStyle,
+  FilterInput,
+  FilterInstance,
+  FilterPrimitive,
   Geometry,
   GradientStop,
   MaskInstance,
@@ -77,6 +80,7 @@ type GeneratedViewNode =
       viewportClip?: string;
       clipPath?: GeneratedClipPath;
       mask?: GeneratedMask;
+      filter?: GeneratedFilter;
       tileContained?: boolean;
       accessibility?: AccessibilityMetadata;
     };
@@ -85,6 +89,11 @@ interface GeneratedMask {
   children: GeneratedViewNode[];
   clip: string;
   luminance: boolean;
+}
+
+interface GeneratedFilter {
+  instance: FilterInstance;
+  canvas: ViewBoxData;
 }
 
 interface GeneratedClipPath {
@@ -306,6 +315,63 @@ function buildViewNodes(
 ): GeneratedViewNode[] {
   const generated: GeneratedViewNode[] = [];
 
+  const buildFilter = (
+    filter: FilterInstance | undefined,
+    targetTransforms: RenderNode["transform"][],
+  ): GeneratedFilter | undefined => {
+    if (!filter || filter.invalid) return undefined;
+    const transform = targetTransforms.reduce(multiplyTransforms);
+    const transformRegion = (region: FilterInstance["region"]): FilterInstance["region"] => {
+      const points = [
+        [region.x, region.y],
+        [region.x + region.width, region.y],
+        [region.x, region.y + region.height],
+        [region.x + region.width, region.y + region.height],
+      ].map(([x, y]) => ({
+        x: transform.a * x! + transform.c * y! + transform.e,
+        y: transform.b * x! + transform.d * y! + transform.f,
+      }));
+      const xs = points.map((point) => point.x);
+      const ys = points.map((point) => point.y);
+      const x = Math.min(...xs);
+      const y = Math.min(...ys);
+      return { x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y };
+    };
+    const transformPrimitive = (primitive: FilterPrimitive): FilterPrimitive => {
+      const subregion = transformRegion(primitive.subregion);
+      if (primitive.type === "offset")
+        return {
+          ...primitive,
+          subregion,
+          dx: transform.a * primitive.dx + transform.c * primitive.dy,
+          dy: transform.b * primitive.dx + transform.d * primitive.dy,
+        };
+      if (primitive.type === "gaussianBlur" || primitive.type === "dropShadow") {
+        const stdDeviationX = Math.hypot(transform.a * primitive.stdDeviationX, transform.c * primitive.stdDeviationY);
+        const stdDeviationY = Math.hypot(transform.b * primitive.stdDeviationX, transform.d * primitive.stdDeviationY);
+        return primitive.type === "gaussianBlur"
+          ? { ...primitive, subregion, stdDeviationX, stdDeviationY }
+          : {
+              ...primitive,
+              subregion,
+              stdDeviationX,
+              stdDeviationY,
+              dx: transform.a * primitive.dx + transform.c * primitive.dy,
+              dy: transform.b * primitive.dx + transform.d * primitive.dy,
+            };
+      }
+      return { ...primitive, subregion };
+    };
+    return {
+      instance: {
+        ...filter,
+        region: transformRegion(filter.region),
+        primitives: filter.primitives.map(transformPrimitive),
+      },
+      canvas: context.coordinateSpace,
+    };
+  };
+
   const buildMask = (
     mask: MaskInstance | undefined,
     targetTransforms: RenderNode["transform"][],
@@ -466,6 +532,7 @@ function buildViewNodes(
       if (children.length > 0) {
         const clipPath = buildClipPath(node.clipPath, targetTransforms);
         const mask = buildMask(node.mask, targetTransforms);
+        const filter = buildFilter(node.filter, targetTransforms);
         generated.push({
           type: "group",
           children,
@@ -475,11 +542,13 @@ function buildViewNodes(
             node.style.isolation === "isolate" ||
             node.style.blendMode !== "normal" ||
             !!clipPath ||
-            !!mask,
+            !!mask ||
+            !!filter,
           blendMode: node.style.blendMode,
           ...(viewportClip ? { viewportClip } : {}),
           ...(clipPath ? { clipPath } : {}),
           ...(mask ? { mask } : {}),
+          ...(filter ? { filter } : {}),
           ...(node.accessibility ? { accessibility: node.accessibility } : {}),
         });
       }
@@ -493,6 +562,7 @@ function buildViewNodes(
       const targetTransforms = [...ancestorTransforms, node.transform];
       const clipPath = buildClipPath(node.clipPath, targetTransforms);
       const mask = buildMask(node.mask, targetTransforms);
+      const filter = buildFilter(node.filter, targetTransforms);
       generated.push({
         type: "group",
         children: [{ type: "text", helper: name }],
@@ -502,10 +572,12 @@ function buildViewNodes(
           node.style.isolation === "isolate" ||
           node.style.blendMode !== "normal" ||
           !!clipPath ||
-          !!mask,
+          !!mask ||
+          !!filter,
         blendMode: node.style.blendMode,
         ...(clipPath ? { clipPath } : {}),
         ...(mask ? { mask } : {}),
+        ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
       });
       continue;
@@ -551,6 +623,7 @@ function buildViewNodes(
       const targetTransforms = [...ancestorTransforms, node.transform];
       const clipPath = buildClipPath(node.clipPath, targetTransforms);
       const mask = buildMask(node.mask, targetTransforms);
+      const filter = buildFilter(node.filter, targetTransforms);
       generated.push({
         type: "group",
         children: [{ type: "image", helper: name }],
@@ -560,10 +633,12 @@ function buildViewNodes(
           node.style.isolation === "isolate" ||
           node.style.blendMode !== "normal" ||
           !!clipPath ||
-          !!mask,
+          !!mask ||
+          !!filter,
         blendMode: node.style.blendMode,
         ...(clipPath ? { clipPath } : {}),
         ...(mask ? { mask } : {}),
+        ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
       });
       continue;
@@ -696,6 +771,7 @@ function buildViewNodes(
       const targetTransforms = [...ancestorTransforms, node.transform];
       const clipPath = buildClipPath(node.clipPath, targetTransforms);
       const mask = buildMask(node.mask, targetTransforms);
+      const filter = buildFilter(node.filter, targetTransforms);
       generated.push({
         type: "group",
         children: paints,
@@ -705,10 +781,12 @@ function buildViewNodes(
           node.style.isolation === "isolate" ||
           node.style.blendMode !== "normal" ||
           !!clipPath ||
-          !!mask,
+          !!mask ||
+          !!filter,
         blendMode: node.style.blendMode,
         ...(clipPath ? { clipPath } : {}),
         ...(mask ? { mask } : {}),
+        ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
       });
     }
@@ -730,6 +808,43 @@ function swiftString(value: string): string {
 
 function swiftTransform(matrix: RenderNode["transform"]): string {
   return `CGAffineTransform(a: ${formatNumber(matrix.a)}, b: ${formatNumber(matrix.b)}, c: ${formatNumber(matrix.c)}, d: ${formatNumber(matrix.d)}, tx: ${formatNumber(matrix.e)}, ty: ${formatNumber(matrix.f)})`;
+}
+
+function filterInputLiteral(input: FilterInput): string {
+  return input.type === "result" ? `.result(${input.index})` : `.${input.type}`;
+}
+
+function filterColorLiteral(color: RGBAColor): string {
+  return `SVGFilterColor(red: ${formatNumber(color.red)}, green: ${formatNumber(color.green)}, blue: ${formatNumber(color.blue)}, alpha: ${formatNumber(color.alpha)})`;
+}
+
+function filterRegionLiteral(region: FilterInstance["region"]): string {
+  return `SVGFilterRegion(x: ${formatNumber(region.x)}, y: ${formatNumber(region.y)}, width: ${formatNumber(region.width)}, height: ${formatNumber(region.height)})`;
+}
+
+function filterPrimitiveLiteral(primitive: FilterPrimitive): string {
+  const region = filterRegionLiteral(primitive.subregion);
+  const linear = primitive.colorInterpolation === "linearRGB" ? "true" : "false";
+  const result = primitive.result ? swiftString(primitive.result) : "nil";
+  switch (primitive.type) {
+    case "gaussianBlur":
+      return `.gaussianBlur(input: ${filterInputLiteral(primitive.input)}, sigmaX: ${formatNumber(primitive.stdDeviationX)}, sigmaY: ${formatNumber(primitive.stdDeviationY)}, edge: .${primitive.edgeMode}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "offset":
+      return `.offset(input: ${filterInputLiteral(primitive.input)}, dx: ${formatNumber(primitive.dx)}, dy: ${formatNumber(primitive.dy)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "flood":
+      return `.flood(color: ${filterColorLiteral(primitive.color)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "merge":
+      return `.merge(inputs: [${primitive.inputs.map(filterInputLiteral).join(", ")}], region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "dropShadow":
+      return `.dropShadow(input: ${filterInputLiteral(primitive.input)}, sigmaX: ${formatNumber(primitive.stdDeviationX)}, sigmaY: ${formatNumber(primitive.stdDeviationY)}, dx: ${formatNumber(primitive.dx)}, dy: ${formatNumber(primitive.dy)}, color: ${filterColorLiteral(primitive.color)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "passthrough":
+      return `.passthrough(input: ${filterInputLiteral(primitive.input)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+  }
+}
+
+function filterDefinitionLiteral(filter: GeneratedFilter): string {
+  const instance = filter.instance;
+  return `SVGFilterDefinition(region: ${filterRegionLiteral(instance.region)}, primitives: [${instance.primitives.map(filterPrimitiveLiteral).join(", ")}], fillPaint: ${filterColorLiteral(instance.fillPaint)}, strokePaint: ${filterColorLiteral(instance.strokePaint)})`;
 }
 
 function textGradientLength(
@@ -1588,9 +1703,17 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
   }
   if (node.type === "gradient") return renderGradientNode(node, level, indentation);
   if (node.type === "pattern") return renderPatternNode(node, level, indentation);
-  const lines = [`${prefix}ZStack {`];
-  for (const child of node.children) lines.push(...renderViewNode(child, level + 1, indentation));
-  lines.push(`${prefix}}`);
+  const lines = node.filter
+    ? [
+        `${prefix}SVGFilteredCanvas(definition: ${filterDefinitionLiteral(node.filter)}, canvas: CGSize(width: ${formatNumber(node.filter.canvas.width)}, height: ${formatNumber(node.filter.canvas.height)})) { graphics, size in`,
+        ...renderGeneratedCommands(node.children, "graphics", level + 1, indentation),
+        `${prefix}}`,
+      ]
+    : [`${prefix}ZStack {`];
+  if (!node.filter) {
+    for (const child of node.children) lines.push(...renderViewNode(child, level + 1, indentation));
+    lines.push(`${prefix}}`);
+  }
   // Flatten the source subtree before applying SVG effects. SwiftUI otherwise
   // distributes masks and opacity across ZStack children, which changes
   // overlap colors and prevents nested clip-path intersections from composing.
@@ -1687,6 +1810,406 @@ function containsGradientNode(nodes: GeneratedViewNode[]): boolean {
           (node.mask ? containsGradientNode(node.mask.children) : false))) ||
       (node.type === "pattern" && containsGradientNode(node.contentNodes)),
   );
+}
+
+function containsFilterNode(nodes: GeneratedViewNode[]): boolean {
+  return nodes.some(
+    (node) =>
+      (node.type === "group" &&
+        (node.filter !== undefined ||
+          containsFilterNode(node.children) ||
+          (node.clipPath ? containsFilterNode(node.clipPath.children) : false) ||
+          (node.mask ? containsFilterNode(node.mask.children) : false))) ||
+      (node.type === "pattern" && containsFilterNode(node.contentNodes)),
+  );
+}
+
+function filterSupport(indentationSize: number): string[] {
+  const source = `private struct SVGFilterColor {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+
+}
+
+private struct SVGFilterRegion {
+    let x: CGFloat
+    let y: CGFloat
+    let width: CGFloat
+    let height: CGFloat
+
+}
+
+private enum SVGFilterInput {
+    case sourceGraphic
+    case sourceAlpha
+    case backgroundImage
+    case backgroundAlpha
+    case fillPaint
+    case strokePaint
+    case result(Int)
+}
+
+private enum SVGFilterEdgeMode {
+    case none
+    case duplicate
+    case wrap
+}
+
+private enum SVGFilterPrimitive {
+    case gaussianBlur(input: SVGFilterInput, sigmaX: CGFloat, sigmaY: CGFloat, edge: SVGFilterEdgeMode, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case offset(input: SVGFilterInput, dx: CGFloat, dy: CGFloat, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case flood(color: SVGFilterColor, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case merge(inputs: [SVGFilterInput], region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case dropShadow(input: SVGFilterInput, sigmaX: CGFloat, sigmaY: CGFloat, dx: CGFloat, dy: CGFloat, color: SVGFilterColor, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case passthrough(input: SVGFilterInput, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+
+    var region: SVGFilterRegion {
+        switch self {
+        case let .gaussianBlur(_, _, _, _, region, _, _),
+             let .offset(_, _, _, region, _, _),
+             let .flood(_, region, _, _),
+             let .merge(_, region, _, _),
+             let .dropShadow(_, _, _, _, _, _, region, _, _),
+             let .passthrough(_, region, _, _):
+            return region
+        }
+    }
+
+    var linearRGB: Bool {
+        switch self {
+        case let .gaussianBlur(_, _, _, _, _, value, _),
+             let .offset(_, _, _, _, value, _),
+             let .flood(_, _, value, _),
+             let .merge(_, _, value, _),
+             let .dropShadow(_, _, _, _, _, _, _, value, _),
+             let .passthrough(_, _, value, _):
+            return value
+        }
+    }
+}
+
+private struct SVGFilterDefinition {
+    let region: SVGFilterRegion
+    let primitives: [SVGFilterPrimitive]
+    let fillPaint: SVGFilterColor
+    let strokePaint: SVGFilterColor
+}
+
+private struct SVGFilteredCanvas: View {
+    let definition: SVGFilterDefinition
+    let canvas: CGSize
+    let drawSource: (CGContext, CGSize) -> Void
+    @Environment(\\.displayScale) private var displayScale
+
+    var body: some View {
+        Canvas { context, size in
+            if let image = render(size: size) {
+                context.draw(Image(decorative: image, scale: displayScale), in: CGRect(origin: .zero, size: size))
+            }
+        }
+    }
+
+    @MainActor
+    private func render(size: CGSize) -> CGImage? {
+        guard size.width > 0, size.height > 0, canvas.width > 0, canvas.height > 0 else { return nil }
+        let pixelWidth = max(1, Int((size.width * displayScale).rounded()))
+        let pixelHeight = max(1, Int((size.height * displayScale).rounded()))
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        guard let graphics = CGContext(
+            data: nil,
+            width: pixelWidth,
+            height: pixelHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: pixelWidth * 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        graphics.translateBy(x: 0, y: CGFloat(pixelHeight))
+        graphics.scaleBy(x: displayScale, y: -displayScale)
+        drawSource(graphics, size)
+        guard let sourceImage = graphics.makeImage() else { return nil }
+        return SVGFilterBitmapRuntime.render(definition, sourceImage: sourceImage, canvas: canvas)
+    }
+}
+
+private struct SVGFilterBitmap {
+    let width: Int
+    let height: Int
+    var values: [Float]
+
+    init(width: Int, height: Int, values: [Float]? = nil) {
+        self.width = width
+        self.height = height
+        self.values = values ?? Array(repeating: 0, count: width * height * 4)
+    }
+
+    func component(_ x: Int, _ y: Int, _ channel: Int) -> Float {
+        guard x >= 0, y >= 0, x < width, y < height else { return 0 }
+        return values[(y * width + x) * 4 + channel]
+    }
+}
+
+private struct SVGFilterPixelRect {
+    let minX: Int
+    let minY: Int
+    let maxX: Int
+    let maxY: Int
+
+    func contains(_ x: Int, _ y: Int) -> Bool {
+        x >= minX && x < maxX && y >= minY && y < maxY
+    }
+}
+
+private enum SVGFilterBitmapRuntime {
+    static func render(_ definition: SVGFilterDefinition, sourceImage: CGImage, canvas: CGSize) -> CGImage? {
+        guard let data = sourceImage.dataProvider?.data, let bytes = CFDataGetBytePtr(data) else { return nil }
+        let width = sourceImage.width
+        let height = sourceImage.height
+        var source = SVGFilterBitmap(width: width, height: height)
+        for y in 0..<height {
+            for x in 0..<width {
+                let byte = y * sourceImage.bytesPerRow + x * 4
+                let value = (y * width + x) * 4
+                source.values[value] = Float(bytes[byte]) / 255
+                source.values[value + 1] = Float(bytes[byte + 1]) / 255
+                source.values[value + 2] = Float(bytes[byte + 2]) / 255
+                source.values[value + 3] = Float(bytes[byte + 3]) / 255
+            }
+        }
+        let scaleX = CGFloat(width) / canvas.width
+        let scaleY = CGFloat(height) / canvas.height
+        let output = apply(definition, source: source, scaleX: scaleX, scaleY: scaleY)
+        let outputBytes = output.values.map { UInt8((min(1, max(0, $0)) * 255).rounded()) }
+        let outputData = Data(outputBytes)
+        guard let provider = CGDataProvider(data: outputData as CFData) else { return nil }
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        return CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: width * 4,
+            space: colorSpace,
+            bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: true,
+            intent: .defaultIntent
+        )
+    }
+
+    private static func pixelRect(_ region: SVGFilterRegion, scaleX: CGFloat, scaleY: CGFloat, height: Int) -> SVGFilterPixelRect {
+        SVGFilterPixelRect(
+            minX: max(0, Int(floor(region.x * scaleX))),
+            minY: max(0, Int(floor(region.y * scaleY))),
+            maxX: min(Int(ceil((region.x + region.width) * scaleX)), Int.max),
+            maxY: min(Int(ceil((region.y + region.height) * scaleY)), height)
+        )
+    }
+
+    private static func cropped(_ image: SVGFilterBitmap, to rect: SVGFilterPixelRect) -> SVGFilterBitmap {
+        var result = image
+        for y in 0..<image.height {
+            for x in 0..<image.width where !rect.contains(x, y) {
+                let index = (y * image.width + x) * 4
+                result.values[index] = 0
+                result.values[index + 1] = 0
+                result.values[index + 2] = 0
+                result.values[index + 3] = 0
+            }
+        }
+        return result
+    }
+
+    private static func constant(_ color: SVGFilterColor, width: Int, height: Int) -> SVGFilterBitmap {
+        let alpha = Float(color.alpha)
+        let pixel: [Float] = [Float(color.red) * alpha, Float(color.green) * alpha, Float(color.blue) * alpha, alpha]
+        return SVGFilterBitmap(width: width, height: height, values: Array(repeating: pixel, count: width * height).flatMap { $0 })
+    }
+
+    private static func alpha(_ image: SVGFilterBitmap) -> SVGFilterBitmap {
+        var result = image
+        for index in stride(from: 0, to: result.values.count, by: 4) {
+            result.values[index] = 0
+            result.values[index + 1] = 0
+            result.values[index + 2] = 0
+        }
+        return result
+    }
+
+    private static func converted(_ image: SVGFilterBitmap, linear: Bool, encode: Bool) -> SVGFilterBitmap {
+        guard linear else { return image }
+        var result = image
+        for index in stride(from: 0, to: result.values.count, by: 4) {
+            let alpha = result.values[index + 3]
+            guard alpha > 0 else { continue }
+            for channel in 0..<3 {
+                let value = min(1, max(0, result.values[index + channel] / alpha))
+                let converted: Float
+                if encode {
+                    converted = value <= 0.0031308 ? value * 12.92 : 1.055 * pow(value, 1 / 2.4) - 0.055
+                } else {
+                    converted = value <= 0.04045 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+                }
+                result.values[index + channel] = converted * alpha
+            }
+        }
+        return result
+    }
+
+    private static func gaussianKernel(_ sigma: CGFloat) -> [Float] {
+        guard sigma > 0 else { return [1] }
+        let radius = max(1, Int(ceil(sigma * 3)))
+        var kernel = (-radius...radius).map { offset in Float(exp(-CGFloat(offset * offset) / (2 * sigma * sigma))) }
+        let total = kernel.reduce(0, +)
+        for index in kernel.indices { kernel[index] /= total }
+        return kernel
+    }
+
+    private static func sample(_ image: SVGFilterBitmap, x: Int, y: Int, channel: Int, edge: SVGFilterEdgeMode, bounds: SVGFilterPixelRect) -> Float {
+        if bounds.contains(x, y) { return image.component(x, y, channel) }
+        switch edge {
+        case .none: return 0
+        case .duplicate:
+            return image.component(min(bounds.maxX - 1, max(bounds.minX, x)), min(bounds.maxY - 1, max(bounds.minY, y)), channel)
+        case .wrap:
+            let width = max(1, bounds.maxX - bounds.minX)
+            let height = max(1, bounds.maxY - bounds.minY)
+            let wrappedX = bounds.minX + ((x - bounds.minX) % width + width) % width
+            let wrappedY = bounds.minY + ((y - bounds.minY) % height + height) % height
+            return image.component(wrappedX, wrappedY, channel)
+        }
+    }
+
+    private static func blur(_ image: SVGFilterBitmap, sigmaX: CGFloat, sigmaY: CGFloat, edge: SVGFilterEdgeMode, bounds: SVGFilterPixelRect) -> SVGFilterBitmap {
+        var horizontal = image
+        let kernelX = gaussianKernel(sigmaX)
+        let radiusX = kernelX.count / 2
+        if radiusX > 0 {
+            for y in 0..<image.height {
+                for x in 0..<image.width {
+                    for channel in 0..<4 {
+                        var value: Float = 0
+                        for offset in -radiusX...radiusX {
+                            value += sample(image, x: x + offset, y: y, channel: channel, edge: edge, bounds: bounds) * kernelX[offset + radiusX]
+                        }
+                        horizontal.values[(y * image.width + x) * 4 + channel] = value
+                    }
+                }
+            }
+        }
+        var vertical = horizontal
+        let kernelY = gaussianKernel(sigmaY)
+        let radiusY = kernelY.count / 2
+        if radiusY > 0 {
+            for y in 0..<image.height {
+                for x in 0..<image.width {
+                    for channel in 0..<4 {
+                        var value: Float = 0
+                        for offset in -radiusY...radiusY {
+                            value += sample(horizontal, x: x, y: y + offset, channel: channel, edge: edge, bounds: bounds) * kernelY[offset + radiusY]
+                        }
+                        vertical.values[(y * image.width + x) * 4 + channel] = value
+                    }
+                }
+            }
+        }
+        return vertical
+    }
+
+    private static func offset(_ image: SVGFilterBitmap, dx: CGFloat, dy: CGFloat) -> SVGFilterBitmap {
+        var result = SVGFilterBitmap(width: image.width, height: image.height)
+        for y in 0..<image.height {
+            for x in 0..<image.width {
+                let sourceX = CGFloat(x) - dx
+                let sourceY = CGFloat(y) - dy
+                let x0 = Int(floor(sourceX))
+                let y0 = Int(floor(sourceY))
+                let fractionX = Float(sourceX - CGFloat(x0))
+                let fractionY = Float(sourceY - CGFloat(y0))
+                for channel in 0..<4 {
+                    let top = image.component(x0, y0, channel) * (1 - fractionX) + image.component(x0 + 1, y0, channel) * fractionX
+                    let bottom = image.component(x0, y0 + 1, channel) * (1 - fractionX) + image.component(x0 + 1, y0 + 1, channel) * fractionX
+                    result.values[(y * image.width + x) * 4 + channel] = top * (1 - fractionY) + bottom * fractionY
+                }
+            }
+        }
+        return result
+    }
+
+    private static func over(_ source: SVGFilterBitmap, _ destination: SVGFilterBitmap) -> SVGFilterBitmap {
+        var result = source
+        for index in stride(from: 0, to: result.values.count, by: 4) {
+            let inverseAlpha = 1 - source.values[index + 3]
+            result.values[index] = source.values[index] + destination.values[index] * inverseAlpha
+            result.values[index + 1] = source.values[index + 1] + destination.values[index + 1] * inverseAlpha
+            result.values[index + 2] = source.values[index + 2] + destination.values[index + 2] * inverseAlpha
+            result.values[index + 3] = source.values[index + 3] + destination.values[index + 3] * inverseAlpha
+        }
+        return result
+    }
+
+    private static func apply(_ definition: SVGFilterDefinition, source unboundedSource: SVGFilterBitmap, scaleX: CGFloat, scaleY: CGFloat) -> SVGFilterBitmap {
+        let filterRect = pixelRect(definition.region, scaleX: scaleX, scaleY: scaleY, height: unboundedSource.height)
+        let source = cropped(unboundedSource, to: filterRect)
+        let sourceAlpha = alpha(source)
+        let transparent = SVGFilterBitmap(width: source.width, height: source.height)
+        let fillPaint = cropped(constant(definition.fillPaint, width: source.width, height: source.height), to: filterRect)
+        let strokePaint = cropped(constant(definition.strokePaint, width: source.width, height: source.height), to: filterRect)
+        var results: [SVGFilterBitmap] = []
+
+        func input(_ value: SVGFilterInput) -> SVGFilterBitmap {
+            switch value {
+            case .sourceGraphic: return source
+            case .sourceAlpha: return sourceAlpha
+            case .backgroundImage, .backgroundAlpha: return transparent
+            case .fillPaint: return fillPaint
+            case .strokePaint: return strokePaint
+            case let .result(index): return results.indices.contains(index) ? results[index] : source
+            }
+        }
+
+        for primitive in definition.primitives {
+            let linear = primitive.linearRGB
+            let region = pixelRect(primitive.region, scaleX: scaleX, scaleY: scaleY, height: source.height)
+            let output: SVGFilterBitmap
+            switch primitive {
+            case let .gaussianBlur(value, sigmaX, sigmaY, edge, _, _, _):
+                output = converted(blur(converted(input(value), linear: linear, encode: false), sigmaX: sigmaX * scaleX, sigmaY: sigmaY * scaleY, edge: edge, bounds: region), linear: linear, encode: true)
+            case let .offset(value, dx, dy, _, _, _):
+                output = offset(input(value), dx: dx * scaleX, dy: dy * scaleY)
+            case let .flood(color, _, _, _):
+                output = constant(color, width: source.width, height: source.height)
+            case let .merge(inputs, _, _, _):
+                var merged = transparent
+                for value in inputs { merged = over(input(value), merged) }
+                output = merged
+            case let .dropShadow(value, sigmaX, sigmaY, dx, dy, color, _, _, _):
+                let shadowAlpha = offset(blur(alpha(input(value)), sigmaX: sigmaX * scaleX, sigmaY: sigmaY * scaleY, edge: .none, bounds: region), dx: dx * scaleX, dy: dy * scaleY)
+                var shadow = constant(color, width: source.width, height: source.height)
+                for index in stride(from: 0, to: shadow.values.count, by: 4) {
+                    let mask = shadowAlpha.values[index + 3]
+                    shadow.values[index] *= mask
+                    shadow.values[index + 1] *= mask
+                    shadow.values[index + 2] *= mask
+                    shadow.values[index + 3] *= mask
+                }
+                output = over(input(value), shadow)
+            case let .passthrough(value, _, _, _):
+                output = input(value)
+            }
+            results.append(cropped(output, to: region))
+        }
+        return cropped(results.last ?? source, to: filterRect)
+    }
+}`;
+  const indentation = " ".repeat(indentationSize);
+  return source.split("\n").map((line) => {
+    const leading = /^ */.exec(line)?.[0].length ?? 0;
+    return `${indentation.repeat(Math.floor(leading / 4))}${line.slice(leading)}`;
+  });
 }
 
 function base64(bytes: Uint8Array): string {
@@ -1904,6 +2427,7 @@ function createView(
     body.push("", ...createTextHelper(helper, coordinateSpace, document, indentationSize));
   for (const helper of imageHelpers) body.push("", ...createImageHelper(helper, coordinateSpace, indentationSize));
   if (containsGradientNode(nodes)) body.push("", ...gradientSupport(indentationSize));
+  if (containsFilterNode(nodes)) body.push("", ...filterSupport(indentationSize));
   return createStructTemplate({
     name,
     indent: indentationSize,
@@ -1962,6 +2486,10 @@ export function generateView(
   };
   const nodes = buildViewNodes(document.children, context);
   const imports = new Set<string>();
+  if (containsFilterNode(nodes)) {
+    imports.add("Foundation");
+    imports.add("SwiftUI");
+  }
   if (context.textHelpers.length > 0) imports.add("CoreText");
   if (context.imageHelpers.some((helper) => helper.node.resource?.type === "raster" && helper.node.resource.bytes)) {
     imports.add("Foundation");

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -88,6 +88,8 @@ export interface RadialGradientPaint extends GradientPaintBase {
 export type PatternUnits = "objectBoundingBox" | "userSpaceOnUse";
 export type MaskUnits = "objectBoundingBox" | "userSpaceOnUse";
 export type ClipPathUnits = "objectBoundingBox" | "userSpaceOnUse";
+export type FilterUnits = "objectBoundingBox" | "userSpaceOnUse";
+export type FilterColorInterpolation = "sRGB" | "linearRGB";
 export type MaskType = "alpha" | "luminance";
 export type SVGBlendMode =
   | "normal"
@@ -140,6 +142,114 @@ export interface MaskInstance {
 }
 
 export interface MaskReference {
+  id?: string;
+  invalid: boolean;
+}
+
+export type FilterInput =
+  | { type: "sourceGraphic" }
+  | { type: "sourceAlpha" }
+  | { type: "backgroundImage" }
+  | { type: "backgroundAlpha" }
+  | { type: "fillPaint" }
+  | { type: "strokePaint" }
+  | { type: "result"; index: number };
+
+export interface FilterPrimitiveRegionSpec {
+  x?: ParsedSVGLength;
+  y?: ParsedSVGLength;
+  width?: ParsedSVGLength;
+  height?: ParsedSVGLength;
+}
+
+interface FilterPrimitiveSpecBase {
+  input?: FilterInput;
+  input2?: FilterInput;
+  result?: string;
+  region: FilterPrimitiveRegionSpec;
+  colorInterpolation: FilterColorInterpolation;
+  source: SourceLocation;
+}
+
+export type FilterPrimitiveSpec =
+  | (FilterPrimitiveSpecBase & {
+      type: "gaussianBlur";
+      input: FilterInput;
+      stdDeviationX: number;
+      stdDeviationY: number;
+      edgeMode: "none" | "duplicate" | "wrap";
+    })
+  | (FilterPrimitiveSpecBase & { type: "offset"; input: FilterInput; dx: number; dy: number })
+  | (FilterPrimitiveSpecBase & { type: "flood"; color: RGBAColor })
+  | (FilterPrimitiveSpecBase & { type: "merge"; inputs: FilterInput[] })
+  | (FilterPrimitiveSpecBase & {
+      type: "dropShadow";
+      input: FilterInput;
+      stdDeviationX: number;
+      stdDeviationY: number;
+      dx: number;
+      dy: number;
+      color: RGBAColor;
+    })
+  | (FilterPrimitiveSpecBase & { type: "passthrough"; input: FilterInput; element: string });
+
+interface FilterPrimitiveBase {
+  result?: string;
+  input2?: FilterInput;
+  subregion: RenderBounds;
+  colorInterpolation: FilterColorInterpolation;
+  source: SourceLocation;
+}
+
+export type FilterPrimitive =
+  | (FilterPrimitiveBase & {
+      type: "gaussianBlur";
+      input: FilterInput;
+      stdDeviationX: number;
+      stdDeviationY: number;
+      edgeMode: "none" | "duplicate" | "wrap";
+    })
+  | (FilterPrimitiveBase & { type: "offset"; input: FilterInput; dx: number; dy: number })
+  | (FilterPrimitiveBase & { type: "flood"; color: RGBAColor })
+  | (FilterPrimitiveBase & { type: "merge"; inputs: FilterInput[] })
+  | (FilterPrimitiveBase & {
+      type: "dropShadow";
+      input: FilterInput;
+      stdDeviationX: number;
+      stdDeviationY: number;
+      dx: number;
+      dy: number;
+      color: RGBAColor;
+    })
+  | (FilterPrimitiveBase & { type: "passthrough"; input: FilterInput; element: string });
+
+export interface FilterResource {
+  id: string;
+  x: ParsedSVGLength;
+  y: ParsedSVGLength;
+  width: ParsedSVGLength;
+  height: ParsedSVGLength;
+  units: FilterUnits;
+  primitiveUnits: FilterUnits;
+  colorInterpolation: FilterColorInterpolation;
+  href?: string;
+  source: SourceLocation;
+  element: ElementNode;
+  primitives: FilterPrimitiveSpec[];
+  instances: Map<RenderNode, FilterInstance>;
+  invalid: boolean;
+}
+
+export interface FilterInstance {
+  resource?: FilterResource;
+  region: RenderBounds;
+  primitives: FilterPrimitive[];
+  fillPaint: RGBAColor;
+  strokePaint: RGBAColor;
+  invalid: boolean;
+}
+
+export interface FilterReference {
   id?: string;
   invalid: boolean;
 }
@@ -274,6 +384,7 @@ export interface ComputedStyle {
   visibility: string;
   clipPath?: ClipPathReference;
   mask?: MaskReference;
+  filter?: FilterReference;
   blendMode: SVGBlendMode;
   isolation: "auto" | "isolate";
   strokeStyle: StrokeStyle;
@@ -303,6 +414,7 @@ export interface RenderShape {
   accessibility?: AccessibilityMetadata;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
+  filter?: FilterInstance;
   /** Materialized marker shadow trees in SVG vertex order. */
   markers?: RenderGroup[];
 }
@@ -328,6 +440,7 @@ export interface RenderGroup {
   accessibility?: AccessibilityMetadata;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
+  filter?: FilterInstance;
   /** Present only on a marker shadow-tree root. */
   markerPlacement?: MarkerPlacement;
   /** True when this group came from a referenced definition. */
@@ -357,6 +470,7 @@ export interface RenderText {
   accessibility?: AccessibilityMetadata;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
+  filter?: FilterInstance;
 }
 
 export interface RenderTextChunk {
@@ -465,6 +579,7 @@ export interface RenderImage {
   accessibility?: AccessibilityMetadata;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
+  filter?: FilterInstance;
 }
 
 export interface RenderForeignObject {
@@ -483,8 +598,6 @@ export interface RenderForeignObject {
     assetName?: string;
     intrinsicSize: { width: number; height: number };
   };
-  /** Retained until the filter runtime lands in issues #67-#71. */
-  filter: string;
   attributes: Readonly<Record<string, string | number>>;
   style: ComputedStyle;
   transform: AffineTransform;
@@ -493,6 +606,7 @@ export interface RenderForeignObject {
   accessibility?: AccessibilityMetadata;
   clipPath?: ClipPathInstance;
   mask?: MaskInstance;
+  filter?: FilterInstance;
 }
 
 /** The union is intentionally extensible for clip, mask, filter, marker, and foreign-object nodes. */
@@ -513,7 +627,8 @@ export interface ResourceRegistry {
   maskElements: Map<string, ElementNode>;
   markers: Map<string, MarkerResource>;
   markerElements: Map<string, ElementNode>;
-  filters: Map<string, ElementNode>;
+  filters: Map<string, FilterResource>;
+  filterElements: Map<string, ElementNode>;
   views: Map<string, ElementNode>;
 }
 

--- a/packages/svg-to-swiftui-core/src/tests/filters.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/filters.test.ts
@@ -1,0 +1,180 @@
+import { __testing, convert, convertWithDiagnostics } from "../index";
+import type { RenderNode } from "../renderTree/types";
+
+function flatten(nodes: RenderNode[]): RenderNode[] {
+  return nodes.flatMap((node) => (node.type === "group" ? [node, ...flatten(node.children)] : [node]));
+}
+
+function filtered(source: string): RenderNode {
+  const node = flatten(__testing.parseRenderDocument(source).children).find((candidate) => candidate.filter);
+  if (!node) throw new Error("Expected a filtered render node");
+  return node;
+}
+
+describe("SVG filter graph and common primitives", () => {
+  test("retains Level 1 defaults and materializes a target-specific graph", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 50"><defs><filter id="f">
+        <feGaussianBlur stdDeviation="3 2" result="blur"/>
+        <feOffset in="blur" dx="4" dy="5" result="shift"/>
+        <feFlood flood-color="#336699" flood-opacity=".5" result="paint"/>
+        <feMerge><feMergeNode in="paint"/><feMergeNode in="shift"/><feMergeNode in="SourceGraphic"/></feMerge>
+      </filter></defs><rect x="10" y="5" width="80" height="40" fill="red" filter="url(#f)"/></svg>
+    `);
+    expect(document.resources.filters.get("f")).toMatchObject({
+      units: "objectBoundingBox",
+      primitiveUnits: "userSpaceOnUse",
+      colorInterpolation: "linearRGB",
+      x: { value: -10, unit: "%" },
+      y: { value: -10, unit: "%" },
+      width: { value: 120, unit: "%" },
+      height: { value: 120, unit: "%" },
+    });
+    const target = flatten(document.children).find((node) => node.filter)!;
+    expect(target.filter).toMatchObject({
+      region: { x: 2, y: 1, width: 96, height: 48 },
+      invalid: false,
+      primitives: [
+        { type: "gaussianBlur", input: { type: "sourceGraphic" }, stdDeviationX: 3, stdDeviationY: 2 },
+        { type: "offset", input: { type: "result", index: 0 }, dx: 4, dy: 5, result: "shift" },
+        { type: "flood", color: { red: 0.2, green: 0.4, blue: 0.6, alpha: 0.5 } },
+        {
+          type: "merge",
+          inputs: [{ type: "result", index: 2 }, { type: "result", index: 1 }, { type: "sourceGraphic" }],
+        },
+      ],
+    });
+  });
+
+  test("resolves href inheritance, local overrides, and inherited invalidity", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20"><defs>
+        <filter id="base" filterUnits="userSpaceOnUse" x="1" y="2" width="18" height="16"><feOffset dx="3"/></filter>
+        <filter id="copy" href="#base" y="4"/>
+        <filter id="missing" href="#nope"/>
+        <filter id="invalid-copy" href="#missing"/>
+      </defs><rect width="10" height="10" filter="url(#copy)"/></svg>
+    `);
+    expect(document.resources.filters.get("copy")).toMatchObject({
+      href: "base",
+      units: "userSpaceOnUse",
+      x: { value: 1 },
+      y: { value: 4 },
+      width: { value: 18 },
+      primitives: [{ type: "offset", dx: 3 }],
+      invalid: false,
+    });
+    expect(document.resources.filters.get("invalid-copy")?.invalid).toBe(true);
+    expect(document.diagnostics.map(({ code }) => code)).toContain("missing-filter-href-resource");
+  });
+
+  test("resolves primitiveUnits, primitive subregions, and context paints", () => {
+    const target = filtered(`
+      <svg viewBox="0 0 200 100"><defs><filter id="f" primitiveUnits="objectBoundingBox"
+        x="0" y="0" width="100%" height="100%">
+        <feOffset in="FillPaint" dx=".1" dy=".2" x="10%" y="20%" width="50%" height="60%"/>
+        <feMerge><feMergeNode in="StrokePaint"/><feMergeNode in="SourceAlpha"/></feMerge>
+      </filter></defs><rect x="20" y="10" width="100" height="50" fill="#ff0000" fill-opacity=".4"
+        stroke="#0000ff" stroke-opacity=".25" filter="url(#f)"/></svg>
+    `);
+    expect(target.filter).toMatchObject({
+      region: { x: 20, y: 10, width: 100, height: 50 },
+      fillPaint: { red: 1, green: 0, blue: 0, alpha: 0.4 },
+      strokePaint: { red: 0, green: 0, blue: 1, alpha: 0.25 },
+      primitives: [
+        {
+          type: "offset",
+          input: { type: "fillPaint" },
+          dx: 10,
+          dy: 10,
+          subregion: { x: 30, y: 20, width: 50, height: 30 },
+        },
+        { type: "merge", inputs: [{ type: "strokePaint" }, { type: "sourceAlpha" }] },
+      ],
+    });
+  });
+
+  test("uses the closest preceding duplicate result and diagnoses malformed graphs", () => {
+    const result = convertWithDiagnostics(`
+      <svg viewBox="0 0 20 20"><defs><filter id="f">
+        <feOffset result="same"/><feFlood result="same"/>
+        <feGaussianBlur in="same" stdDeviation="-2" edgeMode="bad"/>
+        <feOffset in="future"/><feOffset in="BackgroundImage"/>
+        <feColorMatrix in="SourceGraphic"/>
+      </filter></defs><rect width="10" height="10" filter="url(#f)"/></svg>
+    `);
+    expect(result.diagnostics.map(({ code }) => code)).toEqual(
+      expect.arrayContaining([
+        "duplicate-filter-result",
+        "negative-filter-stddeviation",
+        "invalid-filter-edge-mode",
+        "unknown-filter-input",
+        "unsupported-filter-background-input",
+        "unsupported-filter-primitive",
+      ]),
+    );
+    const target = filtered(`
+      <svg viewBox="0 0 20 20"><defs><filter id="f"><feOffset result="same"/><feFlood result="same"/><feGaussianBlur in="same"/></filter></defs><rect width="10" height="10" filter="url(#f)"/></svg>
+    `);
+    expect(target.filter?.primitives[2]).toMatchObject({ input: { type: "result", index: 1 } });
+    const binary = filtered(`
+      <svg viewBox="0 0 10 10"><defs><filter id="f"><feComposite in="SourceAlpha" in2="FillPaint"/></filter></defs>
+      <rect width="10" height="10" filter="url(#f)"/></svg>
+    `);
+    expect(binary.filter?.primitives[0]).toMatchObject({
+      type: "passthrough",
+      input: { type: "sourceAlpha" },
+      input2: { type: "fillPaint" },
+    });
+  });
+
+  test("diagnoses cycles, wrong resources, invalid references, and empty object bounds", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20"><defs><path id="shape" d="M0 0h1v1z"/>
+        <filter id="wrong" href="#shape"/><filter id="a" href="#b"/><filter id="b" href="#a"/>
+      </defs><path d="M0 0" filter="url(#wrong)"/><rect x="2" width="3" height="3" filter="url(#missing)"/>
+      <rect x="6" width="3" height="3" filter="none extra"/></svg>
+    `);
+    expect(document.diagnostics.map(({ code }) => code)).toEqual(
+      expect.arrayContaining([
+        "wrong-filter-href-resource-type",
+        "cyclic-filter-reference",
+        "missing-filter-resource",
+        "invalid-filter-reference",
+      ]),
+    );
+  });
+
+  test("emits the reusable premultiplied RGBA runtime and preserves effect order", () => {
+    const swift = convert(`
+      <svg viewBox="0 0 40 30"><defs><filter id="f"><feDropShadow dx="2" dy="3" stdDeviation="1"/></filter>
+      <clipPath id="c"><rect width="20" height="20"/></clipPath><mask id="m"><rect width="40" height="30" fill="white"/></mask></defs>
+      <rect width="30" height="20" fill="red" filter="url(#f)" clip-path="url(#c)" mask="url(#m)" opacity=".5"/>
+      </svg>
+    `);
+    expect(swift).toContain("private struct SVGFilterBitmap");
+    expect(swift).toContain("case dropShadow");
+    expect(swift).toContain("SVGFilteredCanvas(definition:");
+    expect(swift.indexOf("SVGFilteredCanvas(definition:")).toBeLessThan(swift.indexOf(".clipShape("));
+    expect(swift.indexOf(".clipShape(")).toBeLessThan(swift.indexOf(".mask {"));
+    expect(swift.indexOf(".mask {")).toBeLessThan(swift.indexOf(".opacity(0.5)"));
+    expect(
+      __testing.analyzeCapabilities(
+        __testing.parseRenderDocument(
+          `<svg viewBox="0 0 10 10"><defs><filter id="f"><feOffset/></filter></defs><rect width="10" height="10" filter="url(#f)"/></svg>`,
+        ),
+      ).reasons,
+    ).toContain("document uses an SVG filter graph");
+  });
+
+  test("includes transformed filter extents in painted bounds before clipping", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 100"><defs><filter id="f" x="-50%" y="-50%" width="200%" height="200%"><feFlood flood-color="red"/></filter>
+      <clipPath id="c"><rect x="5" y="5" width="40" height="30"/></clipPath></defs>
+      <rect x="10" y="10" width="20" height="10" transform="translate(10 5) scale(2)" filter="url(#f)" clip-path="url(#c)"/>
+      </svg>
+    `);
+    const target = flatten(document.children).find((node) => node.filter)!;
+    expect(__testing.renderNodeBounds(target)).toEqual({ x: 20, y: 15, width: 70, height: 40 });
+  });
+});

--- a/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
@@ -324,6 +324,89 @@
       "expectedMode": "view",
       "tags": ["geometry", "path", "rect", "view"]
     },
+    "filter-common-primitives": {
+      "width": 160,
+      "height": 100,
+      "expectedMode": "view",
+      "tags": [
+        "clip-path",
+        "effect-order",
+        "feDropShadow",
+        "feFlood",
+        "feGaussianBlur",
+        "feMerge",
+        "feMergeNode",
+        "feOffset",
+        "filter",
+        "mask",
+        "opacity",
+        "view"
+      ],
+      "tolerance": {
+        "channel": 36,
+        "maxOutsidePercent": 8,
+        "maxMeanRgbError": 8,
+        "maxMeanAlphaError": 5
+      },
+      "toleranceReason": "The generated separable Gaussian kernel and SVG reference renderer use slightly different kernel truncation and edge sampling."
+    },
+    "filter-graph-branching": {
+      "width": 140,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": [
+        "branching",
+        "feFlood",
+        "feGaussianBlur",
+        "feMerge",
+        "feMergeNode",
+        "feOffset",
+        "filter",
+        "FillPaint",
+        "SourceAlpha",
+        "StrokePaint",
+        "view"
+      ],
+      "tolerance": { "channel": 36, "maxOutsidePercent": 8, "maxMeanRgbError": 8, "maxMeanAlphaError": 5 },
+      "toleranceReason": "The generated separable Gaussian kernel has deterministic three-sigma truncation while the SVG reference kernel is implementation-defined."
+    },
+    "filter-shadow-equivalence": {
+      "width": 150,
+      "height": 80,
+      "expectedMode": "view",
+      "tags": [
+        "equivalence",
+        "feDropShadow",
+        "feFlood",
+        "feGaussianBlur",
+        "feMerge",
+        "feMergeNode",
+        "feOffset",
+        "filter",
+        "view"
+      ],
+      "tolerance": { "channel": 36, "maxOutsidePercent": 8, "maxMeanRgbError": 8, "maxMeanAlphaError": 5 },
+      "toleranceReason": "The generated separable Gaussian kernel has deterministic three-sigma truncation while the SVG reference kernel is implementation-defined."
+    },
+    "filter-units-regions-transforms": {
+      "width": 150,
+      "height": 90,
+      "expectedMode": "view",
+      "tags": [
+        "feGaussianBlur",
+        "feOffset",
+        "edge-mode",
+        "filter",
+        "filter-regions",
+        "filter-units",
+        "primitive-units",
+        "transform",
+        "view",
+        "zero-blur"
+      ],
+      "tolerance": { "channel": 44, "maxOutsidePercent": 10, "maxMeanRgbError": 10, "maxMeanAlphaError": 6 },
+      "toleranceReason": "Rotated anisotropic kernels are conservatively projected onto device axes and Gaussian edge truncation differs by renderer."
+    },
     "foreign-object-effects": {
       "width": 128,
       "height": 80,

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-common-primitives.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-common-primitives.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 100">
+  <defs>
+    <filter id="blur" x="-30%" y="-40%" width="160%" height="180%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="4 1.5"/>
+    </filter>
+    <filter id="merge" x="-20%" y="-30%" width="160%" height="180%" color-interpolation-filters="sRGB">
+      <feOffset in="SourceAlpha" dx="7" dy="6" result="shifted"/>
+      <feFlood flood-color="#7c3aed" flood-opacity="0.72" result="purple"/>
+      <feMerge>
+        <feMergeNode in="purple"/>
+        <feMergeNode in="shifted"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="shadow" x="-40%" y="-50%" width="190%" height="210%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="5" dy="6" stdDeviation="3" flood-color="#0f172a" flood-opacity="0.7"/>
+    </filter>
+    <clipPath id="greenClip"><rect x="116" y="14" width="33" height="38" rx="3"/></clipPath>
+    <mask id="greenMask" maskUnits="userSpaceOnUse" x="116" y="14" width="33" height="38" mask-type="alpha">
+      <rect x="116" y="14" width="33" height="38" fill="white"/>
+    </mask>
+  </defs>
+  <rect width="160" height="100" fill="#f8fafc"/>
+  <rect x="18" y="18" width="30" height="28" rx="5" fill="#0284c7" filter="url(#blur)"/>
+  <circle cx="82" cy="34" r="16" fill="#f97316" filter="url(#merge)"/>
+  <path d="M120 18h25v28h-25z" fill="#22c55e" filter="url(#shadow)" clip-path="url(#greenClip)" mask="url(#greenMask)" opacity=".82"/>
+  <g transform="translate(18 68) rotate(-8)">
+    <rect width="52" height="12" rx="6" fill="#e11d48" filter="url(#shadow)"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-graph-branching.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-graph-branching.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 80">
+  <defs>
+    <filter id="branch" x="-20%" y="-30%" width="160%" height="180%" color-interpolation-filters="sRGB">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="softAlpha"/>
+      <feOffset in="softAlpha" dx="6" dy="5" result="shiftedAlpha"/>
+      <feFlood flood-color="#0f172a" flood-opacity="0.7" result="shadowColor"/>
+      <feMerge>
+        <feMergeNode in="shadowColor"/>
+        <feMergeNode in="shiftedAlpha"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="paints" x="-10%" y="-30%" width="130%" height="160%" color-interpolation-filters="sRGB">
+      <feOffset in="FillPaint" dx="-2.5" result="fillPaint"/>
+      <feOffset in="StrokePaint" dx="3.5" result="strokePaint"/>
+      <feMerge><feMergeNode in="fillPaint"/><feMergeNode in="strokePaint"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="140" height="80" fill="#f1f5f9"/>
+  <path d="M24 55L42 19l18 36z" fill="#f43f5e" stroke="#7f1d1d" stroke-width="3" filter="url(#branch)"/>
+  <circle cx="98" cy="38" r="19" fill="#06b6d4" filter="url(#branch)"/>
+  <rect x="72" y="67" width="48" height="7" fill="#22c55e" stroke="#1d4ed8" stroke-width="2" filter="url(#paints)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-shadow-equivalence.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-shadow-equivalence.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 80">
+  <defs>
+    <filter id="native" x="-35%" y="-45%" width="180%" height="200%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="5" dy="6" stdDeviation="3" flood-color="#1e293b" flood-opacity="0.65"/>
+    </filter>
+    <filter id="expanded" x="-35%" y="-45%" width="180%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="5" dy="6" result="offset"/>
+      <feFlood flood-color="#1e293b" flood-opacity="0.65" result="color"/>
+      <feMerge><feMergeNode in="color"/><feMergeNode in="offset"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="150" height="80" fill="#f8fafc"/>
+  <rect x="20" y="20" width="42" height="34" rx="7" fill="#8b5cf6" filter="url(#native)"/>
+  <rect x="88" y="20" width="42" height="34" rx="7" fill="#8b5cf6" filter="url(#expanded)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-units-regions-transforms.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-units-regions-transforms.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 90">
+  <defs>
+    <filter id="object" x="-30%" y="-40%" width="170%" height="190%" primitiveUnits="objectBoundingBox" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation=".05 .025" edgeMode="duplicate" x="-20%" y="-30%" width="150%" height="170%"/>
+    </filter>
+    <filter id="user" filterUnits="userSpaceOnUse" x="72" y="7" width="70" height="70" color-interpolation-filters="sRGB">
+      <feOffset dx="8.5" dy="-4.25"/>
+    </filter>
+    <filter id="zero"><feGaussianBlur stdDeviation="0" edgeMode="wrap"/></filter>
+  </defs>
+  <rect width="150" height="90" fill="#f8fafc"/>
+  <g transform="translate(18 17) rotate(-12 24 20)">
+    <rect width="48" height="40" rx="8" fill="#0ea5e9" filter="url(#object)"/>
+  </g>
+  <g transform="rotate(9 105 40)">
+    <path d="M83 17h44v42H83z" fill="#f59e0b" filter="url(#user)"/>
+  </g>
+  <circle cx="126" cy="75" r="8" fill="#ef4444" filter="url(#zero)"/>
+</svg>


### PR DESCRIPTION
## Summary
- model typed filter resources, href inheritance, graph inputs/results, regions, units, diagnostics, and bounds
- generate a deterministic premultiplied RGBA Swift runtime for blur, offset, flood, merge, and drop shadow
- preserve sRGB/linearRGB behavior, device scale, transforms, primitive clipping, and SVG effect order
- add focused unit coverage, four real RGBA fixtures, documentation, and a changeset

## Validation
- 227 core tests pass
- core typecheck and Biome checks pass
- all 4 new SwiftUI RGBA fixtures compile and match their SVG references
- visual manifest validates with 1,892 fixtures
- monorepo build passes

Closes #67