### PR TITLE
Add spatial, noise, and image SVG filters

### DIFF
--- a/.changeset/static-svg-filter-spatial-noise-image.md
+++ b/.changeset/static-svg-filter-spatial-noise-image.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Add static SVG support for `feConvolveMatrix`, `feMorphology`, `feDisplacementMap`, `feTile`, `feTurbulence`, and `feImage`. The typed graph and generated SwiftUI runtime now cover spatial sampling, deterministic seeded noise, local/raster/SVG image inputs, safety limits, structured diagnostics, numeric reference tests, and full-RGBA visual comparisons.

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -71,6 +71,8 @@ Local `filter: url(#id)` references resolve into typed, target-specific directed
 
 Color and compositing nodes support all 16 `feBlend` modes; `feColorMatrix` matrix, saturate, hue rotation, and luminance-to-alpha forms; every `feComponentTransfer` function for RGBA; and all Porter-Duff plus arithmetic `feComposite` operators. Their CPU implementation follows Filter Effects and Compositing Level 1 formulas with safe temporary unpremultiplication, output clamping, and re-premultiplication. Empty tables, exact table/discrete boundaries, missing transfer channels, malformed lists, invalid enums, transparent pixels, and arithmetic coefficients have deterministic tested behavior rather than native-framework-dependent fallbacks.
 
+Spatial and generated-image nodes support `feConvolveMatrix`, `feMorphology`, `feDisplacementMap`, `feTile`, `feTurbulence`, and `feImage`. This includes kernel targets/divisors/edge modes, anisotropic and fractional radii, channel-selected displacement, fractional tile regions, deterministic seeded and stitched noise, embedded raster data, resolved SVG documents, and local fragment `<use>` semantics with `preserveAspectRatio`. Generated code never fetches resources at runtime. Configurable kernel, octave, output-pixel, resource-byte, and nesting limits bound conversion and rendering work.
+
 Generated Swift uses the same deterministic premultiplied-RGBA image-buffer runtime as the visual regression host. Source vector commands are rasterized only at app render time and at the active display scale; conversion never snapshots the full SVG. Filters run before viewport/clip paths, masks, element opacity, and blending, and their regions contribute to reported painted bounds. Unsupported primitives remain typed pass-through graph nodes with diagnostics until their dedicated tickets land.
 
 ### Linear and radial gradients
@@ -243,6 +245,7 @@ The default antialiasing allowance is 24/255 per channel, at most 3% pixels outs
 - [x] SVG clipping paths, clip rules, coordinate systems, transforms, unions, and nested intersections
 - [x] SVG masks, Level 1 blend modes, group compositing, and isolation
 - [x] SVG markers, vertex placement, orientation, units, context paint, viewports, and painter order
+- [x] Static filter graphs, color/compositing, convolution, morphology, displacement, tiling, turbulence, and filter images
 - [x] Embedded CSS cascade, custom properties, and computed presentation styles
 - [x] Basic static SVG `<text>` and `<tspan>` rendering
 - [x] Static SVG `<image>` rendering with deterministic raster/SVG resource resolution

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -36,6 +36,7 @@ import { resolvePatternPaintServers } from "./patterns";
 import type {
   ComputedStyle,
   CSSDiagnosticContext,
+  FilterPrimitiveSpec,
   Geometry,
   MarkerRefCoordinate,
   MarkerReference,
@@ -2172,8 +2173,202 @@ export function buildRenderDocument(
     resources.definitions,
     styleResolver,
     resolved.effective,
+    config,
     diagnostics,
   );
+
+  const filterPrimitiveElements = (filter: ElementNode) =>
+    childElements(filter).filter((element) => {
+      const tag = element.tagName?.toLowerCase() ?? "";
+      return tag.startsWith("fe") && tag !== "femergenode";
+    });
+  const collectFilterDependencies = (nodes: RenderNode[], result = new Set<string>()): Set<string> => {
+    for (const node of nodes) {
+      const id = node.filter?.resource?.id ?? node.style.filter?.id;
+      if (id) result.add(id);
+      if (node.type === "group") collectFilterDependencies(node.children, result);
+      if (node.clipPath) collectFilterDependencies(node.clipPath.children, result);
+      if (node.mask) collectFilterDependencies(node.mask.children, result);
+    }
+    return result;
+  };
+
+  // External SVG feImage resources use the same bounded, cycle-safe nested-document path as <image>.
+  for (const filter of resources.filters.values()) {
+    const elements = filterPrimitiveElements(filter.element);
+    for (const [index, primitive] of filter.primitives.entries()) {
+      if (primitive.type !== "image" || !primitive.image.pendingSVG) continue;
+      const sourceElement = elements[index] ?? filter.element;
+      const pending = primitive.image.pendingSVG;
+      const state = resourceState(config);
+      const limits = resourceLimits(config);
+      if (state.activeCanonicalURLs.includes(pending.canonicalURL)) {
+        addDiagnostic(
+          context,
+          sourceElement,
+          "recursive-filter-image",
+          `Recursive SVG feImage cycle detected: ${[...state.activeCanonicalURLs, pending.canonicalURL].join(" -> ")}.`,
+        );
+        continue;
+      }
+      if (state.depth + 1 > limits.maxNestingDepth) {
+        addDiagnostic(
+          context,
+          sourceElement,
+          "resource-nesting-limit",
+          `SVG feImage '${primitive.image.href}' exceeds the nesting depth limit of ${limits.maxNestingDepth}.`,
+        );
+        continue;
+      }
+      try {
+        const ast = parse(decodeUTF8(pending.bytes));
+        const childSVG = getSVGElement(ast);
+        if (!childSVG) throw new Error("resource does not contain an svg root element");
+        const childConfig: InternalGeneratorConfig = {
+          ...config,
+          fragment: undefined,
+          outerViewport: undefined,
+          __resourceState: state,
+          __resourceBaseURL: pending.canonicalURL,
+        };
+        const referenced = resolveSVGProperties(childSVG, childConfig);
+        const embeddedSVG: ElementNode = {
+          ...childSVG,
+          properties: { ...(childSVG.properties ?? {}), preserveAspectRatio: "none" },
+        };
+        const embedded = resolveSVGProperties(embeddedSVG, childConfig);
+        state.activeCanonicalURLs.push(pending.canonicalURL);
+        state.depth++;
+        let document: RenderDocument;
+        try {
+          document = buildRenderDocument(embeddedSVG, embedded.properties, embedded.diagnostics, childConfig);
+        } finally {
+          state.depth--;
+          state.activeCanonicalURLs.pop();
+        }
+        for (const nested of document.diagnostics)
+          diagnostics.push({ ...nested, message: `SVG feImage '${primitive.image.href}': ${nested.message}` });
+        primitive.image.resource = {
+          type: "svg",
+          canonicalURL: pending.canonicalURL,
+          document,
+          referencedPreserveAspectRatio: referenced.properties.preserveAspectRatio,
+          hasReferencedPreserveAspectRatio: childSVG.properties?.preserveAspectRatio !== undefined,
+        };
+      } catch (error) {
+        addDiagnostic(
+          context,
+          sourceElement,
+          "malformed-svg-filter-image",
+          `SVG feImage '${primitive.image.href}' could not be parsed: ${error instanceof Error ? error.message : String(error)}.`,
+        );
+      }
+    }
+  }
+
+  // Local fragments are rendered with <use> semantics in the primitive coordinate system.
+  const localCandidates: Array<{
+    owner: string;
+    source: Extract<FilterPrimitiveSpec, { type: "image" }>;
+    sourceElement: ElementNode;
+    document: RenderDocument;
+    dependencies: Set<string>;
+  }> = [];
+  for (const filter of resources.filters.values()) {
+    const elements = filterPrimitiveElements(filter.element);
+    for (const [index, primitive] of filter.primitives.entries()) {
+      if (primitive.type !== "image" || !primitive.image.localElementId) continue;
+      const sourceElement = elements[index] ?? filter.element;
+      const id = primitive.image.localElementId;
+      const use: ElementNode = {
+        type: "element",
+        tagName: "use",
+        properties: { href: `#${id}` },
+        children: [],
+      };
+      const localCoordinate: CoordinateContext =
+        filter.primitiveUnits === "objectBoundingBox"
+          ? {
+              viewport: { width: 1, height: 1 },
+              rootViewport: coordinate.rootViewport,
+              fontMetrics: resolved.fontMetrics,
+            }
+          : { ...coordinate, fontMetrics: resolved.fontMetrics };
+      try {
+        const nodes = buildUse(use, resolved.effective, localCoordinate, context);
+        if (nodes.length === 0) {
+          addDiagnostic(
+            context,
+            sourceElement,
+            "non-rendering-filter-image-fragment",
+            `feImage fragment '#${id}' does not produce renderable content.`,
+          );
+          continue;
+        }
+        const box =
+          filter.primitiveUnits === "objectBoundingBox" ? { x: 0, y: 0, width: 1, height: 1 } : properties.viewBox;
+        const document: RenderDocument = {
+          viewport: {
+            width: box.width,
+            height: box.height,
+            viewBox: box,
+            userViewport: { width: box.width, height: box.height },
+            preserveAspectRatio: DEFAULT_PRESERVE_ASPECT_RATIO,
+            coordinateSpace: box,
+            zeroSized: box.width <= 0 || box.height <= 0,
+          },
+          resources,
+          children: nodes,
+          diagnostics: [],
+        };
+        localCandidates.push({
+          owner: filter.id,
+          source: primitive,
+          sourceElement,
+          document,
+          dependencies: collectFilterDependencies(nodes),
+        });
+      } catch (error) {
+        addDiagnostic(
+          context,
+          sourceElement,
+          "invalid-filter-image-fragment",
+          `feImage fragment '#${id}' could not be rendered: ${error instanceof Error ? error.message : String(error)}.`,
+        );
+      }
+    }
+  }
+  const dependencyGraph = new Map<string, Set<string>>();
+  for (const candidate of localCandidates) {
+    const existing = dependencyGraph.get(candidate.owner) ?? new Set<string>();
+    for (const dependency of candidate.dependencies) existing.add(dependency);
+    dependencyGraph.set(candidate.owner, existing);
+  }
+  const reaches = (current: string, target: string, visited: Set<string>): boolean => {
+    if (current === target) return true;
+    if (visited.has(current)) return false;
+    visited.add(current);
+    return [...(dependencyGraph.get(current) ?? [])].some((next) => reaches(next, target, visited));
+  };
+  for (const candidate of localCandidates) {
+    const recursive = [...candidate.dependencies].some((dependency) => reaches(dependency, candidate.owner, new Set()));
+    if (recursive) {
+      addDiagnostic(
+        context,
+        candidate.sourceElement,
+        "recursive-filter-image",
+        `Local feImage '${candidate.source.image.href}' recursively depends on filter #${candidate.owner}; rendering transparent black.`,
+      );
+      continue;
+    }
+    candidate.source.image.resource = {
+      type: "svg",
+      canonicalURL: candidate.source.image.href,
+      document: candidate.document,
+      referencedPreserveAspectRatio: DEFAULT_PRESERVE_ASPECT_RATIO,
+      hasReferencedPreserveAspectRatio: false,
+    };
+  }
   const rootTransform = multiplyTransforms(computedTransform(svg, resolved, context), properties.viewBoxTransform);
   const childCoordinate = { ...coordinate, fontMetrics: resolved.fontMetrics };
   const root: RenderGroup = {

--- a/packages/svg-to-swiftui-core/src/renderTree/filterMath.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/filterMath.ts
@@ -1,12 +1,30 @@
 import type {
   FilterBlendMode,
+  FilterChannelSelector,
   FilterComponentTransferFunction,
   FilterComponentTransferFunctions,
   FilterCompositeOperator,
+  FilterEdgeMode,
+  FilterMorphologyOperator,
+  FilterTurbulenceType,
 } from "./types";
 
 /** A premultiplied RGBA sample. Filter primitives exchange this representation. */
 export type FilterPixel = readonly [red: number, green: number, blue: number, alpha: number];
+
+export interface FilterBitmap {
+  width: number;
+  height: number;
+  /** Premultiplied row-major RGBA values. */
+  values: number[];
+}
+
+export interface FilterPixelRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
 
 type RGB = [number, number, number];
 
@@ -259,4 +277,424 @@ export function compositeFilterPixels(
   );
   const alpha = output[3]!;
   return [Math.min(alpha, output[0]!), Math.min(alpha, output[1]!), Math.min(alpha, output[2]!), alpha];
+}
+
+function pixelAt(image: FilterBitmap, x: number, y: number): FilterPixel {
+  if (x < 0 || y < 0 || x >= image.width || y >= image.height) return [0, 0, 0, 0];
+  const offset = (y * image.width + x) * 4;
+  return [
+    image.values[offset] ?? 0,
+    image.values[offset + 1] ?? 0,
+    image.values[offset + 2] ?? 0,
+    image.values[offset + 3] ?? 0,
+  ];
+}
+
+function setPixel(image: FilterBitmap, x: number, y: number, pixel: FilterPixel): void {
+  const offset = (y * image.width + x) * 4;
+  image.values[offset] = pixel[0];
+  image.values[offset + 1] = pixel[1];
+  image.values[offset + 2] = pixel[2];
+  image.values[offset + 3] = pixel[3];
+}
+
+function emptyLike(image: FilterBitmap): FilterBitmap {
+  return { width: image.width, height: image.height, values: Array(image.width * image.height * 4).fill(0) };
+}
+
+function positiveModulo(value: number, modulus: number): number {
+  return ((value % modulus) + modulus) % modulus;
+}
+
+function edgeCoordinate(value: number, size: number, edge: FilterEdgeMode): number | undefined {
+  if (value >= 0 && value < size) return value;
+  if (edge === "none" || size <= 0) return undefined;
+  if (edge === "duplicate") return Math.min(size - 1, Math.max(0, value));
+  return positiveModulo(value, size);
+}
+
+function sampleNearest(image: FilterBitmap, x: number, y: number, edge: FilterEdgeMode): FilterPixel {
+  const sampleX = edgeCoordinate(Math.round(x), image.width, edge);
+  const sampleY = edgeCoordinate(Math.round(y), image.height, edge);
+  return sampleX === undefined || sampleY === undefined ? [0, 0, 0, 0] : pixelAt(image, sampleX, sampleY);
+}
+
+function sampleBilinear(image: FilterBitmap, x: number, y: number, edge: FilterEdgeMode): FilterPixel {
+  const minX = Math.floor(x);
+  const minY = Math.floor(y);
+  const fractionX = x - minX;
+  const fractionY = y - minY;
+  const samples = [
+    sampleNearest(image, minX, minY, edge),
+    sampleNearest(image, minX + 1, minY, edge),
+    sampleNearest(image, minX, minY + 1, edge),
+    sampleNearest(image, minX + 1, minY + 1, edge),
+  ];
+  return [0, 1, 2, 3].map((channel) => {
+    const top = samples[0]![channel]! + fractionX * (samples[1]![channel]! - samples[0]![channel]!);
+    const bottom = samples[2]![channel]! + fractionX * (samples[3]![channel]! - samples[2]![channel]!);
+    return clamp(top + fractionY * (bottom - top));
+  }) as unknown as FilterPixel;
+}
+
+export interface ConvolveMatrixParameters {
+  orderX: number;
+  orderY: number;
+  kernelMatrix: readonly number[];
+  divisor: number;
+  bias: number;
+  targetX: number;
+  targetY: number;
+  edgeMode: FilterEdgeMode;
+  kernelUnitLengthX?: number;
+  kernelUnitLengthY?: number;
+  preserveAlpha: boolean;
+}
+
+/** W3C feConvolveMatrix, including the required 180° kernel rotation. */
+export function convolveFilterBitmap(image: FilterBitmap, parameters: ConvolveMatrixParameters): FilterBitmap {
+  const result = emptyLike(image);
+  const unitX = parameters.kernelUnitLengthX ?? 1;
+  const unitY = parameters.kernelUnitLengthY ?? 1;
+  for (let y = 0; y < image.height; y++) {
+    for (let x = 0; x < image.width; x++) {
+      const accumulators = [0, 0, 0, 0];
+      for (let row = 0; row < parameters.orderY; row++) {
+        for (let column = 0; column < parameters.orderX; column++) {
+          const source = sampleBilinear(
+            image,
+            x + (column - parameters.targetX) * unitX,
+            y + (row - parameters.targetY) * unitY,
+            parameters.edgeMode,
+          );
+          const kernel =
+            parameters.kernelMatrix[
+              (parameters.orderY - row - 1) * parameters.orderX + (parameters.orderX - column - 1)
+            ] ?? 0;
+          const sample = parameters.preserveAlpha ? unpremultiply(source) : source;
+          for (let channel = 0; channel < 4; channel++) accumulators[channel]! += sample[channel]! * kernel;
+        }
+      }
+      if (parameters.preserveAlpha) {
+        const alpha = pixelAt(image, x, y)[3];
+        setPixel(
+          result,
+          x,
+          y,
+          premultiply(
+            accumulators[0]! / parameters.divisor + parameters.bias,
+            accumulators[1]! / parameters.divisor + parameters.bias,
+            accumulators[2]! / parameters.divisor + parameters.bias,
+            alpha,
+          ),
+        );
+      } else {
+        const channels = accumulators.map((value) => clamp(value / parameters.divisor + parameters.bias));
+        const alpha = channels[3]!;
+        setPixel(result, x, y, [
+          Math.min(alpha, channels[0]!),
+          Math.min(alpha, channels[1]!),
+          Math.min(alpha, channels[2]!),
+          alpha,
+        ]);
+      }
+    }
+  }
+  return result;
+}
+
+/** Component-wise premultiplied rectangular erosion/dilation with transparent edges. */
+export function morphologyFilterBitmap(
+  image: FilterBitmap,
+  operator: FilterMorphologyOperator,
+  radiusX: number,
+  radiusY: number,
+): FilterBitmap {
+  if (radiusX <= 0 || radiusY <= 0) return { ...image, values: [...image.values] };
+  const result = emptyLike(image);
+  const minOffsetX = Math.ceil(-radiusX);
+  const maxOffsetX = Math.floor(radiusX);
+  const minOffsetY = Math.ceil(-radiusY);
+  const maxOffsetY = Math.floor(radiusY);
+  for (let y = 0; y < image.height; y++) {
+    for (let x = 0; x < image.width; x++) {
+      const channels = Array(4).fill(operator === "erode" ? 1 : 0) as number[];
+      for (let offsetY = minOffsetY; offsetY <= maxOffsetY; offsetY++) {
+        for (let offsetX = minOffsetX; offsetX <= maxOffsetX; offsetX++) {
+          const sample = pixelAt(image, x + offsetX, y + offsetY);
+          for (let channel = 0; channel < 4; channel++)
+            channels[channel] =
+              operator === "erode"
+                ? Math.min(channels[channel]!, sample[channel]!)
+                : Math.max(channels[channel]!, sample[channel]!);
+        }
+      }
+      const alpha = channels[3]!;
+      setPixel(result, x, y, [
+        Math.min(alpha, channels[0]!),
+        Math.min(alpha, channels[1]!),
+        Math.min(alpha, channels[2]!),
+        alpha,
+      ]);
+    }
+  }
+  return result;
+}
+
+const channelIndex = (channel: FilterChannelSelector): number => ({ R: 0, G: 1, B: 2, A: 3 })[channel];
+
+/** W3C inverse displacement mapping with unpremultiplied map channels and bilinear source sampling. */
+export function displacementFilterBitmap(
+  source: FilterBitmap,
+  map: FilterBitmap,
+  displacement: { a: number; b: number; c: number; d: number },
+  xChannel: FilterChannelSelector,
+  yChannel: FilterChannelSelector,
+): FilterBitmap {
+  const result = emptyLike(source);
+  const xIndex = channelIndex(xChannel);
+  const yIndex = channelIndex(yChannel);
+  for (let y = 0; y < source.height; y++) {
+    for (let x = 0; x < source.width; x++) {
+      const channels = unpremultiply(pixelAt(map, x, y));
+      const xAmount = channels[xIndex]! - 0.5;
+      const yAmount = channels[yIndex]! - 0.5;
+      setPixel(
+        result,
+        x,
+        y,
+        sampleBilinear(
+          source,
+          x + displacement.a * xAmount + displacement.c * yAmount,
+          y + displacement.b * xAmount + displacement.d * yAmount,
+          "none",
+        ),
+      );
+    }
+  }
+  return result;
+}
+
+/** Repeat an input primitive subregion without painting overlapping tile seams. */
+export function tileFilterBitmap(
+  image: FilterBitmap,
+  inputRegion: FilterPixelRegion,
+  outputRegion: FilterPixelRegion,
+): FilterBitmap {
+  const result = emptyLike(image);
+  if (inputRegion.width <= 0 || inputRegion.height <= 0) return result;
+  const startX = Math.max(0, Math.floor(outputRegion.x));
+  const startY = Math.max(0, Math.floor(outputRegion.y));
+  const endX = Math.min(image.width, Math.ceil(outputRegion.x + outputRegion.width));
+  const endY = Math.min(image.height, Math.ceil(outputRegion.y + outputRegion.height));
+  for (let y = startY; y < endY; y++) {
+    for (let x = startX; x < endX; x++) {
+      const sourceX = inputRegion.x + positiveModulo(x + 0.5 - inputRegion.x, inputRegion.width) - 0.5;
+      const sourceY = inputRegion.y + positiveModulo(y + 0.5 - inputRegion.y, inputRegion.height) - 0.5;
+      setPixel(result, x, y, sampleBilinear(image, sourceX, sourceY, "none"));
+    }
+  }
+  return result;
+}
+
+const RAND_M = 2_147_483_647;
+const RAND_A = 16_807;
+const RAND_Q = 127_773;
+const RAND_R = 2_836;
+const LATTICE_SIZE = 256;
+const LATTICE_MASK = 255;
+const PERLIN_N = 4_096;
+
+export function setupTurbulenceSeed(seed: number): number {
+  let result = Math.trunc(seed);
+  if (result <= 0) result = -(result % (RAND_M - 1)) + 1;
+  if (result > RAND_M - 1) result = RAND_M - 1;
+  return result;
+}
+
+export function nextTurbulenceRandom(seed: number): number {
+  let result = RAND_A * (seed % RAND_Q) - RAND_R * Math.floor(seed / RAND_Q);
+  if (result <= 0) result += RAND_M;
+  return result;
+}
+
+interface StitchInfo {
+  width: number;
+  height: number;
+  wrapX: number;
+  wrapY: number;
+}
+
+/** Exact lattice initialization and noise sequence required by SVG feTurbulence. */
+export class SVGTurbulenceGenerator {
+  private readonly lattice = Array(LATTICE_SIZE * 2 + 2).fill(0) as number[];
+  private readonly gradients = Array.from({ length: 4 }, () =>
+    Array.from({ length: LATTICE_SIZE * 2 + 2 }, () => [0, 0] as [number, number]),
+  );
+
+  constructor(seed: number) {
+    let random = setupTurbulenceSeed(seed);
+    let index = 0;
+    for (let channel = 0; channel < 4; channel++) {
+      for (index = 0; index < LATTICE_SIZE; index++) {
+        this.lattice[index] = index;
+        let x = 0;
+        let y = 0;
+        let length = 0;
+        do {
+          random = nextTurbulenceRandom(random);
+          x = ((random % (LATTICE_SIZE * 2)) - LATTICE_SIZE) / LATTICE_SIZE;
+          random = nextTurbulenceRandom(random);
+          y = ((random % (LATTICE_SIZE * 2)) - LATTICE_SIZE) / LATTICE_SIZE;
+          length = Math.hypot(x, y);
+        } while (length === 0);
+        this.gradients[channel]![index] = [x / length, y / length];
+      }
+    }
+    while (--index) {
+      random = nextTurbulenceRandom(random);
+      const replacement = random % LATTICE_SIZE;
+      [this.lattice[index], this.lattice[replacement]] = [this.lattice[replacement]!, this.lattice[index]!];
+    }
+    for (index = 0; index < LATTICE_SIZE + 2; index++) {
+      this.lattice[LATTICE_SIZE + index] = this.lattice[index]!;
+      for (let channel = 0; channel < 4; channel++)
+        this.gradients[channel]![LATTICE_SIZE + index] = [...this.gradients[channel]![index]!] as [number, number];
+    }
+  }
+
+  private noise(channel: number, x: number, y: number, stitch?: StitchInfo): number {
+    let bx0 = Math.trunc(x + PERLIN_N);
+    let bx1 = bx0 + 1;
+    const rx0 = x + PERLIN_N - bx0;
+    const rx1 = rx0 - 1;
+    let by0 = Math.trunc(y + PERLIN_N);
+    let by1 = by0 + 1;
+    const ry0 = y + PERLIN_N - by0;
+    const ry1 = ry0 - 1;
+    if (stitch) {
+      if (bx0 >= stitch.wrapX) bx0 -= stitch.width;
+      if (bx1 >= stitch.wrapX) bx1 -= stitch.width;
+      if (by0 >= stitch.wrapY) by0 -= stitch.height;
+      if (by1 >= stitch.wrapY) by1 -= stitch.height;
+    }
+    bx0 &= LATTICE_MASK;
+    bx1 &= LATTICE_MASK;
+    by0 &= LATTICE_MASK;
+    by1 &= LATTICE_MASK;
+    const i = this.lattice[bx0]!;
+    const j = this.lattice[bx1]!;
+    const b00 = this.lattice[i + by0]!;
+    const b10 = this.lattice[j + by0]!;
+    const b01 = this.lattice[i + by1]!;
+    const b11 = this.lattice[j + by1]!;
+    const curve = (value: number) => value * value * (3 - 2 * value);
+    const interpolate = (amount: number, left: number, right: number) => left + amount * (right - left);
+    const dot = (gradient: [number, number], dx: number, dy: number) => dx * gradient[0] + dy * gradient[1];
+    const sx = curve(rx0);
+    const sy = curve(ry0);
+    const top = interpolate(
+      sx,
+      dot(this.gradients[channel]![b00]!, rx0, ry0),
+      dot(this.gradients[channel]![b10]!, rx1, ry0),
+    );
+    const bottom = interpolate(
+      sx,
+      dot(this.gradients[channel]![b01]!, rx0, ry1),
+      dot(this.gradients[channel]![b11]!, rx1, ry1),
+    );
+    return interpolate(sy, top, bottom);
+  }
+
+  sample(
+    channel: number,
+    pointX: number,
+    pointY: number,
+    baseFrequencyX: number,
+    baseFrequencyY: number,
+    numOctaves: number,
+    type: FilterTurbulenceType,
+    stitchTiles: boolean,
+    tile: FilterPixelRegion,
+  ): number {
+    let frequencyX = baseFrequencyX;
+    let frequencyY = baseFrequencyY;
+    let stitch: StitchInfo | undefined;
+    if (stitchTiles && tile.width > 0 && tile.height > 0) {
+      const adjusted = (frequency: number, size: number) => {
+        if (frequency === 0) return 0;
+        const low = Math.floor(size * frequency) / size;
+        const high = Math.ceil(size * frequency) / size;
+        return low > 0 && frequency / low < high / frequency ? low : high;
+      };
+      frequencyX = adjusted(frequencyX, tile.width);
+      frequencyY = adjusted(frequencyY, tile.height);
+      const width = Math.trunc(tile.width * frequencyX + 0.5);
+      const height = Math.trunc(tile.height * frequencyY + 0.5);
+      stitch = {
+        width,
+        height,
+        wrapX: Math.trunc(tile.x * frequencyX + PERLIN_N + width),
+        wrapY: Math.trunc(tile.y * frequencyY + PERLIN_N + height),
+      };
+    }
+    let x = pointX * frequencyX;
+    let y = pointY * frequencyY;
+    let ratio = 1;
+    let sum = 0;
+    for (let octave = 0; octave < numOctaves; octave++) {
+      const noise = this.noise(channel, x, y, stitch);
+      sum += (type === "fractalNoise" ? noise : Math.abs(noise)) / ratio;
+      x *= 2;
+      y *= 2;
+      ratio *= 2;
+      if (stitch) {
+        stitch.width *= 2;
+        stitch.wrapX = 2 * stitch.wrapX - PERLIN_N;
+        stitch.height *= 2;
+        stitch.wrapY = 2 * stitch.wrapY - PERLIN_N;
+      }
+    }
+    return clamp(type === "fractalNoise" ? (sum + 1) / 2 : sum);
+  }
+}
+
+export interface TurbulenceParameters {
+  baseFrequencyX: number;
+  baseFrequencyY: number;
+  numOctaves: number;
+  seed: number;
+  stitchTiles: boolean;
+  type: FilterTurbulenceType;
+  region: FilterPixelRegion;
+  scaleX?: number;
+  scaleY?: number;
+}
+
+export function turbulenceFilterBitmap(width: number, height: number, parameters: TurbulenceParameters): FilterBitmap {
+  const result: FilterBitmap = { width, height, values: Array(width * height * 4).fill(0) };
+  const generator = new SVGTurbulenceGenerator(parameters.seed);
+  const scaleX = parameters.scaleX ?? 1;
+  const scaleY = parameters.scaleY ?? 1;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const pointX = x / scaleX;
+      const pointY = y / scaleY;
+      const channels = [0, 1, 2, 3].map((channel) =>
+        generator.sample(
+          channel,
+          pointX,
+          pointY,
+          parameters.baseFrequencyX,
+          parameters.baseFrequencyY,
+          parameters.numOctaves,
+          parameters.type,
+          parameters.stitchTiles,
+          parameters.region,
+        ),
+      );
+      setPixel(result, x, y, premultiply(channels[0]!, channels[1]!, channels[2]!, channels[3]!));
+    }
+  }
+  return result;
 }

