### PR TITLE
Add SVG filter lighting primitives

### DIFF
--- a/.changeset/static-svg-filter-lighting.md
+++ b/.changeset/static-svg-filter-lighting.md
@@ -1,0 +1,5 @@
+---
+"svg-to-swiftui-core": minor
+---
+
+Render SVG diffuse and specular lighting with distant, point, and spot light sources, exact surface normals, primitive-unit coordinates, transforms, color-space handling, and deterministic diagnostics.

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -73,6 +73,8 @@ Color and compositing nodes support all 16 `feBlend` modes; `feColorMatrix` matr
 
 Spatial and generated-image nodes support `feConvolveMatrix`, `feMorphology`, `feDisplacementMap`, `feTile`, `feTurbulence`, and `feImage`. This includes kernel targets/divisors/edge modes, anisotropic and fractional radii, channel-selected displacement, fractional tile regions, deterministic seeded and stitched noise, embedded raster data, resolved SVG documents, and local fragment `<use>` semantics with `preserveAspectRatio`. Generated code never fetches resources at runtime. Configurable kernel, octave, output-pixel, resource-byte, and nesting limits bound conversion and rendering work.
 
+Lighting nodes support `feDiffuseLighting` and `feSpecularLighting` with `feDistantLight`, `fePointLight`, and `feSpotLight`. The generated runtime implements SVG surface normals for interior, edge, and corner pixels; `kernelUnitLength`; spotlight cones; `lighting-color`/`currentColor`; primitive units and transforms; and the required diffuse/specular alpha behavior.
+
 Generated Swift uses the same deterministic premultiplied-RGBA image-buffer runtime as the visual regression host. Source vector commands are rasterized only at app render time and at the active display scale; conversion never snapshots the full SVG. Filters run before viewport/clip paths, masks, element opacity, and blending, and their regions contribute to reported painted bounds. Unsupported primitives remain typed pass-through graph nodes with diagnostics until their dedicated tickets land.
 
 ### Linear and radial gradients
@@ -245,7 +247,7 @@ The default antialiasing allowance is 24/255 per channel, at most 3% pixels outs
 - [x] SVG clipping paths, clip rules, coordinate systems, transforms, unions, and nested intersections
 - [x] SVG masks, Level 1 blend modes, group compositing, and isolation
 - [x] SVG markers, vertex placement, orientation, units, context paint, viewports, and painter order
-- [x] Static filter graphs, color/compositing, convolution, morphology, displacement, tiling, turbulence, and filter images
+- [x] Static filter graphs, color/compositing, convolution, morphology, displacement, tiling, turbulence, filter images, and diffuse/specular lighting
 - [x] Embedded CSS cascade, custom properties, and computed presentation styles
 - [x] Basic static SVG `<text>` and `<tspan>` rendering
 - [x] Static SVG `<image>` rendering with deterministic raster/SVG resource resolution

--- a/packages/svg-to-swiftui-core/src/renderTree/filterMath.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/filterMath.ts
@@ -5,6 +5,7 @@ import type {
   FilterComponentTransferFunctions,
   FilterCompositeOperator,
   FilterEdgeMode,
+  FilterLightSource,
   FilterMorphologyOperator,
   FilterTurbulenceType,
 } from "./types";
@@ -25,6 +26,8 @@ export interface FilterPixelRegion {
   width: number;
   height: number;
 }
+
+export type FilterVector3 = readonly [x: number, y: number, z: number];
 
 type RGB = [number, number, number];
 