--- a/packages/svg-to-swiftui-core/src/renderTree/filters.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/filters.ts
@@ -8,7 +8,10 @@ import {
   resolveSVGLength,
   SVGLengthError,
 } from "../lengths";
+import { type InternalGeneratorConfig, resolveResourceSync } from "../resources";
 import type { Presentation, StyleResolution, SVGStyleResolver } from "../styleCascade";
+import type { FilterConfiguration } from "../types";
+import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio } from "../viewports";
 import { objectBoundingBox } from "./bounds";
 import type {
   FilterBlendMode,
@@ -16,6 +19,8 @@ import type {
   FilterComponentTransferFunction,
   FilterComponentTransferFunctions,
   FilterCompositeOperator,
+  FilterEdgeMode,
+  FilterImageSource,
   FilterInput,
   FilterInstance,
   FilterPrimitive,
@@ -29,6 +34,25 @@ import type {
   RenderNode,
   SourceLocation,
 } from "./types";
+
+export const DEFAULT_FILTER_LIMITS: Required<FilterConfiguration> = {
+  maxKernelCells: 225,
+  maxOctaves: 9,
+  maxOutputPixels: 16_000_000,
+};
+
+export function filterLimits(config: InternalGeneratorConfig): Required<FilterConfiguration> {
+  const configured = { ...DEFAULT_FILTER_LIMITS, ...(config.filters ?? {}) };
+  return {
+    maxKernelCells: positiveIntegerLimit(configured.maxKernelCells, DEFAULT_FILTER_LIMITS.maxKernelCells),
+    maxOctaves: positiveIntegerLimit(configured.maxOctaves, DEFAULT_FILTER_LIMITS.maxOctaves),
+    maxOutputPixels: positiveIntegerLimit(configured.maxOutputPixels, DEFAULT_FILTER_LIMITS.maxOutputPixels),
+  };
+}
+
+function positiveIntegerLimit(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.max(1, Math.trunc(value)) : fallback;
+}
 
 const IDENTITY_COLOR_MATRIX = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0];
 const FILTER_BLEND_MODES = new Set<FilterBlendMode>([
@@ -187,14 +211,15 @@ function numberPair(
 ): [number, number] {
   const raw = attribute(element, name);
   if (raw === undefined || String(raw).trim() === "") return [fallback, fallback];
-  const tokens = String(raw).trim().split(/\s+/);
-  if (tokens.length < 1 || tokens.length > 2) {
+  const tokens = numberList(element, name, diagnostics);
+  if (!tokens || tokens.length < 1 || tokens.length > 2) {
+    if (!tokens) return [fallback, fallback];
     diagnostic(diagnostics, element, `invalid-filter-${name.toLowerCase()}`, `${name} requires one or two numbers.`);
     return [fallback, fallback];
   }
   try {
-    const first = parsePlainNumber(tokens[0], name);
-    const second = tokens.length === 2 ? parsePlainNumber(tokens[1], name) : first;
+    const first = tokens[0]!;
+    const second = tokens[1] ?? first;
     if (first < 0 || second < 0) {
       diagnostic(diagnostics, element, `negative-filter-${name.toLowerCase()}`, `${name} cannot be negative.`);
       return [0, 0];
@@ -209,6 +234,57 @@ function numberPair(
     );
     return [fallback, fallback];
   }
+}
+
+function integerPair(
+  element: ElementNode,
+  name: string,
+  fallback: number,
+  diagnostics: RenderDiagnostic[],
+): [number, number] | undefined {
+  const raw = attribute(element, name);
+  if (raw === undefined || String(raw).trim() === "") return [fallback, fallback];
+  const values = numberList(element, name, diagnostics);
+  if (!values || values.length < 1 || values.length > 2) {
+    if (values)
+      diagnostic(diagnostics, element, `invalid-filter-${name.toLowerCase()}`, `${name} requires one or two integers.`);
+    return undefined;
+  }
+  if (values.some((value) => !Number.isInteger(value))) {
+    diagnostic(diagnostics, element, `invalid-filter-${name.toLowerCase()}`, `${name} requires integer values.`);
+    return undefined;
+  }
+  const first = Math.trunc(values[0]!);
+  const second = Math.trunc(values[1] ?? values[0]!);
+  if (first <= 0 || second <= 0) {
+    diagnostic(
+      diagnostics,
+      element,
+      `invalid-filter-${name.toLowerCase()}`,
+      `${name} values must be greater than zero.`,
+    );
+    return undefined;
+  }
+  return [first, second];
+}
+
+function edgeMode(element: ElementNode, fallback: FilterEdgeMode, diagnostics: RenderDiagnostic[]): FilterEdgeMode {
+  const value = String(attribute(element, "edgeMode") ?? fallback)
+    .trim()
+    .toLowerCase();
+  if (value === "none" || value === "duplicate" || value === "wrap") return value;
+  diagnostic(diagnostics, element, "invalid-filter-edge-mode", `Invalid edgeMode '${value}'; using ${fallback}.`);
+  return fallback;
+}
+
+function booleanValue(element: ElementNode, name: string, fallback: boolean, diagnostics: RenderDiagnostic[]): boolean {
+  const raw = attribute(element, name);
+  if (raw === undefined || String(raw).trim() === "") return fallback;
+  const value = String(raw).trim().toLowerCase();
+  if (value === "true") return true;
+  if (value === "false") return false;
+  diagnostic(diagnostics, element, `invalid-filter-${name.toLowerCase()}`, `${name} must be true or false.`);
+  return fallback;
 }
 
 function numberList(element: ElementNode, name: string, diagnostics: RenderDiagnostic[]): number[] | undefined {
@@ -397,6 +473,68 @@ function floodColor(element: ElementNode, presentation: Presentation, diagnostic
   return { ...color, alpha: color.alpha * parseOpacity(rawOpacity) };
 }
 
+function filterImageSource(
+  element: ElementNode,
+  definitions: Map<string, ElementNode>,
+  config: InternalGeneratorConfig,
+  diagnostics: RenderDiagnostic[],
+): FilterImageSource {
+  const href = String(attribute(element, "href") ?? attribute(element, "xlink:href") ?? "").trim();
+  let preserveAspectRatio = DEFAULT_PRESERVE_ASPECT_RATIO;
+  try {
+    preserveAspectRatio = parsePreserveAspectRatio(attribute(element, "preserveAspectRatio"));
+  } catch (error) {
+    diagnostic(
+      diagnostics,
+      element,
+      "invalid-preserve-aspect-ratio",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  const source: FilterImageSource = { href, preserveAspectRatio };
+  if (!href) {
+    diagnostic(diagnostics, element, "missing-filter-image-resource", "feImage href is empty or missing.");
+    return source;
+  }
+  if (href.startsWith("#")) {
+    const id = href.slice(1);
+    if (!id || !definitions.has(id)) {
+      diagnostic(diagnostics, element, "missing-filter-image-fragment", `feImage fragment '${href}' does not exist.`);
+      return source;
+    }
+    source.localElementId = id;
+    return source;
+  }
+  const resolution = resolveResourceSync(href, "filter-image", element, config);
+  if ("failure" in resolution) {
+    diagnostic(diagnostics, element, resolution.failure.code, resolution.failure.message);
+    return source;
+  }
+  const resource = resolution.resource;
+  if (resource.mimeType === "image/svg+xml") {
+    if (!resource.bytes) {
+      diagnostic(
+        diagnostics,
+        element,
+        "svg-filter-image-bytes-required",
+        `SVG feImage '${href}' requires resolved bytes.`,
+      );
+      return source;
+    }
+    source.pendingSVG = { bytes: resource.bytes, canonicalURL: resource.canonicalURL };
+    return source;
+  }
+  source.resource = {
+    type: "raster",
+    ...(resource.bytes ? { bytes: resource.bytes } : {}),
+    mimeType: resource.mimeType,
+    canonicalURL: resource.canonicalURL,
+    ...(resource.assetName ? { assetName: resource.assetName } : {}),
+    ...(resource.intrinsicSize ? { intrinsicSize: resource.intrinsicSize } : {}),
+  };
+  return source;
+}
+
 function localHref(element: ElementNode, diagnostics: RenderDiagnostic[]): string | undefined {
   const raw = attribute(element, "href") ?? attribute(element, "xlink:href");
   if (raw === undefined || String(raw).trim() === "") return undefined;
@@ -416,6 +554,8 @@ function buildPrimitiveSpecs(
   filter: ElementNode,
   filterPresentation: Presentation,
   styleResolver: SVGStyleResolver,
+  definitions: Map<string, ElementNode>,
+  config: InternalGeneratorConfig,
   diagnostics: RenderDiagnostic[],
 ): FilterPrimitiveSpec[] {
   const specs: FilterPrimitiveSpec[] = [];
@@ -501,15 +641,195 @@ function buildPrimitiveSpecs(
         k4: numberValue(element, "k4", 0, diagnostics),
         ...common,
       };
-    } else if (tag === "fegaussianblur") {
-      const [stdDeviationX, stdDeviationY] = numberPair(element, "stdDeviation", 0, diagnostics);
-      const rawEdge = String(attribute(element, "edgeMode") ?? "none")
+    } else if (tag === "feconvolvematrix") {
+      const order = integerPair(element, "order", 3, diagnostics);
+      const kernelMatrix = numberList(element, "kernelMatrix", diagnostics);
+      const kernelCells = order ? order[0] * order[1] : 0;
+      const limit = filterLimits(config).maxKernelCells;
+      let invalid = !order || !kernelMatrix || kernelMatrix.length !== kernelCells;
+      if (order && kernelMatrix && kernelMatrix.length !== kernelCells)
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-filter-kernel-matrix-size",
+          `kernelMatrix has ${kernelMatrix.length} values but order ${order[0]}×${order[1]} requires ${kernelCells}; using pass-through.`,
+        );
+      if (kernelCells > limit) {
+        diagnostic(
+          diagnostics,
+          element,
+          "filter-kernel-limit",
+          `feConvolveMatrix has ${kernelCells} coefficients, exceeding the ${limit}-coefficient limit; using pass-through.`,
+        );
+        invalid = true;
+      }
+      const defaultDivisor = kernelMatrix?.reduce((sum, value) => sum + value, 0) || 1;
+      const authoredDivisor = numberValue(element, "divisor", defaultDivisor, diagnostics);
+      if (authoredDivisor === 0)
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-filter-divisor",
+          `feConvolveMatrix divisor cannot be zero; using ${defaultDivisor}.`,
+        );
+      const divisor = authoredDivisor === 0 ? defaultDivisor : authoredDivisor;
+      const rawTargetX = numberValue(element, "targetX", Math.floor((order?.[0] ?? 1) / 2), diagnostics);
+      const rawTargetY = numberValue(element, "targetY", Math.floor((order?.[1] ?? 1) / 2), diagnostics);
+      const targetX = Math.trunc(rawTargetX);
+      const targetY = Math.trunc(rawTargetY);
+      if (!Number.isInteger(rawTargetX) || !Number.isInteger(rawTargetY)) {
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-filter-convolution-target",
+          "targetX and targetY require integer values; using pass-through.",
+        );
+        invalid = true;
+      }
+      if (order && (targetX < 0 || targetX >= order[0] || targetY < 0 || targetY >= order[1])) {
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-filter-convolution-target",
+          `targetX/targetY must lie inside the ${order[0]}×${order[1]} kernel; using pass-through.`,
+        );
+        invalid = true;
+      }
+      let kernelUnitLength: [number, number] | undefined;
+      if (hasAttribute(element, "kernelUnitLength")) {
+        const values = numberList(element, "kernelUnitLength", diagnostics);
+        if (values && values.length >= 1 && values.length <= 2 && values.every((value) => value > 0))
+          kernelUnitLength = [values[0]!, values[1] ?? values[0]!];
+        else
+          diagnostic(
+            diagnostics,
+            element,
+            "invalid-filter-kernel-unit-length",
+            "kernelUnitLength requires one or two positive numbers; using the device-pixel default.",
+          );
+      }
+      spec = invalid
+        ? { type: "passthrough", input, element: element.tagName ?? "feConvolveMatrix", ...common }
+        : {
+            type: "convolveMatrix",
+            input,
+            orderX: order![0],
+            orderY: order![1],
+            kernelMatrix: kernelMatrix!,
+            divisor,
+            bias: numberValue(element, "bias", 0, diagnostics),
+            targetX,
+            targetY,
+            edgeMode: edgeMode(element, "duplicate", diagnostics),
+            ...(kernelUnitLength
+              ? { kernelUnitLengthX: kernelUnitLength[0], kernelUnitLengthY: kernelUnitLength[1] }
+              : {}),
+            preserveAlpha: booleanValue(element, "preserveAlpha", false, diagnostics),
+            ...common,
+          };
+    } else if (tag === "femorphology") {
+      const [radiusX, radiusY] = numberPair(element, "radius", 0, diagnostics);
+      const rawOperator = String(attribute(element, "operator") ?? "erode")
         .trim()
         .toLowerCase();
-      const edgeMode = rawEdge === "duplicate" || rawEdge === "wrap" || rawEdge === "none" ? rawEdge : "none";
-      if (edgeMode !== rawEdge)
-        diagnostic(diagnostics, element, "invalid-filter-edge-mode", `Invalid edgeMode '${rawEdge}'; using none.`);
-      spec = { type: "gaussianBlur", input, stdDeviationX, stdDeviationY, edgeMode, ...common };
+      const operator = rawOperator === "dilate" ? "dilate" : "erode";
+      if (rawOperator !== "erode" && rawOperator !== "dilate")
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-filter-morphology-operator",
+          `Invalid feMorphology operator '${rawOperator}'; using erode.`,
+        );
+      spec = { type: "morphology", input, operator, radiusX, radiusY, ...common };
+    } else if (tag === "fedisplacementmap") {
+      const channel = (name: "xChannelSelector" | "yChannelSelector") => {
+        const value = String(attribute(element, name) ?? "A")
+          .trim()
+          .toUpperCase();
+        if (value === "R" || value === "G" || value === "B" || value === "A") return value;
+        diagnostic(
+          diagnostics,
+          element,
+          `invalid-filter-${name.toLowerCase()}`,
+          `${name} must be R, G, B, or A; using A.`,
+        );
+        return "A" as const;
+      };
+      spec = {
+        type: "displacementMap",
+        input,
+        input2: input2 ?? previousInput(),
+        scale: numberValue(element, "scale", 0, diagnostics),
+        xChannel: channel("xChannelSelector"),
+        yChannel: channel("yChannelSelector"),
+        ...common,
+      };
+    } else if (tag === "fetile") {
+      spec = { type: "tile", input, ...common };
+    } else if (tag === "feturbulence") {
+      const [baseFrequencyX, baseFrequencyY] = numberPair(element, "baseFrequency", 0, diagnostics);
+      const parsedOctaves = numberValue(element, "numOctaves", 1, diagnostics);
+      const rawOctaves = Math.trunc(parsedOctaves);
+      if (!Number.isInteger(parsedOctaves))
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-filter-num-octaves",
+          "numOctaves requires an integer; truncating toward zero.",
+        );
+      const maxOctaves = filterLimits(config).maxOctaves;
+      let numOctaves = Math.max(0, rawOctaves);
+      if (rawOctaves < 0)
+        diagnostic(diagnostics, element, "negative-filter-num-octaves", "numOctaves cannot be negative; using 0.");
+      if (numOctaves > maxOctaves) {
+        diagnostic(
+          diagnostics,
+          element,
+          "filter-octave-limit",
+          `feTurbulence requests ${numOctaves} octaves; clamping to the ${maxOctaves}-octave limit.`,
+        );
+        numOctaves = maxOctaves;
+      }
+      const rawStitch = String(attribute(element, "stitchTiles") ?? "noStitch").trim();
+      const stitchTiles = rawStitch === "stitch";
+      if (rawStitch !== "stitch" && rawStitch !== "noStitch")
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-filter-stitch-tiles",
+          `Invalid stitchTiles '${rawStitch}'; using noStitch.`,
+        );
+      const rawType = String(attribute(element, "type") ?? "turbulence").trim();
+      const noiseType = rawType === "fractalNoise" ? "fractalNoise" : "turbulence";
+      if (rawType !== "turbulence" && rawType !== "fractalNoise")
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-filter-turbulence-type",
+          `Invalid feTurbulence type '${rawType}'; using turbulence.`,
+        );
+      spec = {
+        type: "turbulence",
+        baseFrequencyX,
+        baseFrequencyY,
+        numOctaves,
+        seed: Math.trunc(numberValue(element, "seed", 0, diagnostics)),
+        stitchTiles,
+        noiseType,
+        ...common,
+      };
+    } else if (tag === "feimage") {
+      spec = { type: "image", image: filterImageSource(element, definitions, config, diagnostics), ...common };
+    } else if (tag === "fegaussianblur") {
+      const [stdDeviationX, stdDeviationY] = numberPair(element, "stdDeviation", 0, diagnostics);
+      spec = {
+        type: "gaussianBlur",
+        input,
+        stdDeviationX,
+        stdDeviationY,
+        edgeMode: edgeMode(element, "none", diagnostics),
+        ...common,
+      };
     } else if (tag === "feoffset") {
       spec = {
         type: "offset",
@@ -573,6 +893,7 @@ export function resolveFilterResources(
   definitions: Map<string, ElementNode>,
   styleResolver: SVGStyleResolver,
   rootPresentation: Presentation,
+  config: InternalGeneratorConfig,
   diagnostics: RenderDiagnostic[],
 ): Map<string, FilterResource> {
   const resolutions = new Map<ElementNode, StyleResolution>();
@@ -655,7 +976,7 @@ export function resolveFilterResources(
       element,
       primitives:
         primitiveElements.length > 0
-          ? buildPrimitiveSpecs(element, presentation, styleResolver, diagnostics)
+          ? buildPrimitiveSpecs(element, presentation, styleResolver, definitions, config, diagnostics)
           : (base?.primitives ?? []),
       instances: new Map(),
       invalid: href !== undefined && (!base || base.invalid),
@@ -786,6 +1107,47 @@ export function resolveFilterInstance(resource: FilterResource, node: RenderNode
         ...spec,
         stdDeviationX: spec.stdDeviationX * scaleX,
         stdDeviationY: spec.stdDeviationY * scaleY,
+        ...common,
+      });
+    else if (spec.type === "convolveMatrix")
+      primitives.push({
+        ...spec,
+        ...(spec.kernelUnitLengthX === undefined
+          ? {}
+          : {
+              kernelUnitLengthX: spec.kernelUnitLengthX * scaleX,
+              kernelUnitLengthY: spec.kernelUnitLengthY! * scaleY,
+            }),
+        ...common,
+      });
+    else if (spec.type === "morphology")
+      primitives.push({ ...spec, radiusX: spec.radiusX * scaleX, radiusY: spec.radiusY * scaleY, ...common });
+    else if (spec.type === "displacementMap") {
+      const { scale, ...displacement } = spec;
+      primitives.push({
+        ...displacement,
+        displacement: { a: scale * scaleX, b: 0, c: 0, d: scale * scaleY },
+        ...common,
+      });
+    } else if (spec.type === "tile")
+      primitives.push({ ...spec, tileRegion: inputRegion(spec.input, primitives, region), ...common });
+    else if (spec.type === "image" && spec.image.localElementId)
+      primitives.push({
+        ...spec,
+        image: {
+          ...spec.image,
+          contentTransform:
+            resource.primitiveUnits === "objectBoundingBox"
+              ? {
+                  a: bounds?.width ?? 0,
+                  b: 0,
+                  c: 0,
+                  d: bounds?.height ?? 0,
+                  e: bounds?.x ?? 0,
+                  f: bounds?.y ?? 0,
+                }
+              : { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+        },
         ...common,
       });
     else if (spec.type === "offset")

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -94,6 +94,16 @@ interface GeneratedMask {
 interface GeneratedFilter {
   instance: FilterInstance;
   canvas: ViewBoxData;
+  imageHelpers: Array<{ key: string; name: string }>;
+  maxOutputPixels: number;
+}
+
+interface FilterImageHelper {
+  key: string;
+  name: string;
+  primitive: Extract<FilterPrimitive, { type: "image" }>;
+  canvas: ViewBoxData;
+  subdocumentName?: string;
 }
 
 interface GeneratedClipPath {
@@ -117,6 +127,7 @@ interface ViewBuildContext {
     transform: RenderNode["transform"];
     subdocumentName?: string;
   }>;
+  filterImageHelpers: FilterImageHelper[];
   subdocuments: string[][];
   rootName: string;
   config: SwiftUIGeneratorConfig;
@@ -360,15 +371,99 @@ function buildViewNodes(
               dy: transform.b * primitive.dx + transform.d * primitive.dy,
             };
       }
+      if (primitive.type === "morphology")
+        return {
+          ...primitive,
+          subregion,
+          radiusX: Math.hypot(transform.a * primitive.radiusX, transform.b * primitive.radiusX),
+          radiusY: Math.hypot(transform.c * primitive.radiusY, transform.d * primitive.radiusY),
+        };
+      if (primitive.type === "convolveMatrix" && primitive.kernelUnitLengthX !== undefined)
+        return {
+          ...primitive,
+          subregion,
+          kernelUnitLengthX: Math.hypot(
+            transform.a * primitive.kernelUnitLengthX,
+            transform.b * primitive.kernelUnitLengthX,
+          ),
+          kernelUnitLengthY: Math.hypot(
+            transform.c * primitive.kernelUnitLengthY!,
+            transform.d * primitive.kernelUnitLengthY!,
+          ),
+        };
+      if (primitive.type === "displacementMap")
+        return {
+          ...primitive,
+          subregion,
+          displacement: {
+            a: transform.a * primitive.displacement.a + transform.c * primitive.displacement.b,
+            b: transform.b * primitive.displacement.a + transform.d * primitive.displacement.b,
+            c: transform.a * primitive.displacement.c + transform.c * primitive.displacement.d,
+            d: transform.b * primitive.displacement.c + transform.d * primitive.displacement.d,
+          },
+        };
+      if (primitive.type === "tile")
+        return { ...primitive, subregion, tileRegion: transformRegion(primitive.tileRegion) };
+      if (primitive.type === "image" && primitive.image.contentTransform)
+        return {
+          ...primitive,
+          subregion,
+          image: {
+            ...primitive.image,
+            contentTransform: multiplyTransforms(transform, primitive.image.contentTransform),
+          },
+        };
       return { ...primitive, subregion };
     };
+    const instance: FilterInstance = {
+      ...filter,
+      region: transformRegion(filter.region),
+      primitives: filter.primitives.map(transformPrimitive),
+    };
+    const imageHelpers: Array<{ key: string; name: string }> = [];
+    for (const [index, primitive] of instance.primitives.entries()) {
+      if (primitive.type !== "image" || !primitive.image.resource) continue;
+      const key = `filter-image-${index}`;
+      const name = `FilterImageLayer${context.filterImageHelpers.length}`;
+      let subdocumentName: string | undefined;
+      if (primitive.image.resource.type === "svg") {
+        subdocumentName = `${context.rootName}FilterImageDocument${context.subdocuments.length}`;
+        const child = primitive.image.resource.document;
+        const childProperties: SVGElementProperties = {
+          width: child.viewport.width,
+          height: child.viewport.height,
+          viewBox: child.viewport.viewBox,
+          userViewport: child.viewport.userViewport,
+          preserveAspectRatio: child.viewport.preserveAspectRatio,
+          viewBoxTransform: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 },
+          zeroSized: child.viewport.zeroSized,
+        };
+        const generatedChild = generateView(child, childProperties, {
+          ...context.config,
+          structName: subdocumentName,
+          preserveColors: true,
+          usageCommentPrefix: false,
+        });
+        context.subdocuments.push(generatedChild.lines);
+      }
+      context.filterImageHelpers.push({
+        key,
+        name,
+        primitive,
+        canvas: context.coordinateSpace,
+        ...(subdocumentName ? { subdocumentName } : {}),
+      });
+      imageHelpers.push({ key, name });
+    }
+    const configuredMaxPixels = context.config.filters?.maxOutputPixels ?? 16_000_000;
     return {
-      instance: {
-        ...filter,
-        region: transformRegion(filter.region),
-        primitives: filter.primitives.map(transformPrimitive),
-      },
+      instance,
       canvas: context.coordinateSpace,
+      imageHelpers,
+      maxOutputPixels:
+        Number.isFinite(configuredMaxPixels) && configuredMaxPixels > 0
+          ? Math.max(1, Math.trunc(configuredMaxPixels))
+          : 16_000_000,
     };
   };
 
@@ -846,7 +941,7 @@ function filterCompositeOperatorLiteral(operator: Extract<FilterPrimitive, { typ
   return `.${operator === "in" ? "inside" : operator === "out" ? "outside" : operator}`;
 }
 
-function filterPrimitiveLiteral(primitive: FilterPrimitive): string {
+function filterPrimitiveLiteral(primitive: FilterPrimitive, index: number): string {
   const region = filterRegionLiteral(primitive.subregion);
   const linear = primitive.colorInterpolation === "linearRGB" ? "true" : "false";
   const result = primitive.result ? swiftString(primitive.result) : "nil";
@@ -859,6 +954,18 @@ function filterPrimitiveLiteral(primitive: FilterPrimitive): string {
       return `.componentTransfer(input: ${filterInputLiteral(primitive.input)}, functions: [${primitive.functions.map(filterComponentFunctionLiteral).join(", ")}], region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "composite":
       return `.composite(input: ${filterInputLiteral(primitive.input)}, input2: ${filterInputLiteral(primitive.input2)}, operation: ${filterCompositeOperatorLiteral(primitive.operator)}, k1: ${formatNumber(primitive.k1)}, k2: ${formatNumber(primitive.k2)}, k3: ${formatNumber(primitive.k3)}, k4: ${formatNumber(primitive.k4)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "convolveMatrix":
+      return `.convolveMatrix(input: ${filterInputLiteral(primitive.input)}, orderX: ${primitive.orderX}, orderY: ${primitive.orderY}, kernel: [${primitive.kernelMatrix.map((value) => formatNumber(value)).join(", ")}], divisor: ${formatNumber(primitive.divisor)}, bias: ${formatNumber(primitive.bias)}, targetX: ${primitive.targetX}, targetY: ${primitive.targetY}, edge: .${primitive.edgeMode}, unitX: ${primitive.kernelUnitLengthX === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthX)}, unitY: ${primitive.kernelUnitLengthY === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthY)}, preserveAlpha: ${primitive.preserveAlpha}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "morphology":
+      return `.morphology(input: ${filterInputLiteral(primitive.input)}, operation: .${primitive.operator}, radiusX: ${formatNumber(primitive.radiusX)}, radiusY: ${formatNumber(primitive.radiusY)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "displacementMap":
+      return `.displacementMap(input: ${filterInputLiteral(primitive.input)}, input2: ${filterInputLiteral(primitive.input2)}, a: ${formatNumber(primitive.displacement.a)}, b: ${formatNumber(primitive.displacement.b)}, c: ${formatNumber(primitive.displacement.c)}, d: ${formatNumber(primitive.displacement.d)}, xChannel: .${primitive.xChannel.toLowerCase()}, yChannel: .${primitive.yChannel.toLowerCase()}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "tile":
+      return `.tile(input: ${filterInputLiteral(primitive.input)}, tileRegion: ${filterRegionLiteral(primitive.tileRegion)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "turbulence":
+      return `.turbulence(baseFrequencyX: ${formatNumber(primitive.baseFrequencyX)}, baseFrequencyY: ${formatNumber(primitive.baseFrequencyY)}, octaves: ${primitive.numOctaves}, seed: ${primitive.seed}, stitch: ${primitive.stitchTiles}, fractalNoise: ${primitive.noiseType === "fractalNoise"}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "image":
+      return `.image(key: ${swiftString(`filter-image-${index}`)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "gaussianBlur":
       return `.gaussianBlur(input: ${filterInputLiteral(primitive.input)}, sigmaX: ${formatNumber(primitive.stdDeviationX)}, sigmaY: ${formatNumber(primitive.stdDeviationY)}, edge: .${primitive.edgeMode}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "offset":
@@ -876,7 +983,7 @@ function filterPrimitiveLiteral(primitive: FilterPrimitive): string {
 
 function filterDefinitionLiteral(filter: GeneratedFilter): string {
   const instance = filter.instance;
-  return `SVGFilterDefinition(region: ${filterRegionLiteral(instance.region)}, primitives: [${instance.primitives.map(filterPrimitiveLiteral).join(", ")}], fillPaint: ${filterColorLiteral(instance.fillPaint)}, strokePaint: ${filterColorLiteral(instance.strokePaint)})`;
+  return `SVGFilterDefinition(region: ${filterRegionLiteral(instance.region)}, primitives: [${instance.primitives.map((primitive, index) => filterPrimitiveLiteral(primitive, index)).join(", ")}], fillPaint: ${filterColorLiteral(instance.fillPaint)}, strokePaint: ${filterColorLiteral(instance.strokePaint)}, maxOutputPixels: ${filter.maxOutputPixels})`;
 }
 
 function textGradientLength(
@@ -1737,9 +1844,17 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
   if (node.type === "pattern") return renderPatternNode(node, level, indentation);
   const lines = node.filter
     ? [
-        `${prefix}SVGFilteredCanvas(definition: ${filterDefinitionLiteral(node.filter)}, canvas: CGSize(width: ${formatNumber(node.filter.canvas.width)}, height: ${formatNumber(node.filter.canvas.height)})) { graphics, size in`,
+        `${prefix}SVGFilteredCanvas(definition: ${filterDefinitionLiteral(node.filter)}, canvas: CGSize(width: ${formatNumber(node.filter.canvas.width)}, height: ${formatNumber(node.filter.canvas.height)}), drawSource: { graphics, size in`,
         ...renderGeneratedCommands(node.children, "graphics", level + 1, indentation),
-        `${prefix}}`,
+        `${prefix}}, renderFilterImages: { size, scale in`,
+        `${prefix}${indentation}var images: [String: CGImage] = [:]`,
+        ...node.filter.imageHelpers.flatMap(({ key, name }) => [
+          `${prefix}${indentation}let ${name}Renderer = ImageRenderer(content: ${name}().frame(width: size.width, height: size.height))`,
+          `${prefix}${indentation}${name}Renderer.scale = scale`,
+          `${prefix}${indentation}if let image = ${name}Renderer.cgImage { images[${swiftString(key)}] = image }`,
+        ]),
+        `${prefix}${indentation}return images`,
+        `${prefix}})`,
       ]
     : [`${prefix}ZStack {`];
   if (!node.filter) {
@@ -1899,6 +2014,18 @@ private enum SVGFilterCompositeOperator: Equatable {
     case over, inside, outside, atop, xor, lighter, arithmetic
 }
 
+private enum SVGFilterMorphologyOperator {
+    case erode, dilate
+}
+
+private enum SVGFilterChannel {
+    case r, g, b, a
+
+    var index: Int {
+        switch self { case .r: 0; case .g: 1; case .b: 2; case .a: 3 }
+    }
+}
+
 private enum SVGFilterComponentFunction {
     case identity
     case table([Float])
@@ -1912,6 +2039,12 @@ private enum SVGFilterPrimitive {
     case colorMatrix(input: SVGFilterInput, matrix: [Float], region: SVGFilterRegion, linearRGB: Bool, result: String?)
     case componentTransfer(input: SVGFilterInput, functions: [SVGFilterComponentFunction], region: SVGFilterRegion, linearRGB: Bool, result: String?)
     case composite(input: SVGFilterInput, input2: SVGFilterInput, operation: SVGFilterCompositeOperator, k1: Float, k2: Float, k3: Float, k4: Float, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case convolveMatrix(input: SVGFilterInput, orderX: Int, orderY: Int, kernel: [Float], divisor: Float, bias: Float, targetX: Int, targetY: Int, edge: SVGFilterEdgeMode, unitX: CGFloat?, unitY: CGFloat?, preserveAlpha: Bool, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case morphology(input: SVGFilterInput, operation: SVGFilterMorphologyOperator, radiusX: CGFloat, radiusY: CGFloat, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case displacementMap(input: SVGFilterInput, input2: SVGFilterInput, a: CGFloat, b: CGFloat, c: CGFloat, d: CGFloat, xChannel: SVGFilterChannel, yChannel: SVGFilterChannel, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case tile(input: SVGFilterInput, tileRegion: SVGFilterRegion, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case turbulence(baseFrequencyX: CGFloat, baseFrequencyY: CGFloat, octaves: Int, seed: Int, stitch: Bool, fractalNoise: Bool, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case image(key: String, region: SVGFilterRegion, linearRGB: Bool, result: String?)
     case gaussianBlur(input: SVGFilterInput, sigmaX: CGFloat, sigmaY: CGFloat, edge: SVGFilterEdgeMode, region: SVGFilterRegion, linearRGB: Bool, result: String?)
     case offset(input: SVGFilterInput, dx: CGFloat, dy: CGFloat, region: SVGFilterRegion, linearRGB: Bool, result: String?)
     case flood(color: SVGFilterColor, region: SVGFilterRegion, linearRGB: Bool, result: String?)
@@ -1925,6 +2058,12 @@ private enum SVGFilterPrimitive {
              let .colorMatrix(_, _, region, _, _),
              let .componentTransfer(_, _, region, _, _),
              let .composite(_, _, _, _, _, _, _, region, _, _),
+             let .convolveMatrix(_, _, _, _, _, _, _, _, _, _, _, _, region, _, _),
+             let .morphology(_, _, _, _, region, _, _),
+             let .displacementMap(_, _, _, _, _, _, _, _, region, _, _),
+             let .tile(_, _, region, _, _),
+             let .turbulence(_, _, _, _, _, _, region, _, _),
+             let .image(_, region, _, _),
              let .gaussianBlur(_, _, _, _, region, _, _),
              let .offset(_, _, _, region, _, _),
              let .flood(_, region, _, _),
@@ -1941,6 +2080,12 @@ private enum SVGFilterPrimitive {
              let .colorMatrix(_, _, _, value, _),
              let .componentTransfer(_, _, _, value, _),
              let .composite(_, _, _, _, _, _, _, _, value, _),
+             let .convolveMatrix(_, _, _, _, _, _, _, _, _, _, _, _, _, value, _),
+             let .morphology(_, _, _, _, _, value, _),
+             let .displacementMap(_, _, _, _, _, _, _, _, _, value, _),
+             let .tile(_, _, _, value, _),
+             let .turbulence(_, _, _, _, _, _, _, value, _),
+             let .image(_, _, value, _),
              let .gaussianBlur(_, _, _, _, _, value, _),
              let .offset(_, _, _, _, value, _),
              let .flood(_, _, value, _),
@@ -1957,12 +2102,14 @@ private struct SVGFilterDefinition {
     let primitives: [SVGFilterPrimitive]
     let fillPaint: SVGFilterColor
     let strokePaint: SVGFilterColor
+    let maxOutputPixels: Int
 }
 
 private struct SVGFilteredCanvas: View {
     let definition: SVGFilterDefinition
     let canvas: CGSize
     let drawSource: (CGContext, CGSize) -> Void
+    let renderFilterImages: @MainActor (CGSize, CGFloat) -> [String: CGImage]
     @Environment(\\.displayScale) private var displayScale
 
     var body: some View {
@@ -1978,6 +2125,7 @@ private struct SVGFilteredCanvas: View {
         guard size.width > 0, size.height > 0, canvas.width > 0, canvas.height > 0 else { return nil }
         let pixelWidth = max(1, Int((size.width * displayScale).rounded()))
         let pixelHeight = max(1, Int((size.height * displayScale).rounded()))
+        guard pixelWidth <= definition.maxOutputPixels / pixelHeight else { return nil }
         let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
         guard let graphics = CGContext(
             data: nil,
@@ -1992,7 +2140,12 @@ private struct SVGFilteredCanvas: View {
         graphics.scaleBy(x: displayScale, y: -displayScale)
         drawSource(graphics, size)
         guard let sourceImage = graphics.makeImage() else { return nil }
-        return SVGFilterBitmapRuntime.render(definition, sourceImage: sourceImage, canvas: canvas)
+        return SVGFilterBitmapRuntime.render(
+            definition,
+            sourceImage: sourceImage,
+            canvas: canvas,
+            filterImages: renderFilterImages(size, displayScale)
+        )
     }
 }
 
@@ -2024,25 +2177,30 @@ private struct SVGFilterPixelRect {
     }
 }
 
+private struct SVGFilterPixelRegion {
+    let x: CGFloat
+    let y: CGFloat
+    let width: CGFloat
+    let height: CGFloat
+}
+
+private struct SVGFilterStitchInfo {
+    var width: Int
+    var height: Int
+    var wrapX: Int
+    var wrapY: Int
+}
+
 private enum SVGFilterBitmapRuntime {
-    static func render(_ definition: SVGFilterDefinition, sourceImage: CGImage, canvas: CGSize) -> CGImage? {
-        guard let data = sourceImage.dataProvider?.data, let bytes = CFDataGetBytePtr(data) else { return nil }
+    static func render(_ definition: SVGFilterDefinition, sourceImage: CGImage, canvas: CGSize, filterImages: [String: CGImage]) -> CGImage? {
         let width = sourceImage.width
         let height = sourceImage.height
-        var source = SVGFilterBitmap(width: width, height: height)
-        for y in 0..<height {
-            for x in 0..<width {
-                let byte = y * sourceImage.bytesPerRow + x * 4
-                let value = (y * width + x) * 4
-                source.values[value] = Float(bytes[byte]) / 255
-                source.values[value + 1] = Float(bytes[byte + 1]) / 255
-                source.values[value + 2] = Float(bytes[byte + 2]) / 255
-                source.values[value + 3] = Float(bytes[byte + 3]) / 255
-            }
-        }
+        guard width > 0, height > 0, width <= definition.maxOutputPixels / height,
+              let source = bitmap(sourceImage) else { return nil }
         let scaleX = CGFloat(width) / canvas.width
         let scaleY = CGFloat(height) / canvas.height
-        let output = apply(definition, source: source, scaleX: scaleX, scaleY: scaleY)
+        let images = filterImages.compactMapValues(bitmap)
+        let output = apply(definition, source: source, scaleX: scaleX, scaleY: scaleY, filterImages: images)
         let outputBytes = output.values.map { UInt8((min(1, max(0, $0)) * 255).rounded()) }
         let outputData = Data(outputBytes)
         guard let provider = CGDataProvider(data: outputData as CFData) else { return nil }
@@ -2062,11 +2220,29 @@ private enum SVGFilterBitmapRuntime {
         )
     }
 
-    private static func pixelRect(_ region: SVGFilterRegion, scaleX: CGFloat, scaleY: CGFloat, height: Int) -> SVGFilterPixelRect {
+    private static func bitmap(_ image: CGImage) -> SVGFilterBitmap? {
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0 else { return nil }
+        var bytes = Array<UInt8>(repeating: 0, count: width * height * 4)
+        guard let context = CGContext(
+            data: &bytes,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpace(name: CGColorSpace.sRGB)!,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return SVGFilterBitmap(width: width, height: height, values: bytes.map { Float($0) / 255 })
+    }
+
+    private static func pixelRect(_ region: SVGFilterRegion, scaleX: CGFloat, scaleY: CGFloat, width: Int, height: Int) -> SVGFilterPixelRect {
         SVGFilterPixelRect(
             minX: max(0, Int(floor(region.x * scaleX))),
             minY: max(0, Int(floor(region.y * scaleY))),
-            maxX: min(Int(ceil((region.x + region.width) * scaleX)), Int.max),
+            maxX: min(Int(ceil((region.x + region.width) * scaleX)), width),
             maxY: min(Int(ceil((region.y + region.height) * scaleY)), height)
         )
     }
@@ -2330,6 +2506,268 @@ private enum SVGFilterBitmapRuntime {
         return result
     }
 
+    private static func sampleBilinear(_ image: SVGFilterBitmap, x: CGFloat, y: CGFloat, edge: SVGFilterEdgeMode, bounds: SVGFilterPixelRect) -> [Float] {
+        let minX = Int(floor(x))
+        let minY = Int(floor(y))
+        let fractionX = Float(x - CGFloat(minX))
+        let fractionY = Float(y - CGFloat(minY))
+        return (0..<4).map { channel in
+            let top = sample(image, x: minX, y: minY, channel: channel, edge: edge, bounds: bounds) * (1 - fractionX)
+                + sample(image, x: minX + 1, y: minY, channel: channel, edge: edge, bounds: bounds) * fractionX
+            let bottom = sample(image, x: minX, y: minY + 1, channel: channel, edge: edge, bounds: bounds) * (1 - fractionX)
+                + sample(image, x: minX + 1, y: minY + 1, channel: channel, edge: edge, bounds: bounds) * fractionX
+            return clamped(top * (1 - fractionY) + bottom * fractionY)
+        }
+    }
+
+    private static func write(_ pixel: [Float], to image: inout SVGFilterBitmap, x: Int, y: Int) {
+        let index = (y * image.width + x) * 4
+        for channel in 0..<4 { image.values[index + channel] = pixel[channel] }
+    }
+
+    private static func convolve(_ image: SVGFilterBitmap, orderX: Int, orderY: Int, kernel: [Float], divisor: Float, bias: Float, targetX: Int, targetY: Int, edge: SVGFilterEdgeMode, unitX: CGFloat, unitY: CGFloat, preserveAlpha: Bool, bounds: SVGFilterPixelRect) -> SVGFilterBitmap {
+        guard orderX > 0, orderY > 0, kernel.count == orderX * orderY, divisor != 0 else { return image }
+        var result = SVGFilterBitmap(width: image.width, height: image.height)
+        for y in 0..<image.height {
+            for x in 0..<image.width {
+                var sums: [Float] = [0, 0, 0, 0]
+                for row in 0..<orderY {
+                    for column in 0..<orderX {
+                        var pixel = sampleBilinear(
+                            image,
+                            x: CGFloat(x) + CGFloat(column - targetX) * unitX,
+                            y: CGFloat(y) + CGFloat(row - targetY) * unitY,
+                            edge: edge,
+                            bounds: bounds
+                        )
+                        let weight = kernel[(orderY - row - 1) * orderX + orderX - column - 1]
+                        if preserveAlpha {
+                            let alpha = clamped(pixel[3])
+                            if alpha > 0 {
+                                pixel[0] = clamped(pixel[0] / alpha)
+                                pixel[1] = clamped(pixel[1] / alpha)
+                                pixel[2] = clamped(pixel[2] / alpha)
+                            } else {
+                                pixel[0] = 0; pixel[1] = 0; pixel[2] = 0
+                            }
+                        }
+                        for channel in 0..<4 { sums[channel] += pixel[channel] * weight }
+                    }
+                }
+                let index = (y * image.width + x) * 4
+                if preserveAlpha {
+                    let alpha = clamped(image.values[index + 3])
+                    write([
+                        clamped(sums[0] / divisor + bias) * alpha,
+                        clamped(sums[1] / divisor + bias) * alpha,
+                        clamped(sums[2] / divisor + bias) * alpha,
+                        alpha,
+                    ], to: &result, x: x, y: y)
+                } else {
+                    var channels = sums.map { clamped($0 / divisor + bias) }
+                    let alpha = channels[3]
+                    channels[0] = min(alpha, channels[0])
+                    channels[1] = min(alpha, channels[1])
+                    channels[2] = min(alpha, channels[2])
+                    write(channels, to: &result, x: x, y: y)
+                }
+            }
+        }
+        return result
+    }
+
+    private static func morphology(_ image: SVGFilterBitmap, operation: SVGFilterMorphologyOperator, radiusX: CGFloat, radiusY: CGFloat) -> SVGFilterBitmap {
+        guard radiusX > 0, radiusY > 0 else { return image }
+        var result = SVGFilterBitmap(width: image.width, height: image.height)
+        let minX = Int(ceil(-radiusX)); let maxX = Int(floor(radiusX))
+        let minY = Int(ceil(-radiusY)); let maxY = Int(floor(radiusY))
+        for y in 0..<image.height {
+            for x in 0..<image.width {
+                var channels: [Float] = Array(repeating: operation == .erode ? 1 : 0, count: 4)
+                for offsetY in minY...maxY {
+                    for offsetX in minX...maxX {
+                        for channel in 0..<4 {
+                            let value = image.component(x + offsetX, y + offsetY, channel)
+                            channels[channel] = operation == .erode ? min(channels[channel], value) : max(channels[channel], value)
+                        }
+                    }
+                }
+                let alpha = channels[3]
+                channels[0] = min(alpha, channels[0]); channels[1] = min(alpha, channels[1]); channels[2] = min(alpha, channels[2])
+                write(channels, to: &result, x: x, y: y)
+            }
+        }
+        return result
+    }
+
+    private static func displacement(_ source: SVGFilterBitmap, map: SVGFilterBitmap, a: CGFloat, b: CGFloat, c: CGFloat, d: CGFloat, xChannel: SVGFilterChannel, yChannel: SVGFilterChannel) -> SVGFilterBitmap {
+        var result = SVGFilterBitmap(width: source.width, height: source.height)
+        let bounds = SVGFilterPixelRect(minX: 0, minY: 0, maxX: source.width, maxY: source.height)
+        for y in 0..<source.height {
+            for x in 0..<source.width {
+                let index = (y * map.width + x) * 4
+                let alpha = clamped(map.values[index + 3])
+                let xValue = alpha > 0 ? clamped(map.values[index + xChannel.index] / alpha) : 0
+                let yValue = alpha > 0 ? clamped(map.values[index + yChannel.index] / alpha) : 0
+                write(sampleBilinear(
+                    source,
+                    x: CGFloat(x) + a * CGFloat(xValue - 0.5) + c * CGFloat(yValue - 0.5),
+                    y: CGFloat(y) + b * CGFloat(xValue - 0.5) + d * CGFloat(yValue - 0.5),
+                    edge: .none,
+                    bounds: bounds
+                ), to: &result, x: x, y: y)
+            }
+        }
+        return result
+    }
+
+    private static func positiveModulo(_ value: CGFloat, _ modulus: CGFloat) -> CGFloat {
+        let remainder = value.truncatingRemainder(dividingBy: modulus)
+        return remainder < 0 ? remainder + modulus : remainder
+    }
+
+    private static func tile(_ image: SVGFilterBitmap, input: SVGFilterPixelRegion, output: SVGFilterPixelRegion) -> SVGFilterBitmap {
+        var result = SVGFilterBitmap(width: image.width, height: image.height)
+        guard input.width > 0, input.height > 0 else { return result }
+        let bounds = SVGFilterPixelRect(minX: 0, minY: 0, maxX: image.width, maxY: image.height)
+        let startX = max(0, Int(floor(output.x))); let endX = min(image.width, Int(ceil(output.x + output.width)))
+        let startY = max(0, Int(floor(output.y))); let endY = min(image.height, Int(ceil(output.y + output.height)))
+        guard startX < endX, startY < endY else { return result }
+        for y in startY..<endY {
+            for x in startX..<endX {
+                let sourceX = input.x + positiveModulo(CGFloat(x) + 0.5 - input.x, input.width) - 0.5
+                let sourceY = input.y + positiveModulo(CGFloat(y) + 0.5 - input.y, input.height) - 0.5
+                write(sampleBilinear(image, x: sourceX, y: sourceY, edge: .none, bounds: bounds), to: &result, x: x, y: y)
+            }
+        }
+        return result
+    }
+
+    private final class TurbulenceGenerator {
+        private static let latticeSize = 256
+        private static let mask = 255
+        private static let perlinN = 4096
+        private var lattice = Array(repeating: 0, count: 514)
+        private var gradients = Array(repeating: Array(repeating: (CGFloat(0), CGFloat(0)), count: 514), count: 4)
+
+        init(seed: Int) {
+            var random = Self.setupSeed(seed)
+            var index = 0
+            for channel in 0..<4 {
+                for item in 0..<Self.latticeSize {
+                    index = item
+                    lattice[item] = item
+                    var x: CGFloat = 0; var y: CGFloat = 0; var length: CGFloat = 0
+                    repeat {
+                        random = Self.nextRandom(random)
+                        x = CGFloat(random % 512 - 256) / 256
+                        random = Self.nextRandom(random)
+                        y = CGFloat(random % 512 - 256) / 256
+                        length = hypot(x, y)
+                    } while length == 0
+                    gradients[channel][item] = (x / length, y / length)
+                }
+            }
+            index = Self.latticeSize
+            while index > 1 {
+                index -= 1
+                random = Self.nextRandom(random)
+                lattice.swapAt(index, random % Self.latticeSize)
+            }
+            for item in 0..<(Self.latticeSize + 2) {
+                lattice[Self.latticeSize + item] = lattice[item]
+                for channel in 0..<4 { gradients[channel][Self.latticeSize + item] = gradients[channel][item] }
+            }
+        }
+
+        private static func setupSeed(_ value: Int) -> Int {
+            if value <= 0 { return -(value % 2_147_483_646) + 1 }
+            return min(value, 2_147_483_646)
+        }
+
+        private static func nextRandom(_ value: Int) -> Int {
+            var result = 16_807 * (value % 127_773) - 2_836 * (value / 127_773)
+            if result <= 0 { result += 2_147_483_647 }
+            return result
+        }
+
+        private func noise(_ channel: Int, _ x: CGFloat, _ y: CGFloat, _ stitch: SVGFilterStitchInfo?) -> CGFloat {
+            var bx0 = Int(x + CGFloat(Self.perlinN)); var bx1 = bx0 + 1
+            let rx0 = x + CGFloat(Self.perlinN - bx0); let rx1 = rx0 - 1
+            var by0 = Int(y + CGFloat(Self.perlinN)); var by1 = by0 + 1
+            let ry0 = y + CGFloat(Self.perlinN - by0); let ry1 = ry0 - 1
+            if let stitch {
+                if bx0 >= stitch.wrapX { bx0 -= stitch.width }; if bx1 >= stitch.wrapX { bx1 -= stitch.width }
+                if by0 >= stitch.wrapY { by0 -= stitch.height }; if by1 >= stitch.wrapY { by1 -= stitch.height }
+            }
+            bx0 &= Self.mask; bx1 &= Self.mask; by0 &= Self.mask; by1 &= Self.mask
+            let i = lattice[bx0]; let j = lattice[bx1]
+            let b00 = lattice[i + by0]; let b10 = lattice[j + by0]
+            let b01 = lattice[i + by1]; let b11 = lattice[j + by1]
+            func curve(_ value: CGFloat) -> CGFloat { value * value * (3 - 2 * value) }
+            func dot(_ gradient: (CGFloat, CGFloat), _ dx: CGFloat, _ dy: CGFloat) -> CGFloat { dx * gradient.0 + dy * gradient.1 }
+            let sx = curve(rx0); let sy = curve(ry0)
+            let top = dot(gradients[channel][b00], rx0, ry0) + sx * (dot(gradients[channel][b10], rx1, ry0) - dot(gradients[channel][b00], rx0, ry0))
+            let bottom = dot(gradients[channel][b01], rx0, ry1) + sx * (dot(gradients[channel][b11], rx1, ry1) - dot(gradients[channel][b01], rx0, ry1))
+            return top + sy * (bottom - top)
+        }
+
+        func sample(channel: Int, x pointX: CGFloat, y pointY: CGFloat, frequencyX inputFrequencyX: CGFloat, frequencyY inputFrequencyY: CGFloat, octaves: Int, fractalNoise: Bool, stitchTiles: Bool, tile: SVGFilterRegion) -> Float {
+            var frequencyX = inputFrequencyX; var frequencyY = inputFrequencyY
+            var stitch: SVGFilterStitchInfo?
+            if stitchTiles && tile.width > 0 && tile.height > 0 {
+                func adjusted(_ frequency: CGFloat, _ size: CGFloat) -> CGFloat {
+                    guard frequency != 0 else { return 0 }
+                    let low = floor(size * frequency) / size; let high = ceil(size * frequency) / size
+                    return low > 0 && frequency / low < high / frequency ? low : high
+                }
+                frequencyX = adjusted(frequencyX, tile.width); frequencyY = adjusted(frequencyY, tile.height)
+                let width = Int(tile.width * frequencyX + 0.5); let height = Int(tile.height * frequencyY + 0.5)
+                stitch = SVGFilterStitchInfo(
+                    width: width,
+                    height: height,
+                    wrapX: Int(tile.x * frequencyX) + Self.perlinN + width,
+                    wrapY: Int(tile.y * frequencyY) + Self.perlinN + height
+                )
+            }
+            var x = pointX * frequencyX; var y = pointY * frequencyY
+            var ratio: CGFloat = 1; var sum: CGFloat = 0
+            for _ in 0..<octaves {
+                let value = noise(channel, x, y, stitch)
+                sum += (fractalNoise ? value : abs(value)) / ratio
+                x *= 2; y *= 2; ratio *= 2
+                if stitch != nil {
+                    stitch!.width *= 2; stitch!.wrapX = 2 * stitch!.wrapX - Self.perlinN
+                    stitch!.height *= 2; stitch!.wrapY = 2 * stitch!.wrapY - Self.perlinN
+                }
+            }
+            return clamped(Float(fractalNoise ? (sum + 1) / 2 : sum))
+        }
+    }
+
+    private static func turbulence(width: Int, height: Int, baseFrequencyX: CGFloat, baseFrequencyY: CGFloat, octaves: Int, seed: Int, stitch: Bool, fractalNoise: Bool, region: SVGFilterRegion, scaleX: CGFloat, scaleY: CGFloat) -> SVGFilterBitmap {
+        var result = SVGFilterBitmap(width: width, height: height)
+        let generator = TurbulenceGenerator(seed: seed)
+        for y in 0..<height {
+            for x in 0..<width {
+                let channels = (0..<4).map { channel in generator.sample(
+                    channel: channel,
+                    x: CGFloat(x) / scaleX,
+                    y: CGFloat(y) / scaleY,
+                    frequencyX: baseFrequencyX,
+                    frequencyY: baseFrequencyY,
+                    octaves: octaves,
+                    fractalNoise: fractalNoise,
+                    stitchTiles: stitch,
+                    tile: region
+                ) }
+                let alpha = channels[3]
+                write([channels[0] * alpha, channels[1] * alpha, channels[2] * alpha, alpha], to: &result, x: x, y: y)
+            }
+        }
+        return result
+    }
+
     private static func gaussianKernel(_ sigma: CGFloat) -> [Float] {
         guard sigma > 0 else { return [1] }
         let radius = max(1, Int(ceil(sigma * 3)))
@@ -2422,14 +2860,15 @@ private enum SVGFilterBitmapRuntime {
         return result
     }
 
-    private static func apply(_ definition: SVGFilterDefinition, source unboundedSource: SVGFilterBitmap, scaleX: CGFloat, scaleY: CGFloat) -> SVGFilterBitmap {
-        let filterRect = pixelRect(definition.region, scaleX: scaleX, scaleY: scaleY, height: unboundedSource.height)
+    private static func apply(_ definition: SVGFilterDefinition, source unboundedSource: SVGFilterBitmap, scaleX: CGFloat, scaleY: CGFloat, filterImages: [String: SVGFilterBitmap]) -> SVGFilterBitmap {
+        let filterRect = pixelRect(definition.region, scaleX: scaleX, scaleY: scaleY, width: unboundedSource.width, height: unboundedSource.height)
         let source = cropped(unboundedSource, to: filterRect)
         let sourceAlpha = alpha(source)
         let transparent = SVGFilterBitmap(width: source.width, height: source.height)
         let fillPaint = cropped(constant(definition.fillPaint, width: source.width, height: source.height), to: filterRect)
         let strokePaint = cropped(constant(definition.strokePaint, width: source.width, height: source.height), to: filterRect)
         var results: [SVGFilterBitmap] = []
+        var resultRegions: [SVGFilterPixelRect] = []
 
         func input(_ value: SVGFilterInput) -> SVGFilterBitmap {
             switch value {
@@ -2442,9 +2881,16 @@ private enum SVGFilterBitmapRuntime {
             }
         }
 
+        func inputRegion(_ value: SVGFilterInput) -> SVGFilterPixelRect {
+            if case let .result(index) = value, resultRegions.indices.contains(index) {
+                return resultRegions[index]
+            }
+            return filterRect
+        }
+
         for primitive in definition.primitives {
             let linear = primitive.linearRGB
-            let region = pixelRect(primitive.region, scaleX: scaleX, scaleY: scaleY, height: source.height)
+            let region = pixelRect(primitive.region, scaleX: scaleX, scaleY: scaleY, width: source.width, height: source.height)
             let output: SVGFilterBitmap
             switch primitive {
             case let .blend(value, value2, mode, _, _, _):
@@ -2465,8 +2911,68 @@ private enum SVGFilterBitmapRuntime {
                     linear: linear,
                     encode: true
                 )
+            case let .convolveMatrix(value, orderX, orderY, kernel, divisor, bias, targetX, targetY, edge, unitX, unitY, preserveAlpha, _, _, _):
+                let working = converted(input(value), linear: linear, encode: false)
+                output = converted(convolve(
+                    working,
+                    orderX: orderX,
+                    orderY: orderY,
+                    kernel: kernel,
+                    divisor: divisor,
+                    bias: bias,
+                    targetX: targetX,
+                    targetY: targetY,
+                    edge: edge,
+                    unitX: unitX.map { $0 * scaleX } ?? 1,
+                    unitY: unitY.map { $0 * scaleY } ?? 1,
+                    preserveAlpha: preserveAlpha,
+                    bounds: inputRegion(value)
+                ), linear: linear, encode: true)
+            case let .morphology(value, operation, radiusX, radiusY, _, _, _):
+                let working = converted(input(value), linear: linear, encode: false)
+                output = converted(morphology(working, operation: operation, radiusX: radiusX * scaleX, radiusY: radiusY * scaleY), linear: linear, encode: true)
+            case let .displacementMap(value, value2, a, b, c, d, xChannel, yChannel, _, _, _):
+                let map = converted(input(value2), linear: linear, encode: false)
+                output = displacement(
+                    input(value),
+                    map: map,
+                    a: a * scaleX,
+                    b: b * scaleY,
+                    c: c * scaleX,
+                    d: d * scaleY,
+                    xChannel: xChannel,
+                    yChannel: yChannel
+                )
+            case let .tile(value, tileRegion, _, _, _):
+                output = tile(
+                    input(value),
+                    input: SVGFilterPixelRegion(x: tileRegion.x * scaleX, y: tileRegion.y * scaleY, width: tileRegion.width * scaleX, height: tileRegion.height * scaleY),
+                    output: SVGFilterPixelRegion(x: primitive.region.x * scaleX, y: primitive.region.y * scaleY, width: primitive.region.width * scaleX, height: primitive.region.height * scaleY)
+                )
+            case let .turbulence(baseFrequencyX, baseFrequencyY, octaves, seed, stitch, fractalNoise, primitiveRegion, _, _):
+                let generated = turbulence(
+                    width: source.width,
+                    height: source.height,
+                    baseFrequencyX: baseFrequencyX,
+                    baseFrequencyY: baseFrequencyY,
+                    octaves: octaves,
+                    seed: seed,
+                    stitch: stitch,
+                    fractalNoise: fractalNoise,
+                    region: SVGFilterRegion(
+                        x: 0,
+                        y: 0,
+                        width: primitiveRegion.width * scaleX,
+                        height: primitiveRegion.height * scaleY
+                    ),
+                    scaleX: scaleX,
+                    scaleY: scaleY
+                )
+                output = converted(generated, linear: linear, encode: true)
+            case let .image(key, _, _, _):
+                output = filterImages[key] ?? transparent
             case let .gaussianBlur(value, sigmaX, sigmaY, edge, _, _, _):
-                output = converted(blur(converted(input(value), linear: linear, encode: false), sigmaX: sigmaX * scaleX, sigmaY: sigmaY * scaleY, edge: edge, bounds: region), linear: linear, encode: true)
+                output = converted(blur(converted(input(value), linear: linear, encode: false), sigmaX: sigmaX * scaleX, sigmaY: sigmaY * scaleY, edge: edge, bounds: inputRegion(value)), linear: linear, encode: true)
             case let .offset(value, dx, dy, _, _, _):
                 output = offset(input(value), dx: dx * scaleX, dy: dy * scaleY)
             case let .flood(color, _, _, _):
@@ -2476,7 +2982,7 @@ private enum SVGFilterBitmapRuntime {
                 for value in inputs { merged = over(input(value), merged) }
                 output = merged
             case let .dropShadow(value, sigmaX, sigmaY, dx, dy, color, _, _, _):
-                let shadowAlpha = offset(blur(alpha(input(value)), sigmaX: sigmaX * scaleX, sigmaY: sigmaY * scaleY, edge: .none, bounds: region), dx: dx * scaleX, dy: dy * scaleY)
+                let shadowAlpha = offset(blur(alpha(input(value)), sigmaX: sigmaX * scaleX, sigmaY: sigmaY * scaleY, edge: .none, bounds: inputRegion(value)), dx: dx * scaleX, dy: dy * scaleY)
                 var shadow = constant(color, width: source.width, height: source.height)
                 for index in stride(from: 0, to: shadow.values.count, by: 4) {
                     let mask = shadowAlpha.values[index + 3]
@@ -2490,6 +2996,7 @@ private enum SVGFilterBitmapRuntime {
                 output = input(value)
             }
             results.append(cropped(output, to: region))
+            resultRegions.append(region)
         }
         return cropped(results.last ?? source, to: filterRect)
     }
@@ -2597,6 +3104,85 @@ function createImageHelper(
   return body;
 }
 
+function createFilterImageHelper(helper: FilterImageHelper, indentationSize: number): string[] {
+  const indentation = " ".repeat(indentationSize);
+  const i2 = indentation.repeat(2);
+  const i3 = indentation.repeat(3);
+  const i4 = indentation.repeat(4);
+  const primitive = helper.primitive;
+  const resource = primitive.image.resource!;
+  const canvas = helper.canvas;
+  const isLocal = primitive.image.localElementId !== undefined;
+  const intrinsic =
+    resource.type === "raster"
+      ? (resource.intrinsicSize ?? { width: primitive.subregion.width, height: primitive.subregion.height })
+      : { width: resource.document.viewport.width, height: resource.document.viewport.height };
+  const preserveAspectRatio =
+    resource.type === "svg" && primitive.image.preserveAspectRatio.defer && resource.hasReferencedPreserveAspectRatio
+      ? resource.referencedPreserveAspectRatio
+      : primitive.image.preserveAspectRatio;
+  const placement = isLocal
+    ? (primitive.image.contentTransform ?? { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 })
+    : viewBoxTransform(
+        { x: 0, y: 0, width: intrinsic.width, height: intrinsic.height },
+        primitive.subregion,
+        preserveAspectRatio,
+      );
+  const drawRect =
+    resource.type === "svg" && isLocal
+      ? resource.document.viewport.viewBox
+      : { x: 0, y: 0, width: intrinsic.width, height: intrinsic.height };
+  const body = [
+    `private struct ${helper.name}: View {`,
+    `${indentation}var body: some View {`,
+    `${i2}Canvas { context, size in`,
+    `${i3}guard size.width > 0, size.height > 0 else { return }`,
+    `${i3}let viewport = CGAffineTransform(a: size.width / ${formatNumber(canvas.width)}, b: 0, c: 0, d: size.height / ${formatNumber(canvas.height)}, tx: ${formatNumber(-canvas.x)} * size.width / ${formatNumber(canvas.width)}, ty: ${formatNumber(-canvas.y)} * size.height / ${formatNumber(canvas.height)})`,
+    `${i3}context.transform = viewport`,
+    `${i3}context.clip(to: Path(CGRect(x: ${formatNumber(primitive.subregion.x)}, y: ${formatNumber(primitive.subregion.y)}, width: ${formatNumber(primitive.subregion.width)}, height: ${formatNumber(primitive.subregion.height)})))`,
+    `${i3}context.transform = context.transform.concatenating(${swiftTransform(placement)})`,
+  ];
+  if (resource.type === "svg") {
+    body.push(
+      `${i3}if let image = context.resolveSymbol(id: 0) {`,
+      `${i4}context.draw(image, in: CGRect(x: ${formatNumber(drawRect.x)}, y: ${formatNumber(drawRect.y)}, width: ${formatNumber(drawRect.width)}, height: ${formatNumber(drawRect.height)}))`,
+      `${i3}}`,
+      `${i2}} symbols: {`,
+      `${i3}${helper.subdocumentName!}()`,
+      `${i3}.frame(width: ${formatNumber(intrinsic.width)}, height: ${formatNumber(intrinsic.height)})`,
+      `${i3}.tag(0)`,
+      `${i2}}`,
+    );
+  } else if (resource.assetName) {
+    body.push(
+      `${i3}let image = context.resolve(Image(${swiftString(resource.assetName)}))`,
+      `${i3}context.draw(image, in: CGRect(x: 0, y: 0, width: ${formatNumber(intrinsic.width)}, height: ${formatNumber(intrinsic.height)}))`,
+      `${i2}}`,
+    );
+  } else {
+    body.push(
+      `${i3}if let source = Self.embeddedImage {`,
+      `${i4}context.draw(context.resolve(source), in: CGRect(x: 0, y: 0, width: ${formatNumber(intrinsic.width)}, height: ${formatNumber(intrinsic.height)}))`,
+      `${i3}}`,
+      `${i2}}`,
+    );
+  }
+  body.push(`${indentation}}`);
+  if (resource.type === "raster" && resource.bytes) {
+    body.push(
+      "",
+      `${indentation}private static let embeddedImage: Image? = {`,
+      `${i2}guard let data = Data(base64Encoded: ${swiftString(base64(resource.bytes))}),`,
+      `${i2}${indentation}let source = CGImageSourceCreateWithData(data as CFData, nil),`,
+      `${i2}${indentation}let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else { return nil }`,
+      `${i2}return Image(decorative: image, scale: 1, orientation: .up)`,
+      `${indentation}}()`,
+    );
+  }
+  body.push("}");
+  return body;
+}
+
 function gradientSupport(indentationSize: number): string[] {
   const indentation = " ".repeat(indentationSize);
   return [
@@ -2683,6 +3269,7 @@ function createView(
   helpers: ShapeHelper[],
   textHelpers: ViewBuildContext["textHelpers"],
   imageHelpers: ViewBuildContext["imageHelpers"],
+  filterImageHelpers: ViewBuildContext["filterImageHelpers"],
   coordinateSpace: ViewBoxData,
   document: RenderDocument,
   indentationSize: number,
@@ -2715,6 +3302,7 @@ function createView(
   for (const helper of textHelpers)
     body.push("", ...createTextHelper(helper, coordinateSpace, document, indentationSize));
   for (const helper of imageHelpers) body.push("", ...createImageHelper(helper, coordinateSpace, indentationSize));
+  for (const helper of filterImageHelpers) body.push("", ...createFilterImageHelper(helper, indentationSize));
   if (containsGradientNode(nodes)) body.push("", ...gradientSupport(indentationSize));
   if (containsFilterNode(nodes)) body.push("", ...filterSupport(indentationSize));
   return createStructTemplate({
@@ -2769,6 +3357,7 @@ export function generateView(
     activePatterns: new Set(),
     textHelpers: [],
     imageHelpers: [],
+    filterImageHelpers: [],
     subdocuments: [],
     rootName: config.structName ?? "SVGView",
     config,
@@ -2784,6 +3373,14 @@ export function generateView(
     imports.add("Foundation");
     imports.add("ImageIO");
   }
+  if (
+    context.filterImageHelpers.some(
+      (helper) => helper.primitive.image.resource?.type === "raster" && helper.primitive.image.resource.bytes,
+    )
+  ) {
+    imports.add("Foundation");
+    imports.add("ImageIO");
+  }
   if (context.textHelpers.length > 0 || context.imageHelpers.length > 0) imports.add("SwiftUI");
   return {
     lines: [
@@ -2795,6 +3392,7 @@ export function generateView(
         context.helpers,
         context.textHelpers,
         context.imageHelpers,
+        context.filterImageHelpers,
         document.viewport.coordinateSpace,
         document,
         indentationSize,

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -111,6 +111,10 @@ export type SVGBlendMode =
 
 export type FilterBlendMode = SVGBlendMode;
 export type FilterCompositeOperator = "over" | "in" | "out" | "atop" | "xor" | "lighter" | "arithmetic";
+export type FilterEdgeMode = "none" | "duplicate" | "wrap";
+export type FilterChannelSelector = "R" | "G" | "B" | "A";
+export type FilterMorphologyOperator = "erode" | "dilate";
+export type FilterTurbulenceType = "turbulence" | "fractalNoise";
 
 export type FilterComponentTransferFunction =
   | { type: "identity" }
@@ -125,6 +129,37 @@ export type FilterComponentTransferFunctions = [
   FilterComponentTransferFunction,
   FilterComponentTransferFunction,
 ];
+
+export interface RasterImageResource {
+  type: "raster";
+  bytes?: Uint8Array;
+  mimeType: string;
+  canonicalURL: string;
+  assetName?: string;
+  intrinsicSize?: { width: number; height: number };
+}
+
+export interface SVGImageResource {
+  type: "svg";
+  canonicalURL: string;
+  document: RenderDocument;
+  referencedPreserveAspectRatio: PreserveAspectRatio;
+  hasReferencedPreserveAspectRatio: boolean;
+}
+
+export type ImageResource = RasterImageResource | SVGImageResource;
+
+export interface FilterImageSource {
+  href: string;
+  preserveAspectRatio: PreserveAspectRatio;
+  resource?: ImageResource;
+  /** Resolved SVG bytes awaiting render-document construction outside filters.ts to avoid a build-tree import cycle. */
+  pendingSVG?: { bytes: Uint8Array; canonicalURL: string };
+  /** Retained until buildRenderDocument materializes local fragment semantics through a synthesized use tree. */
+  localElementId?: string;
+  /** Local-fragment user space mapped into the referencing filter instance. */
+  contentTransform?: AffineTransform;
+}
 
 export interface NodeCoordinateContext {
   viewport: { width: number; height: number };
@@ -216,8 +251,49 @@ export type FilterPrimitiveSpec =
       input: FilterInput;
       stdDeviationX: number;
       stdDeviationY: number;
-      edgeMode: "none" | "duplicate" | "wrap";
+      edgeMode: FilterEdgeMode;
     })
+  | (FilterPrimitiveSpecBase & {
+      type: "convolveMatrix";
+      input: FilterInput;
+      orderX: number;
+      orderY: number;
+      kernelMatrix: number[];
+      divisor: number;
+      bias: number;
+      targetX: number;
+      targetY: number;
+      edgeMode: FilterEdgeMode;
+      kernelUnitLengthX?: number;
+      kernelUnitLengthY?: number;
+      preserveAlpha: boolean;
+    })
+  | (FilterPrimitiveSpecBase & {
+      type: "morphology";
+      input: FilterInput;
+      operator: FilterMorphologyOperator;
+      radiusX: number;
+      radiusY: number;
+    })
+  | (FilterPrimitiveSpecBase & {
+      type: "displacementMap";
+      input: FilterInput;
+      input2: FilterInput;
+      scale: number;
+      xChannel: FilterChannelSelector;
+      yChannel: FilterChannelSelector;
+    })
+  | (FilterPrimitiveSpecBase & { type: "tile"; input: FilterInput })
+  | (FilterPrimitiveSpecBase & {
+      type: "turbulence";
+      baseFrequencyX: number;
+      baseFrequencyY: number;
+      numOctaves: number;
+      seed: number;
+      stitchTiles: boolean;
+      noiseType: FilterTurbulenceType;
+    })
+  | (FilterPrimitiveSpecBase & { type: "image"; image: FilterImageSource })
   | (FilterPrimitiveSpecBase & { type: "offset"; input: FilterInput; dx: number; dy: number })
   | (FilterPrimitiveSpecBase & { type: "flood"; color: RGBAColor })
   | (FilterPrimitiveSpecBase & { type: "merge"; inputs: FilterInput[] })
@@ -268,8 +344,49 @@ export type FilterPrimitive =
       input: FilterInput;
       stdDeviationX: number;
       stdDeviationY: number;
-      edgeMode: "none" | "duplicate" | "wrap";
+      edgeMode: FilterEdgeMode;
     })
+  | (FilterPrimitiveBase & {
+      type: "convolveMatrix";
+      input: FilterInput;
+      orderX: number;
+      orderY: number;
+      kernelMatrix: number[];
+      divisor: number;
+      bias: number;
+      targetX: number;
+      targetY: number;
+      edgeMode: FilterEdgeMode;
+      kernelUnitLengthX?: number;
+      kernelUnitLengthY?: number;
+      preserveAlpha: boolean;
+    })
+  | (FilterPrimitiveBase & {
+      type: "morphology";
+      input: FilterInput;
+      operator: FilterMorphologyOperator;
+      radiusX: number;
+      radiusY: number;
+    })
+  | (FilterPrimitiveBase & {
+      type: "displacementMap";
+      input: FilterInput;
+      input2: FilterInput;
+      displacement: Pick<AffineTransform, "a" | "b" | "c" | "d">;
+      xChannel: FilterChannelSelector;
+      yChannel: FilterChannelSelector;
+    })
+  | (FilterPrimitiveBase & { type: "tile"; input: FilterInput; tileRegion: RenderBounds })
+  | (FilterPrimitiveBase & {
+      type: "turbulence";
+      baseFrequencyX: number;
+      baseFrequencyY: number;
+      numOctaves: number;
+      seed: number;
+      stitchTiles: boolean;
+      noiseType: FilterTurbulenceType;
+    })
+  | (FilterPrimitiveBase & { type: "image"; image: FilterImageSource })
   | (FilterPrimitiveBase & { type: "offset"; input: FilterInput; dx: number; dy: number })
   | (FilterPrimitiveBase & { type: "flood"; color: RGBAColor })
   | (FilterPrimitiveBase & { type: "merge"; inputs: FilterInput[] })
@@ -616,22 +733,7 @@ export interface RenderImage {
   viewport: ViewBoxData;
   preserveAspectRatio: PreserveAspectRatio;
   imageRendering: string;
-  resource?:
-    | {
-        type: "raster";
-        bytes?: Uint8Array;
-        mimeType: string;
-        canonicalURL: string;
-        assetName?: string;
-        intrinsicSize?: { width: number; height: number };
-      }
-    | {
-        type: "svg";
-        canonicalURL: string;
-        document: RenderDocument;
-        referencedPreserveAspectRatio: PreserveAspectRatio;
-        hasReferencedPreserveAspectRatio: boolean;
-      };
+  resource?: ImageResource;
   attributes: Readonly<Record<string, string | number>>;
   style: ComputedStyle;
   transform: AffineTransform;

--- a/packages/svg-to-swiftui-core/src/resources.ts
+++ b/packages/svg-to-swiftui-core/src/resources.ts
@@ -554,10 +554,11 @@ export async function prepareImageResources(root: ElementNode, config: InternalG
     currentConfig: InternalGeneratorConfig,
     active: string[],
   ): Promise<void> => {
-    if (element.tagName === "image") {
+    if (element.tagName === "image" || element.tagName?.toLowerCase() === "feimage") {
       const raw = String(element.properties?.href ?? element.properties?.["xlink:href"] ?? "").trim();
-      if (raw) {
-        const resolved = await resolveResourceAsync(raw, "image", element, currentConfig);
+      if (raw && !raw.startsWith("#")) {
+        const kind: ResourceKind = element.tagName === "image" ? "image" : "filter-image";
+        const resolved = await resolveResourceAsync(raw, kind, element, currentConfig);
         if (
           "resource" in resolved &&
           resolved.resource.mimeType === "image/svg+xml" &&

--- a/packages/svg-to-swiftui-core/src/tests/filterSpatialNoiseImage.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/filterSpatialNoiseImage.test.ts
@@ -1,0 +1,319 @@
+import { __testing, convert, convertAsync, convertWithDiagnostics, type ResourceRequest } from "../index";
+import {
+  convolveFilterBitmap,
+  displacementFilterBitmap,
+  type FilterBitmap,
+  morphologyFilterBitmap,
+  nextTurbulenceRandom,
+  SVGTurbulenceGenerator,
+  setupTurbulenceSeed,
+  tileFilterBitmap,
+  turbulenceFilterBitmap,
+} from "../renderTree/filterMath";
+import type { FilterPrimitive, RenderNode } from "../renderTree/types";
+
+const PNG = Uint8Array.from(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgQIAZcfRzQAAAABJRU5ErkJggg==",
+    "base64",
+  ),
+);
+
+function flatten(nodes: RenderNode[]): RenderNode[] {
+  return nodes.flatMap((node) => (node.type === "group" ? [node, ...flatten(node.children)] : [node]));
+}
+
+function primitives(source: string, config = {}): FilterPrimitive[] {
+  const document = __testing.parseRenderDocument(source, config);
+  const node = flatten(document.children).find((candidate) => candidate.filter);
+  if (!node?.filter) throw new Error("Expected a filter instance");
+  return node.filter.primitives;
+}
+
+function bitmap(width: number, height: number, values: number[]): FilterBitmap {
+  return { width, height, values };
+}
+
+function pngWithDimensions(width: number, height: number): Uint8Array {
+  const bytes = Uint8Array.from(PNG);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(16, width);
+  view.setUint32(20, height);
+  return bytes;
+}
+
+function pixels(image: FilterBitmap): number[][] {
+  return Array.from({ length: image.width * image.height }, (_, index) => image.values.slice(index * 4, index * 4 + 4));
+}
+
+describe("spatial, noise, and image filter parsing", () => {
+  test("retains every primitive attribute, comma pairs, defaults, and graph inputs", () => {
+    const graph = primitives(`<svg viewBox="0 0 100 50"><defs><filter id="f">
+      <feConvolveMatrix order="3,2" kernelMatrix="1 2 3,4 5 6" divisor="7" bias=".25"
+        targetX="2" targetY="0" edgeMode="wrap" kernelUnitLength="2,3" preserveAlpha="true" result="conv"/>
+      <feMorphology in="conv" operator="dilate" radius="4,5" result="morph"/>
+      <feDisplacementMap in="morph" in2="SourceGraphic" scale="8" xChannelSelector="B" yChannelSelector="A"/>
+      <feTile/><feTurbulence baseFrequency=".02,.03" numOctaves="4" seed="-3.9" stitchTiles="stitch" type="fractalNoise"/>
+    </filter></defs><rect width="100" height="50" filter="url(#f)"/></svg>`);
+    expect(graph).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "convolveMatrix",
+          orderX: 3,
+          orderY: 2,
+          kernelMatrix: [1, 2, 3, 4, 5, 6],
+          divisor: 7,
+          bias: 0.25,
+          targetX: 2,
+          targetY: 0,
+          edgeMode: "wrap",
+          kernelUnitLengthX: 2,
+          kernelUnitLengthY: 3,
+          preserveAlpha: true,
+        }),
+        expect.objectContaining({ type: "morphology", operator: "dilate", radiusX: 4, radiusY: 5 }),
+        expect.objectContaining({
+          type: "displacementMap",
+          input: { type: "result", index: 1 },
+          input2: { type: "sourceGraphic" },
+          displacement: { a: 8, b: 0, c: 0, d: 8 },
+          xChannel: "B",
+          yChannel: "A",
+        }),
+        expect.objectContaining({ type: "tile" }),
+        expect.objectContaining({
+          type: "turbulence",
+          baseFrequencyX: 0.02,
+          baseFrequencyY: 0.03,
+          numOctaves: 4,
+          seed: -3,
+          stitchTiles: true,
+          noiseType: "fractalNoise",
+        }),
+      ]),
+    );
+  });
+
+  test("transforms objectBoundingBox radii, kernel spacing, displacement, and tile input region", () => {
+    const graph = primitives(`<svg viewBox="0 0 200 100"><defs><filter id="f" primitiveUnits="objectBoundingBox">
+      <feConvolveMatrix order="1" kernelMatrix="1" kernelUnitLength=".1 .2" x="10%" y="20%" width="30%" height="40%" result="a"/>
+      <feMorphology in="a" radius=".1 .2" result="b"/>
+      <feDisplacementMap in="b" in2="SourceGraphic" scale=".5"/><feTile in="a"/>
+    </filter></defs><rect x="20" y="10" width="100" height="50" filter="url(#f)"/></svg>`);
+    expect(graph[0]).toMatchObject({
+      kernelUnitLengthX: 10,
+      kernelUnitLengthY: 10,
+      subregion: { x: 30, y: 20, width: 30, height: 20 },
+    });
+    expect(graph[1]).toMatchObject({ radiusX: 10, radiusY: 10 });
+    expect(graph[2]).toMatchObject({ displacement: { a: 50, b: 0, c: 0, d: 25 } });
+    expect(graph[3]).toMatchObject({ tileRegion: { x: 30, y: 20, width: 30, height: 20 } });
+  });
+
+  test("diagnoses malformed values and enforces configurable limits", () => {
+    const result = convertWithDiagnostics(
+      `<svg viewBox="0 0 10 10"><defs><filter id="f">
+      <feConvolveMatrix order="4 4" kernelMatrix="1 2" divisor="0" targetX="1.5"/><feMorphology operator="bad" radius="-1"/>
+      <feConvolveMatrix order="2.5" kernelMatrix="1"/><feDisplacementMap xChannelSelector="X"/>
+      <feTurbulence numOctaves="99.5" type="bad" stitchTiles="bad"/>
+    </filter></defs><rect width="10" height="10" filter="url(#f)"/></svg>`,
+      {
+        filters: { maxKernelCells: 8, maxOctaves: 2, maxOutputPixels: 1 },
+      },
+    );
+    expect(result.diagnostics.map(({ code }) => code)).toEqual(
+      expect.arrayContaining([
+        "filter-kernel-limit",
+        "invalid-filter-divisor",
+        "invalid-filter-convolution-target",
+        "invalid-filter-order",
+        "invalid-filter-morphology-operator",
+        "negative-filter-radius",
+        "invalid-filter-xchannelselector",
+        "filter-octave-limit",
+        "invalid-filter-num-octaves",
+        "invalid-filter-turbulence-type",
+        "invalid-filter-stitch-tiles",
+      ]),
+    );
+    expect(result.swift).toContain("maxOutputPixels: 1");
+  });
+
+  test("materializes data raster, external SVG, and local-fragment feImage without network runtime code", async () => {
+    const requests: ResourceRequest[] = [];
+    const child = Uint8Array.from(
+      Buffer.from(
+        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 1"><rect width="2" height="1" fill="blue"/></svg>`,
+      ),
+    );
+    const source = `<svg viewBox="0 0 20 10"><defs><g id="local"><circle cx="5" cy="5" r="4"/></g><filter id="f">
+      <feImage href="pixel.png" x="0" width="5" height="5" result="a"/>
+      <feImage href="child.svg" x="5" width="5" height="5" result="b"/>
+      <feImage href="#local" x="10" width="5" height="5" preserveAspectRatio="none"/>
+    </filter></defs><rect width="20" height="10" filter="url(#f)"/></svg>`;
+    const swift = await convertAsync(source, {
+      structName: "FilterImages",
+      resources: {
+        policy: "custom",
+        baseURL: "https://assets.example/root.svg",
+        resolver: async (request) => {
+          requests.push(request);
+          if (request.canonicalURL.endsWith("pixel.png")) return { bytes: PNG, mimeType: "image/png" };
+          if (request.canonicalURL.endsWith("child.svg")) return { bytes: child, mimeType: "image/svg+xml" };
+          return undefined;
+        },
+      },
+    });
+    expect(requests.map(({ kind }) => kind)).toEqual(["filter-image", "filter-image"]);
+    expect(swift).toContain("FilterImageLayer0");
+    expect(swift).toContain("FilterImagesFilterImageDocument0");
+    expect(swift).toContain("FilterImagesFilterImageDocument1");
+    expect(swift).toContain("CGImageSourceCreateImageAtIndex");
+    expect(swift).not.toContain("URLSession");
+  });
+
+  test("uses href over xlink:href and rejects recursive local fragments", () => {
+    const document = __testing.parseRenderDocument(`<svg viewBox="0 0 10 10"><defs>
+      <g id="recursive" filter="url(#f)"><rect width="5" height="5"/></g>
+      <filter id="f"><feImage href="#recursive" xlink:href="#other"/></filter>
+      <g id="other"><circle r="1"/></g>
+    </defs><rect width="10" height="10" filter="url(#f)"/></svg>`);
+    expect(document.resources.filters.get("f")?.primitives[0]).toMatchObject({
+      type: "image",
+      image: { href: "#recursive", localElementId: "recursive" },
+    });
+    expect(document.diagnostics.map(({ code }) => code)).toContain("recursive-filter-image");
+  });
+
+  test("applies the shared resource policy, encoded-byte limit, and decoded-pixel limit to feImage", () => {
+    const svg = (href: string) =>
+      `<svg viewBox="0 0 10 10"><defs><filter id="f"><feImage href="${href}"/></filter></defs><rect width="10" height="10" filter="url(#f)"/></svg>`;
+    const denied = convertWithDiagnostics(svg("https://example.test/image.png"));
+    expect(denied.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "external-resource-denied", source: { element: "feImage" } }),
+      ]),
+    );
+    const byteLimited = convertWithDiagnostics(svg("large.png"), {
+      resources: { supplied: { "large.png": { bytes: PNG } }, limits: { maxResourceBytes: 8 } },
+    });
+    expect(byteLimited.diagnostics.map(({ code }) => code)).toContain("resource-byte-limit");
+    const pixelLimited = convertWithDiagnostics(svg("large.png"), {
+      resources: {
+        supplied: { "large.png": { bytes: pngWithDimensions(2, 2) } },
+        limits: { maxImagePixels: 1 },
+      },
+    });
+    expect(pixelLimited.diagnostics.map(({ code }) => code)).toContain("resource-pixel-limit");
+  });
+
+  test("emits typed Swift runtime cases for all six families", () => {
+    const swift = convert(`<svg viewBox="0 0 10 10"><defs><filter id="f">
+      <feConvolveMatrix order="1" kernelMatrix="1"/><feMorphology/><feDisplacementMap/>
+      <feTile/><feTurbulence/><feImage href="#shape"/>
+    </filter><rect id="shape" width="2" height="2"/></defs><rect width="10" height="10" filter="url(#f)"/></svg>`);
+    for (const name of ["convolveMatrix", "morphology", "displacementMap", "tile", "turbulence", "image"])
+      expect(swift).toContain(`case ${name}`);
+    expect(swift).toContain("private final class TurbulenceGenerator");
+    expect(swift).toContain("renderFilterImages:");
+  });
+});
+
+describe("spatial and turbulence reference math", () => {
+  test("rotates convolution kernels 180 degrees and handles edge modes", () => {
+    const source = bitmap(3, 1, [1, 0, 0, 1, 0.5, 0, 0, 1, 0, 0, 0, 1]);
+    const common = {
+      orderX: 3,
+      orderY: 1,
+      kernelMatrix: [1, 0, 0],
+      divisor: 1,
+      bias: 0,
+      targetX: 1,
+      targetY: 0,
+      preserveAlpha: false,
+    };
+    expect(pixels(convolveFilterBitmap(source, { ...common, edgeMode: "none" }))[1]).toEqual([0, 0, 0, 1]);
+    expect(pixels(convolveFilterBitmap(source, { ...common, edgeMode: "duplicate" }))[0]).toEqual([0.5, 0, 0, 1]);
+    expect(pixels(convolveFilterBitmap(source, { ...common, edgeMode: "wrap" }))[0]).toEqual([0.5, 0, 0, 1]);
+  });
+
+  test("supports fractional kernel spacing, divisor/bias, and preserveAlpha", () => {
+    const source = bitmap(2, 1, [0.25, 0, 0, 0.5, 0, 0, 0, 1]);
+    const output = convolveFilterBitmap(source, {
+      orderX: 2,
+      orderY: 1,
+      kernelMatrix: [1, 1],
+      divisor: 2,
+      bias: 0.1,
+      targetX: 0,
+      targetY: 0,
+      edgeMode: "duplicate",
+      kernelUnitLengthX: 0.5,
+      preserveAlpha: true,
+    });
+    expect(pixels(output)[0]?.[0]).toBeCloseTo(0.2166666667);
+    expect(pixels(output)[0]?.slice(1)).toEqual([0.05, 0.05, 0.5]);
+  });
+
+  test("erodes and dilates premultiplied samples with fractional radii and transparent edges", () => {
+    const source = bitmap(3, 1, [0, 0, 0, 0, 0.4, 0.2, 0, 0.5, 0, 0, 0, 0]);
+    expect(pixels(morphologyFilterBitmap(source, "dilate", 1, 0.5))).toEqual([
+      [0.4, 0.2, 0, 0.5],
+      [0.4, 0.2, 0, 0.5],
+      [0.4, 0.2, 0, 0.5],
+    ]);
+    expect(pixels(morphologyFilterBitmap(source, "erode", 1, 0.5))).toEqual([
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ]);
+  });
+
+  test("uses unpremultiplied map channels and the SVG positive coordinate sign", () => {
+    const source = bitmap(3, 1, [1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1]);
+    const map = bitmap(3, 1, [0.5, 0, 0, 0.5, 0.5, 0, 0, 1, 0, 0, 0, 0]);
+    expect(pixels(displacementFilterBitmap(source, map, { a: 2, b: 0, c: 0, d: 0 }, "R", "A"))).toEqual([
+      [0, 1, 0, 1],
+      [0, 1, 0, 1],
+      [0, 1, 0, 1],
+    ]);
+  });
+
+  test("tiles fractional input origins without seams", () => {
+    const source = bitmap(4, 1, [1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1]);
+    const output = tileFilterBitmap(
+      source,
+      { x: 0.25, y: 0, width: 1.5, height: 1 },
+      { x: 0, y: 0, width: 4, height: 1 },
+    );
+    expect(pixels(output)).toEqual([
+      [1, 0, 0, 1],
+      [0, 1, 0, 1],
+      [0.5, 0.5, 0, 1],
+      [1, 0, 0, 1],
+    ]);
+  });
+
+  test("matches the mandated Park-Miller sequence and deterministic turbulence samples", () => {
+    let seed = setupTurbulenceSeed(1);
+    for (let index = 0; index < 10_000; index++) seed = nextTurbulenceRandom(seed);
+    expect(seed).toBe(1_043_618_065);
+    expect(setupTurbulenceSeed(-2_147_483_647)).toBe(2);
+    expect(setupTurbulenceSeed(Number.MAX_SAFE_INTEGER)).toBe(2_147_483_646);
+    const generator = new SVGTurbulenceGenerator(7);
+    expect(
+      generator.sample(0, 12.5, 8.25, 0.04, 0.06, 3, "fractalNoise", false, { x: 0, y: 0, width: 20, height: 10 }),
+    ).toBeCloseTo(0.49089059, 7);
+    const stitched = turbulenceFilterBitmap(5, 3, {
+      baseFrequencyX: 0.12,
+      baseFrequencyY: 0.2,
+      numOctaves: 2,
+      seed: 3,
+      stitchTiles: true,
+      type: "turbulence",
+      region: { x: 0, y: 0, width: 5, height: 3 },
+    });
+    expect(stitched.values).toHaveLength(60);
+    expect(stitched.values.every(Number.isFinite)).toBe(true);
+  });
+});

--- a/packages/svg-to-swiftui-core/src/types.ts
+++ b/packages/svg-to-swiftui-core/src/types.ts
@@ -24,12 +24,23 @@ export interface SwiftUIGeneratorConfig {
   };
   /** Deterministic resource loading. The default embeddedOnly policy performs no filesystem or network I/O. */
   resources?: ResourceConfiguration;
+  /** Bounded deterministic CPU execution for SVG filter primitives. */
+  filters?: FilterConfiguration;
   /** Conversion-time renderer for static SVG <foreignObject> content. Async conversion is required. */
   foreignObjectRenderer?: ForeignObjectRenderer;
   /** Bounded rasterization and artifact behavior for static <foreignObject> snapshots. */
   foreignObjects?: ForeignObjectConfiguration;
   /** Deterministic language and capability inputs used by static SVG semantics. */
   staticEnvironment?: StaticEnvironment;
+}
+
+export interface FilterConfiguration {
+  /** Maximum number of coefficients in one feConvolveMatrix kernel. Defaults to 225 (15×15). */
+  maxKernelCells?: number;
+  /** Maximum accepted feTurbulence octave count. Defaults to 9. */
+  maxOctaves?: number;
+  /** Maximum generated filter bitmap area. Defaults to 16 million pixels. */
+  maxOutputPixels?: number;
 }
 
 export interface StaticEnvironment {

--- a/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
@@ -340,6 +340,32 @@
       },
       "toleranceReason": "A one-pixel filter-subregion boundary differs between the SVG and CoreGraphics rasterizers; interior color-matrix pixels match within the default channel threshold."
     },
+    "filter-common-primitives": {
+      "width": 160,
+      "height": 100,
+      "expectedMode": "view",
+      "tags": [
+        "clip-path",
+        "effect-order",
+        "feDropShadow",
+        "feFlood",
+        "feGaussianBlur",
+        "feMerge",
+        "feMergeNode",
+        "feOffset",
+        "filter",
+        "mask",
+        "opacity",
+        "view"
+      ],
+      "tolerance": {
+        "channel": 36,
+        "maxOutsidePercent": 8,
+        "maxMeanRgbError": 8,
+        "maxMeanAlphaError": 5
+      },
+      "toleranceReason": "The generated separable Gaussian kernel and SVG reference renderer use slightly different kernel truncation and edge sampling."
+    },
     "filter-component-transfer": {
       "width": 128,
       "height": 26,
@@ -383,31 +409,31 @@
       },
       "toleranceReason": "WKWebView and CoreGraphics round one-pixel primitive-subregion boundaries differently; operator interiors match within the default channel threshold."
     },
-    "filter-common-primitives": {
-      "width": 160,
-      "height": 100,
+    "filter-convolve-matrix": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": ["circle", "feConvolveMatrix", "filter", "g", "geometry", "opacity", "path", "rect", "units", "view"]
+    },
+    "filter-displacement-map": {
+      "width": 128,
+      "height": 64,
       "expectedMode": "view",
       "tags": [
-        "clip-path",
-        "effect-order",
-        "feDropShadow",
+        "SourceGraphic",
+        "circle",
+        "feDisplacementMap",
         "feFlood",
-        "feGaussianBlur",
-        "feMerge",
-        "feMergeNode",
-        "feOffset",
         "filter",
-        "mask",
+        "g",
+        "geometry",
         "opacity",
+        "path",
+        "rect",
+        "stroke",
+        "units",
         "view"
-      ],
-      "tolerance": {
-        "channel": 36,
-        "maxOutsidePercent": 8,
-        "maxMeanRgbError": 8,
-        "maxMeanAlphaError": 5
-      },
-      "toleranceReason": "The generated separable Gaussian kernel and SVG reference renderer use slightly different kernel truncation and edge sampling."
+      ]
     },
     "filter-graph-branching": {
       "width": 140,
@@ -426,8 +452,36 @@
         "StrokePaint",
         "view"
       ],
-      "tolerance": { "channel": 36, "maxOutsidePercent": 8, "maxMeanRgbError": 8, "maxMeanAlphaError": 5 },
+      "tolerance": {
+        "channel": 36,
+        "maxOutsidePercent": 8,
+        "maxMeanRgbError": 8,
+        "maxMeanAlphaError": 5
+      },
       "toleranceReason": "The generated separable Gaussian kernel has deterministic three-sigma truncation while the SVG reference kernel is implementation-defined."
+    },
+    "filter-image": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": [
+        "circle",
+        "feImage",
+        "feMerge",
+        "feMergeNode",
+        "filter",
+        "g",
+        "geometry",
+        "preserve-aspect-ratio",
+        "rect",
+        "view"
+      ]
+    },
+    "filter-morphology": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": ["feMorphology", "filter", "g", "geometry", "opacity", "path", "rect", "units", "view"]
     },
     "filter-shadow-equivalence": {
       "width": 150,
@@ -444,8 +498,44 @@
         "filter",
         "view"
       ],
-      "tolerance": { "channel": 36, "maxOutsidePercent": 8, "maxMeanRgbError": 8, "maxMeanAlphaError": 5 },
+      "tolerance": {
+        "channel": 36,
+        "maxOutsidePercent": 8,
+        "maxMeanRgbError": 8,
+        "maxMeanAlphaError": 5
+      },
       "toleranceReason": "The generated separable Gaussian kernel has deterministic three-sigma truncation while the SVG reference kernel is implementation-defined."
+    },
+    "filter-spatial-chain-limits": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": [
+        "SourceGraphic",
+        "circle",
+        "feBlend",
+        "feConvolveMatrix",
+        "feMorphology",
+        "feTurbulence",
+        "filter",
+        "g",
+        "geometry",
+        "opacity",
+        "rect",
+        "view"
+      ]
+    },
+    "filter-tile": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": ["circle", "feFlood", "feTile", "filter", "geometry", "rect", "view"]
+    },
+    "filter-turbulence": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": ["feTurbulence", "filter", "geometry", "rect", "view"]
     },
     "filter-units-regions-transforms": {
       "width": 150,
@@ -463,7 +553,12 @@
         "view",
         "zero-blur"
       ],
-      "tolerance": { "channel": 44, "maxOutsidePercent": 10, "maxMeanRgbError": 10, "maxMeanAlphaError": 6 },
+      "tolerance": {
+        "channel": 44,
+        "maxOutsidePercent": 10,
+        "maxMeanRgbError": 10,
+        "maxMeanAlphaError": 6
+      },
       "toleranceReason": "Rotated anisotropic kernels are conservatively projected onto device axes and Gaussian edge truncation differs by renderer."
     },
     "foreign-object-effects": {
@@ -847,23 +942,23 @@
     "image-data-par": {
       "width": 160,
       "height": 54,
-      "scale": 1,
       "expectedMode": "view",
-      "tags": ["data-url", "image", "png", "preserve-aspect-ratio", "svg-image", "view"]
+      "tags": ["data-url", "image", "png", "preserve-aspect-ratio", "svg-image", "view"],
+      "scale": 1
     },
     "image-external-svg-effects": {
       "width": 120,
       "height": 70,
-      "scale": 3,
       "expectedMode": "view",
-      "tags": ["clip-path", "image", "image-blend", "mask", "opacity", "svg-image", "transform", "view"]
+      "tags": ["clip-path", "image", "image-blend", "mask", "opacity", "svg-image", "transform", "view"],
+      "scale": 3
     },
     "image-raster-formats": {
       "width": 180,
       "height": 45,
-      "scale": 2,
       "expectedMode": "view",
       "tags": ["gif", "image", "image-rendering", "jpeg", "png", "raster", "view", "webp"],
+      "scale": 2,
       "tolerance": {
         "channel": 48,
         "maxOutsidePercent": 12,
@@ -11808,58 +11903,58 @@
     "text-anchor-baseline": {
       "width": 240,
       "height": 100,
-      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
-      "fontFamilies": ["Poppins"],
       "expectedMode": "view",
-      "tags": ["baseline", "font", "text", "text-anchor", "view", "viewBox"]
+      "tags": ["baseline", "font", "text", "text-anchor", "view", "viewBox"],
+      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
+      "fontFamilies": ["Poppins"]
     },
     "text-basic-nested": {
       "width": 240,
       "height": 80,
-      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
-      "fontFamilies": ["Poppins"],
       "expectedMode": "view",
-      "tags": ["font", "font-weight", "text", "tspan", "view"]
+      "tags": ["font", "font-weight", "text", "tspan", "view"],
+      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
+      "fontFamilies": ["Poppins"]
     },
     "text-bidi-direction": {
       "width": 320,
       "height": 130,
-      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
-      "fontFamilies": ["Poppins"],
       "expectedMode": "view",
-      "tags": ["bidi", "direction", "font", "rtl", "text", "tspan", "unicode-bidi", "view"]
+      "tags": ["bidi", "direction", "font", "rtl", "text", "tspan", "unicode-bidi", "view"],
+      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
+      "fontFamilies": ["Poppins"]
     },
     "text-gradient-stroke": {
       "width": 260,
       "height": 100,
-      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
-      "fontFamilies": ["Poppins"],
       "expectedMode": "view",
-      "tags": ["font", "gradient", "linearGradient", "opacity", "paint-order", "stop", "stroke", "text", "view"]
+      "tags": ["font", "gradient", "linearGradient", "opacity", "paint-order", "stop", "stroke", "text", "view"],
+      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
+      "fontFamilies": ["Poppins"]
     },
     "text-length-adjust": {
       "width": 300,
       "height": 130,
-      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
-      "fontFamilies": ["Poppins"],
       "expectedMode": "view",
-      "tags": ["font", "lengthAdjust", "spacing", "text", "textLength", "view"]
+      "tags": ["font", "lengthAdjust", "spacing", "text", "textLength", "view"],
+      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
+      "fontFamilies": ["Poppins"]
     },
     "text-path-layout": {
       "width": 340,
       "height": 180,
-      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
-      "fontFamilies": ["Poppins"],
       "expectedMode": "view",
-      "tags": ["circle", "font", "path", "pathLength", "startOffset", "text", "textPath", "use", "view"]
+      "tags": ["circle", "font", "path", "pathLength", "startOffset", "text", "textPath", "use", "view"],
+      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
+      "fontFamilies": ["Poppins"]
     },
     "text-position-lists": {
       "width": 300,
       "height": 120,
-      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
-      "fontFamilies": ["Poppins"],
       "expectedMode": "view",
       "tags": ["dx", "font", "grapheme", "rotate", "text", "view", "x", "y"],
+      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
+      "fontFamilies": ["Poppins"],
       "tolerance": {
         "maxMeanRgbError": 3.6
       },
@@ -11868,26 +11963,26 @@
     "text-spacing-decoration-transform": {
       "width": 260,
       "height": 100,
-      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
-      "fontFamilies": ["Poppins"],
       "expectedMode": "view",
-      "tags": ["dx", "dy", "font", "spacing", "text", "text-decoration", "transform", "tspan", "view"]
+      "tags": ["dx", "dy", "font", "spacing", "text", "text-decoration", "transform", "tspan", "view"],
+      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
+      "fontFamilies": ["Poppins"]
     },
     "text-unicode-whitespace": {
       "width": 280,
       "height": 110,
-      "fonts": ["fonts/NotoSans.ttf"],
-      "fontFamilies": ["Noto Sans"],
       "expectedMode": "view",
-      "tags": ["bidi", "font", "text", "tspan", "unicode", "view", "whitespace"]
+      "tags": ["bidi", "font", "text", "tspan", "unicode", "view", "whitespace"],
+      "fonts": ["fonts/NotoSans.ttf"],
+      "fontFamilies": ["Noto Sans"]
     },
     "text-vertical-writing": {
       "width": 220,
       "height": 180,
-      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
-      "fontFamilies": ["Poppins"],
       "expectedMode": "view",
-      "tags": ["font", "text", "text-orientation", "vertical", "view", "writing-mode"]
+      "tags": ["font", "text", "text-orientation", "vertical", "view", "writing-mode"],
+      "fonts": ["fonts/Poppins-Regular.ttf", "fonts/Poppins-Bold.ttf", "fonts/Poppins-Italic.ttf"],
+      "fontFamilies": ["Poppins"]
     },
     "transat": {
       "width": 128,

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-convolve-matrix.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-convolve-matrix.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <defs>
+    <filter id="edge" x="-10%" y="-20%" width="120%" height="140%" color-interpolation-filters="sRGB">
+      <feConvolveMatrix order="3" kernelMatrix="-1 -1 -1 -1 8 -1 -1 -1 -1" divisor="1" bias=".25" edgeMode="duplicate" preserveAlpha="true"/>
+    </filter>
+  </defs>
+  <rect width="120" height="60" fill="#18243c"/>
+  <g filter="url(#edge)">
+    <rect x="15" y="10" width="35" height="40" rx="8" fill="#ff7043"/>
+    <circle cx="78" cy="30" r="20" fill="#42a5f5" fill-opacity=".75"/>
+    <path d="M94 10L110 30 94 50Z" fill="#ffee58"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-displacement-map.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-displacement-map.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <defs>
+    <filter id="warp" x="-20%" y="-30%" width="140%" height="160%" color-interpolation-filters="sRGB">
+      <feFlood flood-color="#ff0080" result="map"/>
+      <feDisplacementMap in="SourceGraphic" in2="map" scale="14" xChannelSelector="R" yChannelSelector="B"/>
+    </filter>
+  </defs>
+  <rect width="120" height="60" fill="#17112b"/>
+  <g filter="url(#warp)">
+    <rect x="10" y="12" width="100" height="36" rx="8" fill="#26c6da"/>
+    <path d="M10 20h100M10 30h100M10 40h100" stroke="#fff" stroke-width="3"/>
+    <circle cx="35" cy="30" r="12" fill="#ec407a" fill-opacity=".8"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-image.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-image.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <defs>
+    <g id="local"><rect width="20" height="20" rx="5" fill="#7e57c2"/><circle cx="10" cy="10" r="5" fill="#fff"/></g>
+    <filter id="images" x="0" y="0" width="120" height="60" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feImage href="#local" x="5" y="5" width="30" height="50" preserveAspectRatio="xMidYMid meet" result="localImage"/>
+      <feImage href="../assets/nested-image.svg" x="45" y="5" width="30" height="50" preserveAspectRatio="xMidYMid slice" result="svgImage"/>
+      <feImage href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgQIAZcfRzQAAAABJRU5ErkJggg==" x="85" y="5" width="30" height="50" preserveAspectRatio="none" result="rasterImage"/>
+      <feMerge><feMergeNode in="localImage"/><feMergeNode in="svgImage"/><feMergeNode in="rasterImage"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="120" height="60" fill="#102027" filter="url(#images)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-morphology.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-morphology.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <defs>
+    <filter id="erode" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feMorphology operator="erode" radius="3 2"/>
+    </filter>
+    <filter id="dilate" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feMorphology operator="dilate" radius="3 2"/>
+    </filter>
+  </defs>
+  <rect width="120" height="60" fill="#101820"/>
+  <g fill="#66bb6a">
+    <path d="M10 25h15V10h10v15h15v10H35v15H25V35H10z" filter="url(#erode)"/>
+    <path d="M70 25h15V10h10v15h15v10H95v15H85V35H70z" filter="url(#dilate)" fill-opacity=".7"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-spatial-chain-limits.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-spatial-chain-limits.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 40">
+  <defs>
+    <filter id="bounded" x="0" y="0" width="80" height="40" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feConvolveMatrix order="16 16" divisor="1" edgeMode="duplicate" result="limited" kernelMatrix="
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"/>
+      <feMorphology in="limited" radius="0" result="disabled"/>
+      <feTurbulence baseFrequency=".08" numOctaves="20" seed="4" result="boundedNoise"/>
+      <feBlend in="SourceGraphic" in2="boundedNoise" mode="normal"/>
+    </filter>
+  </defs>
+  <g filter="url(#bounded)">
+    <rect width="80" height="40" fill="#172a3a"/>
+    <circle cx="20" cy="20" r="12" fill="#f4d35e"/>
+    <rect x="40" y="8" width="30" height="24" rx="5" fill="#ee6352" fill-opacity=".8"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-tile.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-tile.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <defs>
+    <filter id="tiles" x="0" y="0" width="120" height="60" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood x="2.5" y="2.5" width="15" height="15" flood-color="#ffca28" result="base"/>
+      <feTile in="base" x="0" y="0" width="120" height="60"/>
+    </filter>
+  </defs>
+  <rect width="120" height="60" fill="#263238"/>
+  <circle cx="10" cy="10" r="5" fill="#ef5350" filter="url(#tiles)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-turbulence.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-turbulence.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <defs>
+    <filter id="cloud" x="0" y="0" width="60" height="60" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feTurbulence type="fractalNoise" baseFrequency=".035 .07" numOctaves="3" seed="11" stitchTiles="stitch"/>
+    </filter>
+    <filter id="marble" x="60" y="0" width="60" height="60" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feTurbulence type="turbulence" baseFrequency=".04" numOctaves="4" seed="-5"/>
+    </filter>
+  </defs>
+  <rect width="60" height="60" filter="url(#cloud)"/>
+  <rect x="60" width="60" height="60" filter="url(#marble)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/run-visual-tests.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/run-visual-tests.ts
@@ -156,7 +156,7 @@ function collectFixtureResources(
   const bytes: Buffer[] = [];
   const visited = new Set<string>();
   const visit = (document: string, documentURL: URL): void => {
-    for (const match of document.matchAll(/<image\b[^>]*\b(?:href|xlink:href)\s*=\s*["']([^"']+)["']/gi)) {
+    for (const match of document.matchAll(/<(?:image|feImage)\b[^>]*\b(?:href|xlink:href)\s*=\s*["']([^"']+)["']/gi)) {
       const href = match[1]!;
       if (/^(?:data:|#)/i.test(href)) continue;
       const resourceURL = new URL(href, documentURL);
@@ -180,7 +180,7 @@ function collectFixtureResources(
 
 function inlineFixtureImages(source: string, sourceURL: URL): string {
   return source.replace(
-    /(<image\b[^>]*\b(?:href|xlink:href)\s*=\s*)(["'])([^"']+)\2/gi,
+    /(<(?:image|feImage)\b[^>]*\b(?:href|xlink:href)\s*=\s*)(["'])([^"']+)\2/gi,
     (match, prefix: string, quote: string, href: string) => {
       if (/^(?:data:|#|https?:)/i.test(href)) return match;
       const resourceURL = new URL(href, sourceURL);


### PR DESCRIPTION
Closes #69

## What changed

- Add typed parsing and SwiftUI rendering for `feConvolveMatrix`, `feMorphology`, `feDisplacementMap`, `feTile`, `feTurbulence`, and `feImage`.
- Add deterministic CPU implementations with primitive regions, chaining, color spaces, transforms, edge modes, and premultiplied-alpha handling.
- Resolve raster, external SVG, and local-fragment `feImage` resources at conversion time with cycle and resource-policy enforcement.
- Add configurable limits for kernel cells, turbulence octaves, and output pixels.
- Add unit/integration tests and seven full-RGBA visual fixtures compiled and rendered through SwiftUI.
- Document support and add a minor changeset.

## Validation

- `bun run test` — 274 passed
- `bun run typecheck` — passed for svg-to-swiftui-core
- `bun run lint` — passed for svg-to-swiftui-core
- `bun run build` — passed for svg-to-swiftui-core
- `bun run visual-test:verify` — 1,903 fixtures valid
- `bun run visual-test --changed --fresh` — 7/7 exact SwiftUI visual fixtures passed