@@ -492,6 +495,154 @@ export function tileFilterBitmap(
       const sourceX = inputRegion.x + positiveModulo(x + 0.5 - inputRegion.x, inputRegion.width) - 0.5;
       const sourceY = inputRegion.y + positiveModulo(y + 0.5 - inputRegion.y, inputRegion.height) - 0.5;
       setPixel(result, x, y, sampleBilinear(image, sourceX, sourceY, "none"));
+    }
+  }
+  return result;
+}
+
+function normalizeVector(x: number, y: number, z: number): FilterVector3 {
+  const length = Math.hypot(x, y, z);
+  return length > 0 ? [x / length, y / length, z / length] : [0, 0, 0];
+}
+
+function regionContains(region: FilterPixelRegion, x: number, y: number): boolean {
+  return x >= region.x && y >= region.y && x < region.x + region.width && y < region.y + region.height;
+}
+
+function sampleRegionAlpha(image: FilterBitmap, x: number, y: number, region: FilterPixelRegion): number {
+  const minX = Math.floor(x);
+  const minY = Math.floor(y);
+  const fractionX = x - minX;
+  const fractionY = y - minY;
+  const alpha = (sampleX: number, sampleY: number) =>
+    regionContains(region, sampleX, sampleY) ? pixelAt(image, sampleX, sampleY)[3] : 0;
+  const top = alpha(minX, minY) * (1 - fractionX) + alpha(minX + 1, minY) * fractionX;
+  const bottom = alpha(minX, minY + 1) * (1 - fractionX) + alpha(minX + 1, minY + 1) * fractionX;
+  return clamp(top * (1 - fractionY) + bottom * fractionY);
+}
+
+export interface SurfaceNormalParameters {
+  surfaceScale: number;
+  /** Authored filter-coordinate distance. Omitted values use one device pixel. */
+  kernelUnitLengthX?: number;
+  kernelUnitLengthY?: number;
+  /** Device pixels per filter-coordinate unit. */
+  scaleX?: number;
+  scaleY?: number;
+  region?: FilterPixelRegion;
+}
+
+/** SVG lighting surface normal using the specification's distinct corner, edge, and interior Sobel kernels. */
+export function surfaceNormal(
+  image: FilterBitmap,
+  x: number,
+  y: number,
+  parameters: SurfaceNormalParameters,
+): FilterVector3 {
+  const scaleX = parameters.scaleX ?? 1;
+  const scaleY = parameters.scaleY ?? 1;
+  const dx = parameters.kernelUnitLengthX ?? 1 / scaleX;
+  const dy = parameters.kernelUnitLengthY ?? 1 / scaleY;
+  const stepX = dx * scaleX;
+  const stepY = dy * scaleY;
+  const region = parameters.region ?? { x: 0, y: 0, width: image.width, height: image.height };
+  const left = x - stepX < region.x;
+  const right = x + stepX >= region.x + region.width;
+  const top = y - stepY < region.y;
+  const bottom = y + stepY >= region.y + region.height;
+  if ((left && right) || (top && bottom) || dx <= 0 || dy <= 0) return [0, 0, 1];
+
+  const differenceX = left ? [0, -1, 1] : right ? [-1, 1, 0] : [-1, 0, 1];
+  const smoothY = top ? [0, 2, 1] : bottom ? [1, 2, 0] : [1, 2, 1];
+  const differenceY = top ? [0, -1, 1] : bottom ? [-1, 1, 0] : [-1, 0, 1];
+  const smoothX = left ? [0, 2, 1] : right ? [1, 2, 0] : [1, 2, 1];
+  let sumX = 0;
+  let sumY = 0;
+  for (let row = 0; row < 3; row++) {
+    for (let column = 0; column < 3; column++) {
+      const alpha = sampleRegionAlpha(image, x + (column - 1) * stepX, y + (row - 1) * stepY, region);
+      sumX += smoothY[row]! * differenceX[column]! * alpha;
+      sumY += differenceY[row]! * smoothX[column]! * alpha;
+    }
+  }
+  const horizontalEdge = left || right;
+  const verticalEdge = top || bottom;
+  const factorX = horizontalEdge ? (verticalEdge ? 2 / 3 : 1 / 2) : verticalEdge ? 1 / 3 : 1 / 4;
+  const factorY = verticalEdge ? (horizontalEdge ? 2 / 3 : 1 / 2) : horizontalEdge ? 1 / 3 : 1 / 4;
+  return normalizeVector(
+    (-parameters.surfaceScale * factorX * sumX) / dx,
+    (-parameters.surfaceScale * factorY * sumY) / dy,
+    1,
+  );
+}
+
+export interface LightingParameters extends SurfaceNormalParameters {
+  type: "diffuse" | "specular";
+  constant: number;
+  specularExponent?: number;
+  /** RGB components already expressed in color-interpolation-filters space. */
+  color: readonly [red: number, green: number, blue: number];
+  light?: FilterLightSource;
+}
+
+function lightAt(
+  light: FilterLightSource,
+  x: number,
+  y: number,
+  z: number,
+): { direction: FilterVector3; colorScale: number } {
+  if (light.type === "distant") return { direction: normalizeVector(light.x, light.y, light.z), colorScale: 1 };
+  const direction = normalizeVector(light.x - x, light.y - y, light.z - z);
+  if (light.type === "point") return { direction, colorScale: 1 };
+  const spotDirection = normalizeVector(
+    light.pointsAtX - light.x,
+    light.pointsAtY - light.y,
+    light.pointsAtZ - light.z,
+  );
+  const cosine = -(direction[0] * spotDirection[0] + direction[1] * spotDirection[1] + direction[2] * spotDirection[2]);
+  if (cosine <= 0) return { direction, colorScale: 0 };
+  if (light.limitingConeAngle !== undefined) {
+    const limit = Math.cos((light.limitingConeAngle * Math.PI) / 180);
+    if (cosine < limit) return { direction, colorScale: 0 };
+  }
+  return { direction, colorScale: cosine ** light.specularExponent };
+}
+
+/** Deterministic CPU reference for feDiffuseLighting and feSpecularLighting. */
+export function lightingFilterBitmap(image: FilterBitmap, parameters: LightingParameters): FilterBitmap {
+  const result = emptyLike(image);
+  if (!parameters.light) return result;
+  const scaleX = parameters.scaleX ?? 1;
+  const scaleY = parameters.scaleY ?? 1;
+  const region = parameters.region ?? { x: 0, y: 0, width: image.width, height: image.height };
+  const startX = Math.max(0, Math.floor(region.x));
+  const startY = Math.max(0, Math.floor(region.y));
+  const endX = Math.min(image.width, Math.ceil(region.x + region.width));
+  const endY = Math.min(image.height, Math.ceil(region.y + region.height));
+  for (let y = startY; y < endY; y++) {
+    for (let x = startX; x < endX; x++) {
+      const alpha = pixelAt(image, x, y)[3];
+      const height = parameters.surfaceScale * alpha;
+      const normal = surfaceNormal(image, x, y, parameters);
+      const light = lightAt(parameters.light, x / scaleX, y / scaleY, height);
+      let intensity: number;
+      if (parameters.type === "diffuse") {
+        intensity =
+          parameters.constant *
+          Math.max(0, normal[0] * light.direction[0] + normal[1] * light.direction[1] + normal[2] * light.direction[2]);
+      } else {
+        const half = normalizeVector(light.direction[0], light.direction[1], light.direction[2] + 1);
+        intensity =
+          parameters.constant *
+          Math.max(0, normal[0] * half[0] + normal[1] * half[1] + normal[2] * half[2]) **
+            (parameters.specularExponent ?? 1);
+      }
+      const channels = parameters.color.map((channel) => clamp(channel * light.colorScale * intensity));
+      if (parameters.type === "diffuse") setPixel(result, x, y, [channels[0]!, channels[1]!, channels[2]!, 1]);
+      else {
+        const outputAlpha = Math.max(channels[0]!, channels[1]!, channels[2]!);
+        setPixel(result, x, y, [channels[0]!, channels[1]!, channels[2]!, outputAlpha]);
+      }
     }
   }
   return result;

--- a/packages/svg-to-swiftui-core/src/renderTree/filters.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/filters.ts
@@ -23,6 +23,8 @@ import type {
   FilterImageSource,
   FilterInput,
   FilterInstance,
+  FilterLightSource,
+  FilterLightSourceSpec,
   FilterPrimitive,
   FilterPrimitiveRegionSpec,
   FilterPrimitiveSpec,
@@ -234,6 +236,60 @@ function numberPair(
     );
     return [fallback, fallback];
   }
+}
+
+function positiveNumberPair(
+  element: ElementNode,
+  name: string,
+  diagnostics: RenderDiagnostic[],
+): [number, number] | undefined {
+  if (!hasAttribute(element, name)) return undefined;
+  const values = numberList(element, name, diagnostics);
+  if (values && values.length >= 1 && values.length <= 2 && values.every((value) => value > 0))
+    return [values[0]!, values[1] ?? values[0]!];
+  diagnostic(
+    diagnostics,
+    element,
+    `invalid-filter-${name.toLowerCase()}`,
+    `${name} requires one or two positive numbers; using the device-pixel default.`,
+  );
+  return undefined;
+}
+
+function nonNegativeNumber(
+  element: ElementNode,
+  name: string,
+  fallback: number,
+  diagnostics: RenderDiagnostic[],
+): number {
+  const value = numberValue(element, name, fallback, diagnostics);
+  if (value >= 0) return value;
+  diagnostic(
+    diagnostics,
+    element,
+    `negative-filter-${name.toLowerCase()}`,
+    `${name} cannot be negative; using ${fallback}.`,
+  );
+  return fallback;
+}
+
+function rangedNumber(
+  element: ElementNode,
+  name: string,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+  diagnostics: RenderDiagnostic[],
+): number {
+  const value = numberValue(element, name, fallback, diagnostics);
+  if (value >= minimum && value <= maximum) return value;
+  diagnostic(
+    diagnostics,
+    element,
+    `invalid-filter-${name.toLowerCase()}-range`,
+    `${name} must be between ${minimum} and ${maximum}; using ${fallback}.`,
+  );
+  return fallback;
 }
 
 function integerPair(
@@ -473,6 +529,76 @@ function floodColor(element: ElementNode, presentation: Presentation, diagnostic
   return { ...color, alpha: color.alpha * parseOpacity(rawOpacity) };
 }
 
+function lightingColor(element: ElementNode, presentation: Presentation, diagnostics: RenderDiagnostic[]): RGBAColor {
+  const rawColor = String(presentation["lighting-color"] ?? "white").trim();
+  const colorSource = rawColor.toLowerCase() === "currentcolor" ? String(presentation.color ?? "black") : rawColor;
+  const parsed = parseRGBAColor(colorSource);
+  if (!parsed)
+    diagnostic(diagnostics, element, "invalid-lighting-color", `Invalid lighting-color '${rawColor}'; using white.`);
+  const color = parsed ?? { red: 1, green: 1, blue: 1, alpha: 1 };
+  return { ...color, alpha: 1 };
+}
+
+function lightSource(element: ElementNode, diagnostics: RenderDiagnostic[]): FilterLightSourceSpec | undefined {
+  const sources: FilterLightSourceSpec[] = [];
+  for (const child of children(element)) {
+    const tag = child.tagName?.toLowerCase() ?? "";
+    if (["title", "desc", "metadata", "script", "animate", "set"].includes(tag)) continue;
+    if (tag === "fedistantlight") {
+      sources.push({
+        type: "distant",
+        azimuth: numberValue(child, "azimuth", 0, diagnostics),
+        elevation: numberValue(child, "elevation", 0, diagnostics),
+      });
+    } else if (tag === "fepointlight") {
+      sources.push({
+        type: "point",
+        x: numberValue(child, "x", 0, diagnostics),
+        y: numberValue(child, "y", 0, diagnostics),
+        z: numberValue(child, "z", 0, diagnostics),
+      });
+    } else if (tag === "fespotlight") {
+      sources.push({
+        type: "spot",
+        x: numberValue(child, "x", 0, diagnostics),
+        y: numberValue(child, "y", 0, diagnostics),
+        z: numberValue(child, "z", 0, diagnostics),
+        pointsAtX: numberValue(child, "pointsAtX", 0, diagnostics),
+        pointsAtY: numberValue(child, "pointsAtY", 0, diagnostics),
+        pointsAtZ: numberValue(child, "pointsAtZ", 0, diagnostics),
+        specularExponent: rangedNumber(child, "specularExponent", 1, 1, 128, diagnostics),
+        ...(hasAttribute(child, "limitingConeAngle")
+          ? { limitingConeAngle: numberValue(child, "limitingConeAngle", 0, diagnostics) }
+          : {}),
+      });
+    } else {
+      diagnostic(
+        diagnostics,
+        child,
+        "unsupported-filter-light-source",
+        `<${child.tagName}> is not a supported SVG filter light source.`,
+      );
+    }
+  }
+  if (sources.length === 0) {
+    diagnostic(
+      diagnostics,
+      element,
+      "missing-filter-light-source",
+      `<${element.tagName}> requires exactly one feDistantLight, fePointLight, or feSpotLight child; rendering transparent black.`,
+    );
+    return undefined;
+  }
+  if (sources.length > 1)
+    diagnostic(
+      diagnostics,
+      element,
+      "multiple-filter-light-sources",
+      `<${element.tagName}> has multiple light sources; using the first source in document order.`,
+    );
+  return sources[0];
+}
+
 function filterImageSource(
   element: ElementNode,
   definitions: Map<string, ElementNode>,
@@ -695,19 +821,7 @@ function buildPrimitiveSpecs(
         );
         invalid = true;
       }
-      let kernelUnitLength: [number, number] | undefined;
-      if (hasAttribute(element, "kernelUnitLength")) {
-        const values = numberList(element, "kernelUnitLength", diagnostics);
-        if (values && values.length >= 1 && values.length <= 2 && values.every((value) => value > 0))
-          kernelUnitLength = [values[0]!, values[1] ?? values[0]!];
-        else
-          diagnostic(
-            diagnostics,
-            element,
-            "invalid-filter-kernel-unit-length",
-            "kernelUnitLength requires one or two positive numbers; using the device-pixel default.",
-          );
-      }
+      const kernelUnitLength = positiveNumberPair(element, "kernelUnitLength", diagnostics);
       spec = invalid
         ? { type: "passthrough", input, element: element.tagName ?? "feConvolveMatrix", ...common }
         : {
@@ -820,6 +934,31 @@ function buildPrimitiveSpecs(
       };
     } else if (tag === "feimage") {
       spec = { type: "image", image: filterImageSource(element, definitions, config, diagnostics), ...common };
+    } else if (tag === "fediffuselighting") {
+      const kernelUnitLength = positiveNumberPair(element, "kernelUnitLength", diagnostics);
+      spec = {
+        type: "diffuseLighting",
+        input,
+        surfaceScale: numberValue(element, "surfaceScale", 1, diagnostics),
+        diffuseConstant: nonNegativeNumber(element, "diffuseConstant", 1, diagnostics),
+        ...(kernelUnitLength ? { kernelUnitLengthX: kernelUnitLength[0], kernelUnitLengthY: kernelUnitLength[1] } : {}),
+        color: lightingColor(element, resolved, diagnostics),
+        light: lightSource(element, diagnostics),
+        ...common,
+      };
+    } else if (tag === "fespecularlighting") {
+      const kernelUnitLength = positiveNumberPair(element, "kernelUnitLength", diagnostics);
+      spec = {
+        type: "specularLighting",
+        input,
+        surfaceScale: numberValue(element, "surfaceScale", 1, diagnostics),
+        specularConstant: nonNegativeNumber(element, "specularConstant", 1, diagnostics),
+        specularExponent: rangedNumber(element, "specularExponent", 1, 1, 128, diagnostics),
+        ...(kernelUnitLength ? { kernelUnitLengthX: kernelUnitLength[0], kernelUnitLengthY: kernelUnitLength[1] } : {}),
+        color: lightingColor(element, resolved, diagnostics),
+        light: lightSource(element, diagnostics),
+        ...common,
+      };
     } else if (tag === "fegaussianblur") {
       const [stdDeviationX, stdDeviationY] = numberPair(element, "stdDeviation", 0, diagnostics);
       spec = {
@@ -1072,6 +1211,43 @@ function paintColor(paint: Paint, opacity: number): RGBAColor {
   return color ? { ...color, alpha: color.alpha * opacity } : CLEAR;
 }
 
+function resolveLightSource(
+  source: FilterLightSourceSpec | undefined,
+  unitsValue: FilterUnits,
+  bounds: RenderBounds | undefined,
+): FilterLightSource | undefined {
+  if (!source) return undefined;
+  const scaleX = unitsValue === "objectBoundingBox" ? (bounds?.width ?? 0) : 1;
+  const scaleY = unitsValue === "objectBoundingBox" ? (bounds?.height ?? 0) : 1;
+  const originX = unitsValue === "objectBoundingBox" ? (bounds?.x ?? 0) : 0;
+  const originY = unitsValue === "objectBoundingBox" ? (bounds?.y ?? 0) : 0;
+  if (source.type === "distant") {
+    const azimuth = (source.azimuth * Math.PI) / 180;
+    const elevation = (source.elevation * Math.PI) / 180;
+    return {
+      type: "distant",
+      x: Math.cos(azimuth) * Math.cos(elevation) * scaleX,
+      y: Math.sin(azimuth) * Math.cos(elevation) * scaleY,
+      z: Math.sin(elevation),
+    };
+  }
+  const position = {
+    x: originX + source.x * scaleX,
+    y: originY + source.y * scaleY,
+    z: source.z,
+  };
+  if (source.type === "point") return { type: "point", ...position };
+  return {
+    type: "spot",
+    ...position,
+    pointsAtX: originX + source.pointsAtX * scaleX,
+    pointsAtY: originY + source.pointsAtY * scaleY,
+    pointsAtZ: source.pointsAtZ,
+    specularExponent: source.specularExponent,
+    ...(source.limitingConeAngle === undefined ? {} : { limitingConeAngle: source.limitingConeAngle }),
+  };
+}
+
 /** Resolve filter regions and primitive-unit parameters for one referencing render node. */
 export function resolveFilterInstance(resource: FilterResource, node: RenderNode): FilterInstance {
   const bounds = objectBoundingBox(node);
@@ -1094,6 +1270,7 @@ export function resolveFilterInstance(resource: FilterResource, node: RenderNode
   };
   const scaleX = resource.primitiveUnits === "objectBoundingBox" ? (bounds?.width ?? 0) : 1;
   const scaleY = resource.primitiveUnits === "objectBoundingBox" ? (bounds?.height ?? 0) : 1;
+  const scaleZ = Math.sqrt(Math.abs(scaleX * scaleY));
   const primitives: FilterPrimitive[] = [];
   for (const spec of resource.primitives) {
     const common = {
@@ -1118,6 +1295,19 @@ export function resolveFilterInstance(resource: FilterResource, node: RenderNode
               kernelUnitLengthX: spec.kernelUnitLengthX * scaleX,
               kernelUnitLengthY: spec.kernelUnitLengthY! * scaleY,
             }),
+        ...common,
+      });
+    else if (spec.type === "diffuseLighting" || spec.type === "specularLighting")
+      primitives.push({
+        ...spec,
+        surfaceScale: spec.surfaceScale * scaleZ,
+        ...(spec.kernelUnitLengthX === undefined
+          ? {}
+          : {
+              kernelUnitLengthX: spec.kernelUnitLengthX * scaleX,
+              kernelUnitLengthY: spec.kernelUnitLengthY! * scaleY,
+            }),
+        light: resolveLightSource(spec.light, resource.primitiveUnits, bounds),
         ...common,
       });
     else if (spec.type === "morphology")

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -15,6 +15,7 @@ import type {
   ComputedStyle,
   FilterInput,
   FilterInstance,
+  FilterLightSource,
   FilterPrimitive,
   Geometry,
   GradientStop,
@@ -348,6 +349,32 @@ function buildViewNodes(
       const y = Math.min(...ys);
       return { x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y };
     };
+    const zScale = Math.sqrt(Math.abs(transform.a * transform.d - transform.b * transform.c));
+    const transformLight = (light: FilterLightSource | undefined): FilterLightSource | undefined => {
+      if (!light) return undefined;
+      if (light.type === "distant")
+        return {
+          type: "distant",
+          x: transform.a * light.x + transform.c * light.y,
+          y: transform.b * light.x + transform.d * light.y,
+          z: light.z * zScale,
+        };
+      const position = {
+        x: transform.a * light.x + transform.c * light.y + transform.e,
+        y: transform.b * light.x + transform.d * light.y + transform.f,
+        z: light.z * zScale,
+      };
+      if (light.type === "point") return { type: "point", ...position };
+      return {
+        type: "spot",
+        ...position,
+        pointsAtX: transform.a * light.pointsAtX + transform.c * light.pointsAtY + transform.e,
+        pointsAtY: transform.b * light.pointsAtX + transform.d * light.pointsAtY + transform.f,
+        pointsAtZ: light.pointsAtZ * zScale,
+        specularExponent: light.specularExponent,
+        ...(light.limitingConeAngle === undefined ? {} : { limitingConeAngle: light.limitingConeAngle }),
+      };
+    };
     const transformPrimitive = (primitive: FilterPrimitive): FilterPrimitive => {
       const subregion = transformRegion(primitive.subregion);
       if (primitive.type === "offset")
@@ -390,6 +417,25 @@ function buildViewNodes(
             transform.c * primitive.kernelUnitLengthY!,
             transform.d * primitive.kernelUnitLengthY!,
           ),
+        };
+      if (primitive.type === "diffuseLighting" || primitive.type === "specularLighting")
+        return {
+          ...primitive,
+          subregion,
+          surfaceScale: primitive.surfaceScale * zScale,
+          ...(primitive.kernelUnitLengthX === undefined
+            ? {}
+            : {
+                kernelUnitLengthX: Math.hypot(
+                  transform.a * primitive.kernelUnitLengthX,
+                  transform.b * primitive.kernelUnitLengthX,
+                ),
+                kernelUnitLengthY: Math.hypot(
+                  transform.c * primitive.kernelUnitLengthY!,
+                  transform.d * primitive.kernelUnitLengthY!,
+                ),
+              }),
+          light: transformLight(primitive.light),
         };
       if (primitive.type === "displacementMap")
         return {
@@ -913,6 +959,15 @@ function filterColorLiteral(color: RGBAColor): string {
   return `SVGFilterColor(red: ${formatNumber(color.red)}, green: ${formatNumber(color.green)}, blue: ${formatNumber(color.blue)}, alpha: ${formatNumber(color.alpha)})`;
 }
 
+function filterLightLiteral(light: FilterLightSource | undefined): string {
+  if (!light) return "nil";
+  if (light.type === "distant")
+    return `.distant(x: ${formatNumber(light.x)}, y: ${formatNumber(light.y)}, z: ${formatNumber(light.z)})`;
+  if (light.type === "point")
+    return `.point(x: ${formatNumber(light.x)}, y: ${formatNumber(light.y)}, z: ${formatNumber(light.z)})`;
+  return `.spot(x: ${formatNumber(light.x)}, y: ${formatNumber(light.y)}, z: ${formatNumber(light.z)}, pointsAtX: ${formatNumber(light.pointsAtX)}, pointsAtY: ${formatNumber(light.pointsAtY)}, pointsAtZ: ${formatNumber(light.pointsAtZ)}, exponent: ${formatNumber(light.specularExponent)}, coneAngle: ${light.limitingConeAngle === undefined ? "nil" : formatNumber(light.limitingConeAngle)})`;
+}
+
 function filterRegionLiteral(region: FilterInstance["region"]): string {
   return `SVGFilterRegion(x: ${formatNumber(region.x)}, y: ${formatNumber(region.y)}, width: ${formatNumber(region.width)}, height: ${formatNumber(region.height)})`;
 }
@@ -966,6 +1021,10 @@ function filterPrimitiveLiteral(primitive: FilterPrimitive, index: number): stri
       return `.turbulence(baseFrequencyX: ${formatNumber(primitive.baseFrequencyX)}, baseFrequencyY: ${formatNumber(primitive.baseFrequencyY)}, octaves: ${primitive.numOctaves}, seed: ${primitive.seed}, stitch: ${primitive.stitchTiles}, fractalNoise: ${primitive.noiseType === "fractalNoise"}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "image":
       return `.image(key: ${swiftString(`filter-image-${index}`)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "diffuseLighting":
+      return `.diffuseLighting(input: ${filterInputLiteral(primitive.input)}, surfaceScale: ${formatNumber(primitive.surfaceScale)}, diffuseConstant: ${formatNumber(primitive.diffuseConstant)}, unitX: ${primitive.kernelUnitLengthX === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthX)}, unitY: ${primitive.kernelUnitLengthY === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthY)}, color: ${filterColorLiteral(primitive.color)}, light: ${filterLightLiteral(primitive.light)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+    case "specularLighting":
+      return `.specularLighting(input: ${filterInputLiteral(primitive.input)}, surfaceScale: ${formatNumber(primitive.surfaceScale)}, specularConstant: ${formatNumber(primitive.specularConstant)}, specularExponent: ${formatNumber(primitive.specularExponent)}, unitX: ${primitive.kernelUnitLengthX === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthX)}, unitY: ${primitive.kernelUnitLengthY === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthY)}, color: ${filterColorLiteral(primitive.color)}, light: ${filterLightLiteral(primitive.light)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "gaussianBlur":
       return `.gaussianBlur(input: ${filterInputLiteral(primitive.input)}, sigmaX: ${formatNumber(primitive.stdDeviationX)}, sigmaY: ${formatNumber(primitive.stdDeviationY)}, edge: .${primitive.edgeMode}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "offset":
@@ -1980,6 +2039,18 @@ function filterSupport(indentationSize: number): string[] {
 
 }
 
+private struct SVGFilterVector3 {
+    let x: CGFloat
+    let y: CGFloat
+    let z: CGFloat
+}
+
+private enum SVGFilterLight {
+    case distant(x: CGFloat, y: CGFloat, z: CGFloat)
+    case point(x: CGFloat, y: CGFloat, z: CGFloat)
+    case spot(x: CGFloat, y: CGFloat, z: CGFloat, pointsAtX: CGFloat, pointsAtY: CGFloat, pointsAtZ: CGFloat, exponent: CGFloat, coneAngle: CGFloat?)
+}
+
 private struct SVGFilterRegion {
     let x: CGFloat
     let y: CGFloat
@@ -2045,6 +2116,8 @@ private enum SVGFilterPrimitive {
     case tile(input: SVGFilterInput, tileRegion: SVGFilterRegion, region: SVGFilterRegion, linearRGB: Bool, result: String?)
     case turbulence(baseFrequencyX: CGFloat, baseFrequencyY: CGFloat, octaves: Int, seed: Int, stitch: Bool, fractalNoise: Bool, region: SVGFilterRegion, linearRGB: Bool, result: String?)
     case image(key: String, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case diffuseLighting(input: SVGFilterInput, surfaceScale: CGFloat, diffuseConstant: CGFloat, unitX: CGFloat?, unitY: CGFloat?, color: SVGFilterColor, light: SVGFilterLight?, region: SVGFilterRegion, linearRGB: Bool, result: String?)
+    case specularLighting(input: SVGFilterInput, surfaceScale: CGFloat, specularConstant: CGFloat, specularExponent: CGFloat, unitX: CGFloat?, unitY: CGFloat?, color: SVGFilterColor, light: SVGFilterLight?, region: SVGFilterRegion, linearRGB: Bool, result: String?)
     case gaussianBlur(input: SVGFilterInput, sigmaX: CGFloat, sigmaY: CGFloat, edge: SVGFilterEdgeMode, region: SVGFilterRegion, linearRGB: Bool, result: String?)
     case offset(input: SVGFilterInput, dx: CGFloat, dy: CGFloat, region: SVGFilterRegion, linearRGB: Bool, result: String?)
     case flood(color: SVGFilterColor, region: SVGFilterRegion, linearRGB: Bool, result: String?)
@@ -2064,6 +2137,8 @@ private enum SVGFilterPrimitive {
              let .tile(_, _, region, _, _),
              let .turbulence(_, _, _, _, _, _, region, _, _),
              let .image(_, region, _, _),
+             let .diffuseLighting(_, _, _, _, _, _, _, region, _, _),
+             let .specularLighting(_, _, _, _, _, _, _, _, region, _, _),
              let .gaussianBlur(_, _, _, _, region, _, _),
              let .offset(_, _, _, region, _, _),
              let .flood(_, region, _, _),
@@ -2086,6 +2161,8 @@ private enum SVGFilterPrimitive {
              let .tile(_, _, _, value, _),
              let .turbulence(_, _, _, _, _, _, _, value, _),
              let .image(_, _, value, _),
+             let .diffuseLighting(_, _, _, _, _, _, _, _, value, _),
+             let .specularLighting(_, _, _, _, _, _, _, _, _, value, _),
              let .gaussianBlur(_, _, _, _, _, value, _),
              let .offset(_, _, _, _, value, _),
              let .flood(_, _, value, _),
@@ -2848,6 +2925,109 @@ private enum SVGFilterBitmapRuntime {
         return result
     }
 
+    private static func normalized(_ x: CGFloat, _ y: CGFloat, _ z: CGFloat) -> SVGFilterVector3 {
+        let length = sqrt(x * x + y * y + z * z)
+        guard length > 0 else { return SVGFilterVector3(x: 0, y: 0, z: 0) }
+        return SVGFilterVector3(x: x / length, y: y / length, z: z / length)
+    }
+
+    private static func surfaceNormal(_ image: SVGFilterBitmap, x: Int, y: Int, surfaceScale: CGFloat, unitX: CGFloat?, unitY: CGFloat?, scaleX: CGFloat, scaleY: CGFloat, bounds: SVGFilterPixelRect) -> SVGFilterVector3 {
+        let dx = unitX ?? 1 / scaleX
+        let dy = unitY ?? 1 / scaleY
+        let stepX = dx * scaleX
+        let stepY = dy * scaleY
+        let left = CGFloat(x) - stepX < CGFloat(bounds.minX)
+        let right = CGFloat(x) + stepX >= CGFloat(bounds.maxX)
+        let top = CGFloat(y) - stepY < CGFloat(bounds.minY)
+        let bottom = CGFloat(y) + stepY >= CGFloat(bounds.maxY)
+        guard !(left && right), !(top && bottom), dx > 0, dy > 0 else {
+            return SVGFilterVector3(x: 0, y: 0, z: 1)
+        }
+        let differenceX: [Float] = left ? [0, -1, 1] : right ? [-1, 1, 0] : [-1, 0, 1]
+        let smoothY: [Float] = top ? [0, 2, 1] : bottom ? [1, 2, 0] : [1, 2, 1]
+        let differenceY: [Float] = top ? [0, -1, 1] : bottom ? [-1, 1, 0] : [-1, 0, 1]
+        let smoothX: [Float] = left ? [0, 2, 1] : right ? [1, 2, 0] : [1, 2, 1]
+        var sumX: Float = 0
+        var sumY: Float = 0
+        for row in 0..<3 {
+            for column in 0..<3 {
+                let alpha = sampleBilinear(
+                    image,
+                    x: CGFloat(x) + CGFloat(column - 1) * stepX,
+                    y: CGFloat(y) + CGFloat(row - 1) * stepY,
+                    edge: .none,
+                    bounds: bounds
+                )[3]
+                sumX += smoothY[row] * differenceX[column] * alpha
+                sumY += differenceY[row] * smoothX[column] * alpha
+            }
+        }
+        let horizontalEdge = left || right
+        let verticalEdge = top || bottom
+        let factors: (CGFloat, CGFloat)
+        switch (horizontalEdge, verticalEdge) {
+        case (true, true): factors = (CGFloat(2) / 3, CGFloat(2) / 3)
+        case (true, false): factors = (CGFloat(1) / 2, CGFloat(1) / 3)
+        case (false, true): factors = (CGFloat(1) / 3, CGFloat(1) / 2)
+        case (false, false): factors = (CGFloat(1) / 4, CGFloat(1) / 4)
+        }
+        return normalized(
+            -surfaceScale * factors.0 * CGFloat(sumX) / dx,
+            -surfaceScale * factors.1 * CGFloat(sumY) / dy,
+            1
+        )
+    }
+
+    private static func lightAt(_ light: SVGFilterLight, x: CGFloat, y: CGFloat, z: CGFloat) -> (SVGFilterVector3, CGFloat) {
+        switch light {
+        case let .distant(lightX, lightY, lightZ):
+            return (normalized(lightX, lightY, lightZ), 1)
+        case let .point(lightX, lightY, lightZ):
+            return (normalized(lightX - x, lightY - y, lightZ - z), 1)
+        case let .spot(lightX, lightY, lightZ, pointsAtX, pointsAtY, pointsAtZ, exponent, coneAngle):
+            let direction = normalized(lightX - x, lightY - y, lightZ - z)
+            let spot = normalized(pointsAtX - lightX, pointsAtY - lightY, pointsAtZ - lightZ)
+            let cosine = -(direction.x * spot.x + direction.y * spot.y + direction.z * spot.z)
+            guard cosine > 0 else { return (direction, 0) }
+            if let coneAngle, cosine < cos(coneAngle * .pi / 180) { return (direction, 0) }
+            return (direction, pow(cosine, exponent))
+        }
+    }
+
+    private static func lighting(_ image: SVGFilterBitmap, diffuse: Bool, surfaceScale: CGFloat, constant: CGFloat, specularExponent: CGFloat, unitX: CGFloat?, unitY: CGFloat?, color: SVGFilterColor, light: SVGFilterLight?, scaleX: CGFloat, scaleY: CGFloat, bounds: SVGFilterPixelRect) -> SVGFilterBitmap {
+        var result = SVGFilterBitmap(width: image.width, height: image.height)
+        guard let light else { return result }
+        let lightColor = [color.red, color.green, color.blue].map { Float(min(1, max(0, $0))) }
+        let startY = max(0, bounds.minY)
+        let endY = min(image.height, bounds.maxY)
+        let startX = max(0, bounds.minX)
+        let endX = min(image.width, bounds.maxX)
+        guard startX < endX, startY < endY else { return result }
+        for y in startY..<endY {
+            for x in startX..<endX {
+                let index = (y * image.width + x) * 4
+                let height = surfaceScale * CGFloat(image.values[index + 3])
+                let normal = surfaceNormal(image, x: x, y: y, surfaceScale: surfaceScale, unitX: unitX, unitY: unitY, scaleX: scaleX, scaleY: scaleY, bounds: bounds)
+                let (direction, lightScale) = lightAt(light, x: CGFloat(x) / scaleX, y: CGFloat(y) / scaleY, z: height)
+                let intensity: CGFloat
+                if diffuse {
+                    intensity = constant * max(0, normal.x * direction.x + normal.y * direction.y + normal.z * direction.z)
+                } else {
+                    let half = normalized(direction.x, direction.y, direction.z + 1)
+                    intensity = constant * pow(max(0, normal.x * half.x + normal.y * half.y + normal.z * half.z), specularExponent)
+                }
+                let channels = lightColor.map { clamped($0 * Float(lightScale * intensity)) }
+                if diffuse {
+                    write([channels[0], channels[1], channels[2], 1], to: &result, x: x, y: y)
+                } else {
+                    let alpha = max(channels[0], channels[1], channels[2])
+                    write([channels[0], channels[1], channels[2], alpha], to: &result, x: x, y: y)
+                }
+            }
+        }
+        return result
+    }
+
     private static func over(_ source: SVGFilterBitmap, _ destination: SVGFilterBitmap) -> SVGFilterBitmap {
         var result = source
         for index in stride(from: 0, to: result.values.count, by: 4) {
@@ -2971,6 +3151,36 @@ private enum SVGFilterBitmapRuntime {
                 output = converted(generated, linear: linear, encode: true)
             case let .image(key, _, _, _):
                 output = filterImages[key] ?? transparent
+            case let .diffuseLighting(value, surfaceScale, diffuseConstant, unitX, unitY, color, light, _, _, _):
+                output = converted(lighting(
+                    input(value),
+                    diffuse: true,
+                    surfaceScale: surfaceScale,
+                    constant: diffuseConstant,
+                    specularExponent: 1,
+                    unitX: unitX,
+                    unitY: unitY,
+                    color: color,
+                    light: light,
+                    scaleX: scaleX,
+                    scaleY: scaleY,
+                    bounds: inputRegion(value)
+                ), linear: linear, encode: true)
+            case let .specularLighting(value, surfaceScale, specularConstant, specularExponent, unitX, unitY, color, light, _, _, _):
+                output = converted(lighting(
+                    input(value),
+                    diffuse: false,
+                    surfaceScale: surfaceScale,
+                    constant: specularConstant,
+                    specularExponent: specularExponent,
+                    unitX: unitX,
+                    unitY: unitY,
+                    color: color,
+                    light: light,
+                    scaleX: scaleX,
+                    scaleY: scaleY,
+                    bounds: inputRegion(value)
+                ), linear: linear, encode: true)
             case let .gaussianBlur(value, sigmaX, sigmaY, edge, _, _, _):
                 output = converted(blur(converted(input(value), linear: linear, encode: false), sigmaX: sigmaX * scaleX, sigmaY: sigmaY * scaleY, edge: edge, bounds: inputRegion(value)), linear: linear, encode: true)
             case let .offset(value, dx, dy, _, _, _):

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -116,6 +116,36 @@ export type FilterChannelSelector = "R" | "G" | "B" | "A";
 export type FilterMorphologyOperator = "erode" | "dilate";
 export type FilterTurbulenceType = "turbulence" | "fractalNoise";
 
+export type FilterLightSourceSpec =
+  | { type: "distant"; azimuth: number; elevation: number }
+  | { type: "point"; x: number; y: number; z: number }
+  | {
+      type: "spot";
+      x: number;
+      y: number;
+      z: number;
+      pointsAtX: number;
+      pointsAtY: number;
+      pointsAtZ: number;
+      specularExponent: number;
+      limitingConeAngle?: number;
+    };
+
+export type FilterLightSource =
+  | { type: "distant"; x: number; y: number; z: number }
+  | { type: "point"; x: number; y: number; z: number }
+  | {
+      type: "spot";
+      x: number;
+      y: number;
+      z: number;
+      pointsAtX: number;
+      pointsAtY: number;
+      pointsAtZ: number;
+      specularExponent: number;
+      limitingConeAngle?: number;
+    };
+
 export type FilterComponentTransferFunction =
   | { type: "identity" }
   | { type: "table"; values: number[] }
@@ -294,6 +324,27 @@ export type FilterPrimitiveSpec =
       noiseType: FilterTurbulenceType;
     })
   | (FilterPrimitiveSpecBase & { type: "image"; image: FilterImageSource })
+  | (FilterPrimitiveSpecBase & {
+      type: "diffuseLighting";
+      input: FilterInput;
+      surfaceScale: number;
+      diffuseConstant: number;
+      kernelUnitLengthX?: number;
+      kernelUnitLengthY?: number;
+      color: RGBAColor;
+      light?: FilterLightSourceSpec;
+    })
+  | (FilterPrimitiveSpecBase & {
+      type: "specularLighting";
+      input: FilterInput;
+      surfaceScale: number;
+      specularConstant: number;
+      specularExponent: number;
+      kernelUnitLengthX?: number;
+      kernelUnitLengthY?: number;
+      color: RGBAColor;
+      light?: FilterLightSourceSpec;
+    })
   | (FilterPrimitiveSpecBase & { type: "offset"; input: FilterInput; dx: number; dy: number })
   | (FilterPrimitiveSpecBase & { type: "flood"; color: RGBAColor })
   | (FilterPrimitiveSpecBase & { type: "merge"; inputs: FilterInput[] })
@@ -387,6 +438,27 @@ export type FilterPrimitive =
       noiseType: FilterTurbulenceType;
     })
   | (FilterPrimitiveBase & { type: "image"; image: FilterImageSource })
+  | (FilterPrimitiveBase & {
+      type: "diffuseLighting";
+      input: FilterInput;
+      surfaceScale: number;
+      diffuseConstant: number;
+      kernelUnitLengthX?: number;
+      kernelUnitLengthY?: number;
+      color: RGBAColor;
+      light?: FilterLightSource;
+    })
+  | (FilterPrimitiveBase & {
+      type: "specularLighting";
+      input: FilterInput;
+      surfaceScale: number;
+      specularConstant: number;
+      specularExponent: number;
+      kernelUnitLengthX?: number;
+      kernelUnitLengthY?: number;
+      color: RGBAColor;
+      light?: FilterLightSource;
+    })
   | (FilterPrimitiveBase & { type: "offset"; input: FilterInput; dx: number; dy: number })
   | (FilterPrimitiveBase & { type: "flood"; color: RGBAColor })
   | (FilterPrimitiveBase & { type: "merge"; inputs: FilterInput[] })

--- a/packages/svg-to-swiftui-core/src/tests/filterLighting.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/filterLighting.test.ts
@@ -1,0 +1,212 @@
+import { __testing, convert, convertWithDiagnostics } from "../index";
+import { type FilterBitmap, type FilterVector3, lightingFilterBitmap, surfaceNormal } from "../renderTree/filterMath";
+import type { FilterPrimitive, RenderNode } from "../renderTree/types";
+
+function flatten(nodes: RenderNode[]): RenderNode[] {
+  return nodes.flatMap((node) => (node.type === "group" ? [node, ...flatten(node.children)] : [node]));
+}
+
+function primitives(source: string): FilterPrimitive[] {
+  const document = __testing.parseRenderDocument(source);
+  const node = flatten(document.children).find((candidate) => candidate.filter);
+  if (!node?.filter) throw new Error("Expected a filter instance");
+  return node.filter.primitives;
+}
+
+function alphaBitmap(width: number, height: number, alpha: number[]): FilterBitmap {
+  return {
+    width,
+    height,
+    values: alpha.flatMap((value) => [0, 0, 0, value]),
+  };
+}
+
+function expectVector(actual: FilterVector3, expected: FilterVector3, digits = 7): void {
+  expected.forEach((value, index) => {
+    expect(actual[index]).toBeCloseTo(value, digits);
+  });
+}
+
+describe("SVG filter lighting parsing", () => {
+  test("retains diffuse/specular parameters, CSS lighting colors, and every light source", () => {
+    const graph =
+      primitives(`<svg viewBox="0 0 100 50"><style>.lit { lighting-color: currentColor }</style><defs><filter id="f">
+      <feDiffuseLighting class="lit" color="#4080c0" surfaceScale="3" diffuseConstant=".75" kernelUnitLength="2,3" result="d">
+        <feDistantLight azimuth="45" elevation="30"/>
+      </feDiffuseLighting>
+      <feSpecularLighting in="d" lighting-color="#ff8040" surfaceScale="4" specularConstant=".5" specularExponent="16" result="s">
+        <fePointLight x="20" y="10" z="30"/>
+      </feSpecularLighting>
+      <feDiffuseLighting in="s"><feSpotLight x="5" y="6" z="7" pointsAtX="8" pointsAtY="9" pointsAtZ="1" specularExponent="12" limitingConeAngle="25"/></feDiffuseLighting>
+    </filter></defs><rect width="100" height="50" filter="url(#f)"/></svg>`);
+    expect(graph[0]).toMatchObject({
+      type: "diffuseLighting",
+      surfaceScale: 3,
+      diffuseConstant: 0.75,
+      kernelUnitLengthX: 2,
+      kernelUnitLengthY: 3,
+      color: { red: 64 / 255, green: 128 / 255, blue: 192 / 255, alpha: 1 },
+      light: { type: "distant" },
+    });
+    if (graph[0]?.type !== "diffuseLighting" || graph[0].light?.type !== "distant")
+      throw new Error("Expected distant light");
+    expect(graph[0].light.x).toBeCloseTo(0.6123724357);
+    expect(graph[0].light.y).toBeCloseTo(0.6123724357);
+    expect(graph[0].light.z).toBeCloseTo(0.5);
+    expect(graph[1]).toMatchObject({
+      type: "specularLighting",
+      input: { type: "result", index: 0 },
+      surfaceScale: 4,
+      specularConstant: 0.5,
+      specularExponent: 16,
+      light: { type: "point", x: 20, y: 10, z: 30 },
+    });
+    expect(graph[2]).toMatchObject({
+      type: "diffuseLighting",
+      light: {
+        type: "spot",
+        x: 5,
+        y: 6,
+        z: 7,
+        pointsAtX: 8,
+        pointsAtY: 9,
+        pointsAtZ: 1,
+        specularExponent: 12,
+        limitingConeAngle: 25,
+      },
+    });
+  });
+
+  test("resolves objectBoundingBox light coordinates, height, and kernel distances", () => {
+    const graph = primitives(`<svg viewBox="0 0 200 100"><defs><filter id="f" primitiveUnits="objectBoundingBox">
+      <feDiffuseLighting surfaceScale=".2" kernelUnitLength=".1 .2"><fePointLight x=".25" y=".5" z=".3"/></feDiffuseLighting>
+    </filter></defs><rect x="20" y="10" width="100" height="50" filter="url(#f)"/></svg>`);
+    expect(graph[0]).toMatchObject({
+      type: "diffuseLighting",
+      surfaceScale: Math.sqrt(5000) * 0.2,
+      kernelUnitLengthX: 10,
+      kernelUnitLengthY: 10,
+      light: { type: "point", x: 45, y: 35, z: 0.3 },
+    });
+  });
+
+  test("diagnoses missing/multiple lights and malformed parameter ranges with deterministic fallbacks", () => {
+    const result = convertWithDiagnostics(`<svg viewBox="0 0 10 10"><defs><filter id="f">
+      <feDiffuseLighting diffuseConstant="-1" kernelUnitLength="0" lighting-color="not-a-color"/>
+      <feSpecularLighting specularConstant="-2" specularExponent="200"><fePointLight/><feDistantLight/></feSpecularLighting>
+      <feDiffuseLighting><feSpotLight specularExponent="0"/><feUnknownLight/></feDiffuseLighting>
+    </filter></defs><rect width="10" height="10" filter="url(#f)"/></svg>`);
+    expect(result.diagnostics.map(({ code }) => code)).toEqual(
+      expect.arrayContaining([
+        "negative-filter-diffuseconstant",
+        "invalid-filter-kernelunitlength",
+        "invalid-lighting-color",
+        "missing-filter-light-source",
+        "negative-filter-specularconstant",
+        "invalid-filter-specularexponent-range",
+        "multiple-filter-light-sources",
+        "unsupported-filter-light-source",
+      ]),
+    );
+    expect(() =>
+      convert(`<svg><filter id="f"><feDiffuseLighting/></filter><rect filter="url(#f)"/></svg>`, { strict: true }),
+    ).toThrow("requires exactly one");
+  });
+
+  test("emits typed Swift lighting primitives instead of pass-through nodes", () => {
+    const swift = convert(`<svg viewBox="0 0 10 10"><defs><filter id="f">
+      <feDiffuseLighting><feDistantLight elevation="45"/></feDiffuseLighting>
+      <feSpecularLighting><feSpotLight z="10"/></feSpecularLighting>
+    </filter></defs><circle cx="5" cy="5" r="4" filter="url(#f)"/></svg>`);
+    expect(swift).toContain("case diffuseLighting(input: SVGFilterInput");
+    expect(swift).toContain("case specularLighting(input: SVGFilterInput");
+    expect(swift).toContain("case distant(x: CGFloat");
+    expect(swift).toContain("private static func surfaceNormal");
+    expect(swift).not.toContain("unsupported-filter-primitive");
+  });
+});
+
+describe("SVG filter lighting reference math", () => {
+  const ramp = alphaBitmap(3, 3, [0, 0.5, 1, 0, 0.5, 1, 0, 0.5, 1]);
+  const expectedRampNormal: FilterVector3 = [-Math.SQRT1_2, 0, Math.SQRT1_2];
+
+  test("uses the exact interior, edge, and corner normal kernels", () => {
+    expectVector(surfaceNormal(ramp, 1, 1, { surfaceScale: 1 }), expectedRampNormal);
+    expectVector(surfaceNormal(ramp, 0, 1, { surfaceScale: 1 }), expectedRampNormal);
+    expectVector(surfaceNormal(ramp, 0, 0, { surfaceScale: 1 }), expectedRampNormal);
+    expectVector(surfaceNormal(ramp, 2, 2, { surfaceScale: 1 }), expectedRampNormal);
+  });
+
+  test("handles constant, transparent, fractional-kernel, and tiny height maps", () => {
+    const flat = alphaBitmap(3, 3, Array(9).fill(0.5));
+    expectVector(surfaceNormal(flat, 1, 1, { surfaceScale: 5 }), [0, 0, 1]);
+    expectVector(surfaceNormal(alphaBitmap(1, 1, [0]), 0, 0, { surfaceScale: 5 }), [0, 0, 1]);
+    expect(surfaceNormal(ramp, 1, 1, { surfaceScale: 1, kernelUnitLengthX: 0.5, kernelUnitLengthY: 0.5 })).toEqual(
+      expect.arrayContaining([expect.any(Number), expect.any(Number), expect.any(Number)]),
+    );
+  });
+
+  test("computes opaque diffuse and max-channel-alpha specular output", () => {
+    const flat = alphaBitmap(1, 1, [0.5]);
+    const light = { type: "distant", x: 0, y: 0, z: 1 } as const;
+    expect(
+      lightingFilterBitmap(flat, {
+        type: "diffuse",
+        surfaceScale: 2,
+        constant: 0.5,
+        color: [0.8, 0.4, 0.2],
+        light,
+      }).values,
+    ).toEqual([0.4, 0.2, 0.1, 1]);
+    expect(
+      lightingFilterBitmap(flat, {
+        type: "specular",
+        surfaceScale: 2,
+        constant: 0.5,
+        specularExponent: 16,
+        color: [0.8, 0.4, 0.2],
+        light,
+      }).values,
+    ).toEqual([0.4, 0.2, 0.1, 0.4]);
+  });
+
+  test("applies spotlight attenuation and limiting cones", () => {
+    const flat = alphaBitmap(1, 1, [0]);
+    const inside = lightingFilterBitmap(flat, {
+      type: "diffuse",
+      surfaceScale: 1,
+      constant: 1,
+      color: [1, 1, 1],
+      light: {
+        type: "spot",
+        x: 0,
+        y: 0,
+        z: 10,
+        pointsAtX: 0,
+        pointsAtY: 0,
+        pointsAtZ: 0,
+        specularExponent: 4,
+        limitingConeAngle: 30,
+      },
+    });
+    const outside = lightingFilterBitmap(flat, {
+      type: "diffuse",
+      surfaceScale: 1,
+      constant: 1,
+      color: [1, 1, 1],
+      light: {
+        type: "spot",
+        x: 0,
+        y: 0,
+        z: 10,
+        pointsAtX: 10,
+        pointsAtY: 0,
+        pointsAtZ: 0,
+        specularExponent: 4,
+        limitingConeAngle: 30,
+      },
+    });
+    expect(inside.values).toEqual([1, 1, 1, 1]);
+    expect(outside.values).toEqual([0, 0, 0, 1]);
+  });
+});

--- a/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/visual-tests/fixture-manifest.json
@@ -477,6 +477,85 @@
         "view"
       ]
     },
+    "filter-lighting-diffuse": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": [
+        "SourceAlpha",
+        "circle",
+        "feComposite",
+        "feDiffuseLighting",
+        "feGaussianBlur",
+        "filter",
+        "geometry",
+        "path",
+        "rect",
+        "view"
+      ],
+      "tolerance": {
+        "maxOutsidePercent": 5
+      },
+      "toleranceReason": "The SVG and generated Swift renderers use different Gaussian kernel truncation and edge antialiasing; the lit interiors and alpha match, with differences confined to softened shape edges."
+    },
+    "filter-lighting-specular": {
+      "width": 128,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": [
+        "SourceAlpha",
+        "SourceGraphic",
+        "circle",
+        "feComposite",
+        "feGaussianBlur",
+        "feSpecularLighting",
+        "filter",
+        "g",
+        "geometry",
+        "rect",
+        "view"
+      ]
+    },
+    "filter-lighting-spot": {
+      "width": 128,
+      "height": 51,
+      "expectedMode": "view",
+      "tags": [
+        "SourceAlpha",
+        "circle",
+        "feComposite",
+        "feDiffuseLighting",
+        "feGaussianBlur",
+        "filter",
+        "g",
+        "geometry",
+        "rect",
+        "view"
+      ]
+    },
+    "filter-lighting-units-transforms": {
+      "width": 128,
+      "height": 77,
+      "expectedMode": "view",
+      "tags": [
+        "SourceAlpha",
+        "feComposite",
+        "feDiffuseLighting",
+        "feGaussianBlur",
+        "feSpecularLighting",
+        "filter",
+        "g",
+        "geometry",
+        "rect",
+        "transform",
+        "units",
+        "view"
+      ],
+      "tolerance": {
+        "maxOutsidePercent": 3.2
+      },
+      "toleranceReason": "CoreGraphics and the SVG reference rasterizer round transformed softened edges and the one-pixel specular sample differently; the objectBoundingBox lighting interior matches within default channel and mean-error limits."
+    },
     "filter-morphology": {
       "width": 128,
       "height": 64,

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-lighting-diffuse.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-lighting-diffuse.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 80" width="160" height="80">
+  <defs>
+    <filter id="distant" filterUnits="userSpaceOnUse" x="0" y="0" width="80" height="80" color-interpolation-filters="sRGB">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.5" result="bump"/>
+      <feDiffuseLighting in="bump" surfaceScale="6" diffuseConstant="1.1" kernelUnitLength="1" lighting-color="#ffb45c" result="light">
+        <feDistantLight azimuth="225" elevation="45"/>
+      </feDiffuseLighting>
+      <feComposite in="light" in2="SourceAlpha" operator="in"/>
+    </filter>
+    <filter id="point" filterUnits="userSpaceOnUse" x="80" y="0" width="80" height="80" color-interpolation-filters="linearRGB">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="bump"/>
+      <feDiffuseLighting in="bump" surfaceScale="8" diffuseConstant="1" lighting-color="#68d8ff" result="light">
+        <fePointLight x="102" y="18" z="28"/>
+      </feDiffuseLighting>
+      <feComposite in="light" in2="SourceAlpha" operator="in"/>
+    </filter>
+  </defs>
+  <rect width="160" height="80" fill="#151b2d"/>
+  <circle cx="40" cy="40" r="27" fill="#ffffff" filter="url(#distant)"/>
+  <path d="M90 62V20h24c22 0 36 12 36 21s-14 21-36 21z" fill="#ffffff" filter="url(#point)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-lighting-specular.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-lighting-specular.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="10 5 160 80" width="160" height="80">
+  <defs>
+    <filter id="spec" filterUnits="userSpaceOnUse" x="10" y="5" width="160" height="80" color-interpolation-filters="sRGB">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2.2" result="bump"/>
+      <feSpecularLighting in="bump" surfaceScale="7" specularConstant="1.25" specularExponent="18" kernelUnitLength="1" lighting-color="#d9edff" result="shine">
+        <fePointLight x="58" y="20" z="35"/>
+      </feSpecularLighting>
+      <feComposite in="shine" in2="SourceAlpha" operator="in" result="masked"/>
+      <feComposite in="SourceGraphic" in2="masked" operator="arithmetic" k2="1" k3="1"/>
+    </filter>
+  </defs>
+  <rect x="10" y="5" width="160" height="80" fill="#0f1424"/>
+  <g filter="url(#spec)">
+    <circle cx="58" cy="45" r="28" fill="#7247d8"/>
+    <rect x="98" y="18" width="58" height="54" rx="13" fill="#246ea8"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-lighting-spot.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-lighting-spot.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 72" width="180" height="72">
+  <defs>
+    <filter id="spot" filterUnits="userSpaceOnUse" x="0" y="0" width="180" height="72" color-interpolation-filters="sRGB">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="1.4" result="bump"/>
+      <feDiffuseLighting in="bump" surfaceScale="5" diffuseConstant="1.4" lighting-color="#fff3b0" result="cone">
+        <feSpotLight x="34" y="10" z="32" pointsAtX="72" pointsAtY="38" pointsAtZ="0" specularExponent="6" limitingConeAngle="30"/>
+      </feDiffuseLighting>
+      <feComposite in="cone" in2="SourceAlpha" operator="in"/>
+    </filter>
+  </defs>
+  <rect width="180" height="72" fill="#161b26"/>
+  <g filter="url(#spot)" fill="#fff">
+    <circle cx="36" cy="38" r="20"/>
+    <circle cx="90" cy="38" r="20"/>
+    <circle cx="144" cy="38" r="20"/>
+  </g>
+</svg>

--- a/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-lighting-units-transforms.svg
+++ b/packages/svg-to-swiftui-core/visual-tests/fixtures/filter-lighting-units-transforms.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="20 10 150 90" width="150" height="90">
+  <defs>
+    <filter id="box" primitiveUnits="objectBoundingBox" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="linearRGB">
+      <feGaussianBlur in="SourceAlpha" stdDeviation=".025 .04" result="bump"/>
+      <feDiffuseLighting in="bump" surfaceScale=".12" diffuseConstant="1" kernelUnitLength=".015 .025" lighting-color="#7dff9f" result="lit">
+        <fePointLight x=".2" y=".1" z=".4"/>
+      </feDiffuseLighting>
+      <feComposite in="lit" in2="SourceAlpha" operator="in"/>
+    </filter>
+    <filter id="tiny" filterUnits="userSpaceOnUse" x="130" y="70" width="8" height="8">
+      <feSpecularLighting in="SourceAlpha" surfaceScale="3" specularConstant="1" specularExponent="8" lighting-color="white">
+        <feDistantLight azimuth="0" elevation="70"/>
+      </feSpecularLighting>
+    </filter>
+  </defs>
+  <rect x="20" y="10" width="150" height="90" fill="#11182a"/>
+  <g transform="translate(16 -4) rotate(12 82 55)">
+    <rect x="48" y="27" width="72" height="50" rx="12" fill="white" filter="url(#box)"/>
+  </g>
+  <rect x="132" y="72" width="1" height="1" fill="white" filter="url(#tiny)"/>
+</svg>


### PR DESCRIPTION
Closes #71

## What changed

- Add `feDiffuseLighting` and `feSpecularLighting` to the typed filter graph and generated Swift runtime.
- Support `feDistantLight`, `fePointLight`, and `feSpotLight`, including cones, transforms, primitive units, `kernelUnitLength`, and `lighting-color`/`currentColor`.
- Implement exact SVG edge, corner, and interior surface-normal kernels plus required diffuse/specular alpha behavior.
- Add deterministic diagnostics, numeric unit coverage, four real visual fixtures, documentation, and a minor changeset.

## Validation

- 282 Jest tests passed
- Core lint, typecheck, and build passed
- Visual manifest valid with 1,907 fixtures
- 4/4 new SVG-vs-Swift lighting fixtures passed