### PR TITLE
Add deterministic SVG animation frame harness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Verify visual fixture manifest
         run: bun run visual-test:verify
 
+      - name: Verify animation fixture manifest
+        run: bun run animation-test:verify
+
       - name: Verify SVG2 static conformance inventory
         run: bun run conformance:verify
 
@@ -74,13 +77,30 @@ jobs:
       - name: Restore content-validated visual cache
         uses: actions/cache@v4
         with:
-          path: packages/svg-to-swiftui-core/visual-tests/renders
-          key: rgba-visual-${{ runner.os }}-${{ hashFiles('bun.lock', 'packages/svg-to-swiftui-core/src/**', 'packages/svg-to-swiftui-core/visual-tests/**') }}
+          path: |
+            packages/svg-to-swiftui-core/visual-tests/renders
+            packages/svg-to-swiftui-core/animation-tests/renders
+          key: rgba-visual-${{ runner.os }}-${{ hashFiles('bun.lock', 'packages/svg-to-swiftui-core/src/**', 'packages/svg-to-swiftui-core/visual-tests/**', 'packages/svg-to-swiftui-core/animation-tests/**') }}
           restore-keys: |
             rgba-visual-${{ runner.os }}-
 
       - name: Run SwiftUI RGBA visual tests
         run: bun run visual-test
+
+      - name: Run temporal SwiftUI RGBA frame tests
+        run: bun run animation-test -- --videos
+
+      - name: Retain animated SVG review artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: animated-svg-review
+          path: |
+            packages/svg-to-swiftui-core/animation-tests/renders/summary.json
+            packages/svg-to-swiftui-core/animation-tests/renders/**/*.mp4
+            packages/svg-to-swiftui-core/animation-tests/renders/**/*-diff.png
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Retain failed visual artifacts
         if: failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ bun run lint         # Lint all packages
 bun run format       # Check formatting
 bun run typecheck    # Type-check all packages
 bun run visual-test  # Visual regression tests (macOS only, compares SVG vs Swift rendering)
+bun run animation-test # Temporal regression tests (macOS only, compares exact RGBA frames)
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The compiler targets the complete **static appearance of SVG 2 and Filter Effect
 - **1,909 deterministic visual tests** that compile and render the generated SwiftUI
 - Strict and permissive conversion modes with structured, source-located diagnostics
 
-Animations, scripts, navigation, media playback, and other dynamic browser behavior are intentionally outside the static rendering profile. See the [full, machine-verified coverage matrix](packages/svg-to-swiftui-core/conformance/REPORT.md) for exact support and limitations.
+Animations, scripts, navigation, media playback, and other dynamic browser behavior are intentionally outside the static rendering profile. Declarative animation support is now being built through the ordered [Animated SVG roadmap](https://github.com/bring-shrubbery/SVG-to-SwiftUI/issues/94). See the [full, machine-verified static coverage matrix](packages/svg-to-swiftui-core/conformance/REPORT.md) for exact current support and limitations.
 
 ## SVG in. Native SwiftUI out.
 
@@ -93,6 +93,7 @@ bun run test
 bun run typecheck
 bun run conformance:verify
 bun run visual-test       # macOS: compiles and compares all SwiftUI renders
+bun run animation-test    # macOS: compares exact SVG and SwiftUI frame times
 ```
 
 ## Project structure

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "typecheck": "turbo typecheck",
     "visual-test": "bun run --filter svg-to-swiftui-core visual-test",
     "visual-test:verify": "bun run --filter svg-to-swiftui-core visual-test:verify",
+    "animation-test": "bun run --filter svg-to-swiftui-core animation-test",
+    "animation-test:verify": "bun run --filter svg-to-swiftui-core animation-test:verify",
     "conformance:verify": "bun run --filter svg-to-swiftui-core conformance:verify",
     "conformance:report": "bun run --filter svg-to-swiftui-core conformance:report",
     "conformance:benchmark": "bun run --filter svg-to-swiftui-core conformance:benchmark"

--- a/packages/svg-to-swiftui-core/.gitignore
+++ b/packages/svg-to-swiftui-core/.gitignore
@@ -3,3 +3,4 @@ dist
 src/**/*.js
 .eslintcache
 visual-tests/renders/
+animation-tests/renders/

--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -229,6 +229,9 @@ bun run visual-test -- --tag opacity            # one feature family
 bun run visual-test -- --changed                # changed fixture SVGs
 bun run visual-test -- --fresh                  # ignore render caches
 bun run visual-test:verify                       # manifest + codegen integrity (all platforms)
+bun run animation-test                          # exact-time SVG/SwiftUI RGBA frame comparisons
+bun run animation-test -- --videos              # also encode review-only MP4 artifacts
+bun run animation-test:verify                   # temporal manifest integrity (all platforms)
 bun run conformance:verify                       # complete SVG2 classification + evidence
 bun run conformance:benchmark                    # compact Shape fast-path budget
 bun run conformance:report                       # regenerate conformance/REPORT.md
@@ -239,13 +242,19 @@ Reference caches are content-addressed from SVG bytes and render options. Swift 
 
 The default antialiasing allowance is 24/255 per channel, at most 3% pixels outside that allowance, and mean premultiplied RGB/alpha error no greater than 3/255. These limits accommodate resvg/CoreGraphics edge rasterization differences while still rejecting solid-color, layer-order, and opacity errors. Fixture-specific overrides must keep every channel enabled and include a reason in the manifest.
 
+### Temporal animation tests
+
+The animation harness extends the same compiler pipeline across an exact microsecond schedule. WebKit is paused and explicitly seeks both the SVG/SMIL document timeline and CSS Web Animations timeline. Generated Swift is compiled once, then SwiftUI renders every matching timestamp through an injected deterministic time value. Each lossless frame is compared with the same premultiplied-RGBA metrics, and summaries identify the worst frame and timestamp.
+
+Optional MP4 files are review artifacts only. They are encoded after the lossless comparisons and never decide whether a test passes. Animation compiler support is being implemented in dependency order under the [Animated SVG roadmap](https://github.com/bring-shrubbery/SVG-to-SwiftUI/issues/94).
+
 ## Migration from 0.4
 
 Existing `convert()`, `convertAsync()`, and diagnostics APIs remain source-compatible. Their generated Swift is unchanged for already-supported SVGs. New code can adopt `convertDetailed()`/`convertDetailedAsync()` for explicit output mode, artifacts, conformance data, and richer diagnostics. If a 0.4 integration relied on ignored animation, event, or navigation markup, permissive conversion now reports it and strict conversion rejects it. No core conversion path performs ambient network or filesystem I/O; keep using an explicit resource resolver.
 
 ## Roadmap
 
-The static roadmap is complete and tracked in the [generated conformance report](conformance/REPORT.md). Dynamic animation and interaction remain explicitly out of scope.
+The static roadmap is complete and tracked in the [generated conformance report](conformance/REPORT.md). Declarative animation is the next compiler phase; its implementation is tracked in the [Animated SVG roadmap](https://github.com/bring-shrubbery/SVG-to-SwiftUI/issues/94). Browser scripting and unrestricted DOM mutation remain explicitly outside the native SwiftUI profile.
 
 - [x] SVG `<path>` element
   - [x] Line commands

--- a/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "defaults": {
+    "scale": 2,
+    "background": null,
+    "fonts": [],
+    "fontFamilies": [],
+    "tolerance": {
+      "channel": 24,
+      "maxOutsidePercent": 3,
+      "maxMeanRgbError": 3,
+      "maxMeanAlphaError": 3
+    }
+  },
+  "fixtures": {
+    "harness-static-clock": {
+      "mode": "comparison",
+      "referenceBackend": "webkit",
+      "width": 96,
+      "height": 64,
+      "expectedMode": "view",
+      "tags": ["clock-transport", "compiler-pipeline", "static-control"],
+      "timeline": {
+        "durationMicroseconds": 1000000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [0, 333333, 1000000]
+      }
+    },
+    "reference-css-seek": {
+      "mode": "reference-probe",
+      "referenceBackend": "webkit",
+      "width": 96,
+      "height": 48,
+      "tags": ["css-animation", "reference-seek"],
+      "timeline": {
+        "durationMicroseconds": 1000000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [0, 500000, 1000000]
+      },
+      "expectDistinctReferenceFrames": true
+    },
+    "reference-smil-seek": {
+      "mode": "reference-probe",
+      "referenceBackend": "webkit",
+      "width": 96,
+      "height": 48,
+      "tags": ["animate", "reference-seek", "smil"],
+      "timeline": {
+        "durationMicroseconds": 1000000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [0, 500000, 1000000]
+      },
+      "expectDistinctReferenceFrames": true
+    }
+  }
+}

--- a/packages/svg-to-swiftui-core/animation-tests/batch-render.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/batch-render.ts
@@ -1,0 +1,288 @@
+/** Compile each generated declaration once, render exact document times, and compare every lossless RGBA frame. */
+import { execFile as execFileCallback } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import type { ExpectedOutputMode } from "../visual-tests/manifest";
+import { parseBackground } from "../visual-tests/manifest";
+import { comparePngFiles, type RgbaMetrics, type RgbaTolerance } from "../visual-tests/rgba-compare";
+
+const execFile = promisify(execFileCallback);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SUPPORT_PATH = resolve(__dirname, "../visual-tests/swiftui-renderer-support.swift");
+const SWIFT_RENDERER_VERSION = "temporal-swiftui-srgb-v1";
+
+export interface AnimationBatchFrame {
+  index: number;
+  timeMicroseconds: number;
+  stem: string;
+  referencePath: string;
+}
+
+export interface AnimationBatchItem {
+  name: string;
+  swiftCode: string;
+  swiftTypeName: string;
+  width: number;
+  height: number;
+  scale: number;
+  background: string | null;
+  fonts: string[];
+  expectedMode: ExpectedOutputMode;
+  tolerance: RgbaTolerance;
+  frames: AnimationBatchFrame[];
+}
+
+export interface AnimationFrameResult {
+  fixture: string;
+  frameIndex: number;
+  timeMicroseconds: number;
+  status: "pass" | "fail" | "error";
+  score: number;
+  metrics?: RgbaMetrics;
+  referencePath: string;
+  swiftPath: string;
+  diffPath: string;
+  error?: string;
+}
+
+interface SwiftRenderCacheEntry {
+  hash: string;
+}
+
+function hash(...values: (string | Buffer)[]): string {
+  const digest = createHash("sha256");
+  for (const value of values) digest.update(value);
+  return digest.digest("hex");
+}
+
+function swiftString(value: string): string {
+  return JSON.stringify(value).replaceAll("/", "/");
+}
+
+function generatedSource(support: string, items: AnimationBatchItem[]): string {
+  const declarations = items
+    .map(
+      (item) =>
+        `#sourceLocation(file: ${swiftString(`${item.name}.generated.swift`)}, line: 1)\n${item.swiftCode}\n#sourceLocation()`,
+    )
+    .join("\n\n");
+  const factories = items
+    .map((item) =>
+      item.expectedMode === "shape"
+        ? `    { AnyView(${item.swiftTypeName}().fill(Color.black)) }`
+        : `    { AnyView(${item.swiftTypeName}()) }`,
+    )
+    .join(",\n");
+  return `${support}
+
+${declarations}
+
+let _visualFactories: [() -> AnyView] = [
+${factories}
+]
+let _visualTaskData = try Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1]))
+let _visualTasks = try JSONDecoder().decode([_VisualTask].self, from: _visualTaskData)
+Task { @MainActor in
+    do {
+        for task in _visualTasks {
+            try _renderVisualTask(task, factories: _visualFactories)
+        }
+        exit(0)
+    } catch {
+        fputs("SwiftUI temporal render failed: \\(error)\\n", stderr)
+        exit(1)
+    }
+}
+RunLoop.main.run()
+`;
+}
+
+function compilerFailure(error: unknown): string {
+  if (typeof error === "object" && error !== null) {
+    const typed = error as { stderr?: string; stdout?: string; message?: string };
+    return [typed.message, typed.stdout, typed.stderr].filter(Boolean).join("\n").trim();
+  }
+  return String(error);
+}
+
+function framePaths(rendersDir: string, fixture: string, stem: string) {
+  const framesDirectory = join(rendersDir, fixture, "frames");
+  return {
+    framesDirectory,
+    swiftPath: join(framesDirectory, `${stem}-swift.png`),
+    diffPath: join(framesDirectory, `${stem}-diff.png`),
+    receiptPath: join(framesDirectory, `${stem}-time.txt`),
+  };
+}
+
+export async function runAnimationBatch(
+  items: AnimationBatchItem[],
+  rendersDir: string,
+  fresh = false,
+): Promise<AnimationFrameResult[]> {
+  if (items.length === 0) return [];
+  const support = readFileSync(SUPPORT_PATH, "utf8");
+  const source = generatedSource(support, items);
+  const sourceHash = hash(source).slice(0, 20);
+  const cacheDirectory = join(rendersDir, ".cache");
+  const cachePath = join(rendersDir, ".swift-frame-cache.json");
+  mkdirSync(cacheDirectory, { recursive: true });
+  let cache: Record<string, SwiftRenderCacheEntry> = {};
+  try {
+    cache = JSON.parse(readFileSync(cachePath, "utf8"));
+  } catch {}
+
+  const binaryPath = join(cacheDirectory, `swiftui-animation-${sourceHash}`);
+  const temporaryFiles: string[] = [];
+  let renderingError: string | undefined;
+  try {
+    if (fresh || !existsSync(binaryPath)) {
+      const sourceDirectory = join(tmpdir(), `svg-swiftui-animation-${sourceHash}`);
+      mkdirSync(sourceDirectory, { recursive: true });
+      const sourcePath = join(sourceDirectory, "main.swift");
+      writeFileSync(sourcePath, source);
+      temporaryFiles.push(sourcePath);
+      console.log(`  Compiling ${items.length} temporal SwiftUI declaration(s)...`);
+      try {
+        await execFile(
+          "xcrun",
+          ["swiftc", "-module-cache-path", join(cacheDirectory, "module-cache"), sourcePath, "-o", binaryPath],
+          { timeout: 900_000, maxBuffer: 100 * 1024 * 1024 },
+        );
+      } catch (error) {
+        throw new Error(`Generated temporal SwiftUI compilation failed.\n${compilerFailure(error)}`);
+      }
+    } else {
+      console.log(`  Using cached temporal SwiftUI renderer for ${items.length} fixture(s)`);
+    }
+
+    const tasks: object[] = [];
+    const pending: { cacheKey: string; itemHash: string }[] = [];
+    for (const [itemIndex, item] of items.entries()) {
+      for (const frame of item.frames) {
+        const paths = framePaths(rendersDir, item.name, frame.stem);
+        mkdirSync(paths.framesDirectory, { recursive: true });
+        const cacheKey = `${item.name}/${frame.stem}`;
+        const itemHash = hash(
+          SWIFT_RENDERER_VERSION,
+          support,
+          item.swiftCode,
+          JSON.stringify({
+            width: item.width,
+            height: item.height,
+            scale: item.scale,
+            background: item.background,
+            fonts: item.fonts,
+            expectedMode: item.expectedMode,
+            timeMicroseconds: frame.timeMicroseconds,
+          }),
+          ...item.fonts.map((font) => readFileSync(resolve(__dirname, font))),
+        );
+        if (
+          !fresh &&
+          cache[cacheKey]?.hash === itemHash &&
+          existsSync(paths.swiftPath) &&
+          existsSync(paths.receiptPath) &&
+          readFileSync(paths.receiptPath, "utf8") === String(frame.timeMicroseconds)
+        )
+          continue;
+        const [backgroundR, backgroundG, backgroundB, backgroundA] = parseBackground(item.background);
+        tasks.push({
+          index: itemIndex,
+          width: item.width,
+          height: item.height,
+          scale: item.scale,
+          backgroundR,
+          backgroundG,
+          backgroundB,
+          backgroundA,
+          fonts: item.fonts.map((font) => resolve(__dirname, font)),
+          output: paths.swiftPath,
+          timeMicroseconds: frame.timeMicroseconds,
+          timeReceipt: paths.receiptPath,
+        });
+        pending.push({ cacheKey, itemHash });
+      }
+    }
+
+    if (tasks.length > 0) {
+      const tasksPath = join(tmpdir(), `svg-swiftui-animation-tasks-${sourceHash}-${Date.now()}.json`);
+      temporaryFiles.push(tasksPath);
+      writeFileSync(tasksPath, JSON.stringify(tasks));
+      console.log(`  Rendering ${tasks.length} SwiftUI frame(s) at explicit document times...`);
+      try {
+        await execFile(binaryPath, [tasksPath], { timeout: 900_000, maxBuffer: 100 * 1024 * 1024 });
+      } catch (error) {
+        throw new Error(`Generated temporal SwiftUI renderer failed.\n${compilerFailure(error)}`);
+      }
+      for (const { cacheKey, itemHash } of pending) cache[cacheKey] = { hash: itemHash };
+    } else {
+      console.log("  All SwiftUI temporal frames are valid cache hits");
+    }
+    writeFileSync(cachePath, JSON.stringify(cache, null, 2));
+  } catch (error) {
+    renderingError = error instanceof Error ? error.message : String(error);
+  } finally {
+    for (const path of temporaryFiles) {
+      try {
+        unlinkSync(path);
+      } catch {}
+    }
+  }
+
+  const results: AnimationFrameResult[] = [];
+  for (const item of items) {
+    for (const frame of item.frames) {
+      const paths = framePaths(rendersDir, item.name, frame.stem);
+      if (renderingError) {
+        results.push({
+          fixture: item.name,
+          frameIndex: frame.index,
+          timeMicroseconds: frame.timeMicroseconds,
+          status: "error",
+          score: 0,
+          error: renderingError,
+          referencePath: frame.referencePath,
+          swiftPath: paths.swiftPath,
+          diffPath: paths.diffPath,
+        });
+        continue;
+      }
+      try {
+        const receipt = readFileSync(paths.receiptPath, "utf8");
+        if (receipt !== String(frame.timeMicroseconds))
+          throw new Error(`Swift time receipt was ${receipt}; expected ${frame.timeMicroseconds}`);
+        const comparison = comparePngFiles(frame.referencePath, paths.swiftPath, paths.diffPath, item.tolerance);
+        if (comparison.passed && existsSync(paths.diffPath)) unlinkSync(paths.diffPath);
+        results.push({
+          fixture: item.name,
+          frameIndex: frame.index,
+          timeMicroseconds: frame.timeMicroseconds,
+          status: comparison.passed ? "pass" : "fail",
+          score: Math.round((100 - comparison.metrics.outsidePercent) * 100) / 100,
+          metrics: comparison.metrics,
+          referencePath: frame.referencePath,
+          swiftPath: paths.swiftPath,
+          diffPath: paths.diffPath,
+        });
+      } catch (error) {
+        results.push({
+          fixture: item.name,
+          frameIndex: frame.index,
+          timeMicroseconds: frame.timeMicroseconds,
+          status: "error",
+          score: 0,
+          error: error instanceof Error ? error.message : String(error),
+          referencePath: frame.referencePath,
+          swiftPath: paths.swiftPath,
+          diffPath: paths.diffPath,
+        });
+      }
+    }
+  }
+  return results;
+}

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/harness-static-clock.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/harness-static-clock.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="64" viewBox="0 0 96 64">
+  <rect width="96" height="64" rx="12" fill="#172554"/>
+  <circle cx="32" cy="32" r="18" fill="#38bdf8"/>
+  <path d="M58 20h22v24H58z" fill="#f97316"/>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-css-seek.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-css-seek.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="48" viewBox="0 0 96 48">
+  <style>
+    @keyframes travel { from { transform: translateX(0px); } to { transform: translateX(64px); } }
+    #dot { animation: travel 1s linear both paused; }
+  </style>
+  <rect width="96" height="48" rx="8" fill="#0f172a"/>
+  <circle id="dot" cx="16" cy="24" r="10" fill="#f97316"/>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-smil-seek.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-smil-seek.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="48" viewBox="0 0 96 48">
+  <rect width="96" height="48" rx="8" fill="#0f172a"/>
+  <circle cx="16" cy="24" r="10" fill="#38bdf8">
+    <animate attributeName="cx" from="16" to="80" dur="1s" fill="freeze"/>
+  </circle>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/manifest.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/manifest.ts
@@ -1,0 +1,235 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import type { RgbaTolerance } from "../visual-tests/rgba-compare";
+
+const ANIMATION_TESTS_DIR = __dirname;
+export const ANIMATION_FIXTURES_DIR = resolve(ANIMATION_TESTS_DIR, "fixtures");
+export const ANIMATION_MANIFEST_PATH = resolve(ANIMATION_TESTS_DIR, "animation-fixture-manifest.json");
+
+export type AnimationFixtureMode = "comparison" | "reference-probe";
+export type ExpectedOutputMode = "shape" | "view";
+export type AnimationReferenceBackend = "webkit";
+
+function validateBackground(value: string | null): void {
+  if (value !== null && !/^#([\da-f]{6}|[\da-f]{8})$/i.test(value))
+    throw new Error(`Background must be null, #RRGGBB, or #RRGGBBAA: ${value}`);
+}
+
+export interface AnimationTimeline {
+  durationMicroseconds: number;
+  framesPerSecond: number;
+  sampleTimesMicroseconds?: number[];
+  includeEndFrame?: boolean;
+}
+
+interface RawAnimationFixture {
+  mode: AnimationFixtureMode;
+  referenceBackend: AnimationReferenceBackend;
+  width: number;
+  height: number;
+  scale?: number;
+  background?: string | null;
+  fonts?: string[];
+  fontFamilies?: string[];
+  expectedMode?: ExpectedOutputMode;
+  tags: string[];
+  timeline: AnimationTimeline;
+  expectDistinctReferenceFrames?: boolean;
+  tolerance?: Partial<RgbaTolerance>;
+  toleranceReason?: string;
+}
+
+interface AnimationManifestFile {
+  version: 1;
+  defaults: {
+    scale: number;
+    background: string | null;
+    fonts: string[];
+    fontFamilies?: string[];
+    tolerance: RgbaTolerance;
+  };
+  fixtures: Record<string, RawAnimationFixture>;
+}
+
+export interface AnimationFrame {
+  index: number;
+  timeMicroseconds: number;
+  stem: string;
+}
+
+export interface LoadedAnimationFixture {
+  name: string;
+  relativePath: string;
+  sourcePath: string;
+  mode: AnimationFixtureMode;
+  referenceBackend: AnimationReferenceBackend;
+  width: number;
+  height: number;
+  scale: number;
+  background: string | null;
+  fonts: string[];
+  fontFamilies: string[];
+  expectedMode?: ExpectedOutputMode;
+  tags: string[];
+  timeline: AnimationTimeline;
+  frames: AnimationFrame[];
+  expectDistinctReferenceFrames: boolean;
+  tolerance: RgbaTolerance;
+  toleranceReason?: string;
+}
+
+function findSvgFiles(directory = ANIMATION_FIXTURES_DIR): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) files.push(...findSvgFiles(path));
+    else if (entry.isFile() && entry.name.endsWith(".svg")) files.push(path);
+  }
+  return files.sort();
+}
+
+function fixtureKey(path: string): string {
+  return relative(ANIMATION_FIXTURES_DIR, path)
+    .replace(/\\/g, "/")
+    .replace(/\.svg$/, "");
+}
+
+export function animationFrameStem(index: number, timeMicroseconds: number): string {
+  return `${String(index).padStart(6, "0")}-${String(timeMicroseconds).padStart(15, "0")}`;
+}
+
+export function timelineFrames(timeline: AnimationTimeline): AnimationFrame[] {
+  const explicit = timeline.sampleTimesMicroseconds;
+  const times = explicit
+    ? [...explicit]
+    : Array.from(
+        {
+          length:
+            Math.floor((timeline.durationMicroseconds * timeline.framesPerSecond) / 1_000_000) +
+            (timeline.includeEndFrame ? 1 : 0),
+        },
+        (_, index) => Math.floor((index * 1_000_000) / timeline.framesPerSecond),
+      );
+  return times.map((timeMicroseconds, index) => ({
+    index,
+    timeMicroseconds,
+    stem: animationFrameStem(index, timeMicroseconds),
+  }));
+}
+
+function readManifest(): AnimationManifestFile {
+  return JSON.parse(readFileSync(ANIMATION_MANIFEST_PATH, "utf8")) as AnimationManifestFile;
+}
+
+export function loadAnimationFixtures(): LoadedAnimationFixture[] {
+  const manifest = readManifest();
+  if (manifest.version !== 1) throw new Error(`Unsupported animation fixture manifest version: ${manifest.version}`);
+  return Object.entries(manifest.fixtures)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, entry]) => ({
+      name,
+      relativePath: `${name}.svg`,
+      sourcePath: resolve(ANIMATION_FIXTURES_DIR, `${name}.svg`),
+      mode: entry.mode,
+      referenceBackend: entry.referenceBackend,
+      width: entry.width,
+      height: entry.height,
+      scale: entry.scale ?? manifest.defaults.scale,
+      background: entry.background === undefined ? manifest.defaults.background : entry.background,
+      fonts: entry.fonts ?? manifest.defaults.fonts,
+      fontFamilies: entry.fontFamilies ?? manifest.defaults.fontFamilies ?? [],
+      ...(entry.expectedMode ? { expectedMode: entry.expectedMode } : {}),
+      tags: entry.tags,
+      timeline: entry.timeline,
+      frames: timelineFrames(entry.timeline),
+      expectDistinctReferenceFrames: entry.expectDistinctReferenceFrames ?? false,
+      tolerance: { ...manifest.defaults.tolerance, ...entry.tolerance },
+      ...(entry.toleranceReason ? { toleranceReason: entry.toleranceReason } : {}),
+    }));
+}
+
+function validPositiveInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+export function validateAnimationManifest(): string[] {
+  const errors: string[] = [];
+  let manifest: AnimationManifestFile;
+  let fixtures: LoadedAnimationFixture[];
+  try {
+    manifest = readManifest();
+    fixtures = loadAnimationFixtures();
+  } catch (error) {
+    return [error instanceof Error ? error.message : String(error)];
+  }
+
+  const actual = new Set(findSvgFiles().map(fixtureKey));
+  const declared = new Set(fixtures.map((fixture) => fixture.name));
+  for (const name of actual)
+    if (!declared.has(name)) errors.push(`Animation fixture missing from manifest: ${name}.svg`);
+  for (const name of declared) if (!actual.has(name)) errors.push(`Animation manifest entry has no SVG: ${name}.svg`);
+
+  for (const fixture of fixtures) {
+    const prefix = `${fixture.name}:`;
+    const raw = manifest.fixtures[fixture.name]!;
+    if (!Number.isFinite(fixture.width) || fixture.width <= 0) errors.push(`${prefix} width must be positive`);
+    if (!Number.isFinite(fixture.height) || fixture.height <= 0) errors.push(`${prefix} height must be positive`);
+    if (!Number.isFinite(fixture.scale) || fixture.scale <= 0) errors.push(`${prefix} scale must be positive`);
+    if (!validPositiveInteger(fixture.timeline.durationMicroseconds))
+      errors.push(`${prefix} durationMicroseconds must be a positive safe integer`);
+    if (!validPositiveInteger(fixture.timeline.framesPerSecond))
+      errors.push(`${prefix} framesPerSecond must be a positive safe integer`);
+    if (fixture.timeline.framesPerSecond > 240) errors.push(`${prefix} framesPerSecond must not exceed 240`);
+    if (fixture.frames.length === 0) errors.push(`${prefix} timeline must produce at least one frame`);
+    if (fixture.frames.length > 10_000) errors.push(`${prefix} timeline must not exceed 10,000 frames`);
+    const times = fixture.frames.map((frame) => frame.timeMicroseconds);
+    if (times.some((time) => !Number.isSafeInteger(time) || time < 0))
+      errors.push(`${prefix} sample times must be non-negative safe integer microseconds`);
+    if (new Set(times).size !== times.length) errors.push(`${prefix} sample times must be unique`);
+    if (times.some((time, index) => index > 0 && time <= times[index - 1]!))
+      errors.push(`${prefix} sample times must be strictly increasing`);
+    if (times.some((time) => time > fixture.timeline.durationMicroseconds))
+      errors.push(`${prefix} sample times must not exceed durationMicroseconds`);
+    if (fixture.mode === "comparison" && !fixture.expectedMode)
+      errors.push(`${prefix} comparison fixtures require expectedMode`);
+    if (fixture.mode === "reference-probe" && fixture.expectedMode)
+      errors.push(`${prefix} reference probes must not declare expectedMode`);
+    if (fixture.referenceBackend !== "webkit") errors.push(`${prefix} referenceBackend must be webkit`);
+    if (fixture.expectDistinctReferenceFrames && fixture.frames.length < 2)
+      errors.push(`${prefix} distinct-frame probes require at least two frames`);
+    if (fixture.tags.length === 0) errors.push(`${prefix} at least one feature tag is required`);
+    if (new Set(fixture.tags).size !== fixture.tags.length) errors.push(`${prefix} feature tags must be unique`);
+    if (raw.tolerance && !raw.toleranceReason)
+      errors.push(`${prefix} tolerance overrides require a narrow justification`);
+    if (raw.toleranceReason && !raw.tolerance) errors.push(`${prefix} toleranceReason requires an override`);
+    try {
+      validateBackground(fixture.background);
+    } catch (error) {
+      errors.push(`${prefix} ${error instanceof Error ? error.message : String(error)}`);
+    }
+    for (const font of fixture.fonts) {
+      const fontPath = resolve(ANIMATION_TESTS_DIR, font);
+      if (!fontPath.startsWith(ANIMATION_TESTS_DIR) || !existsSync(fontPath))
+        errors.push(`${prefix} deterministic font does not exist: ${font}`);
+    }
+    if (fixture.fonts.length > 0 && fixture.fontFamilies.length === 0)
+      errors.push(`${prefix} deterministic fonts require at least one fontFamilies entry`);
+    if (!existsSync(fixture.sourcePath)) continue;
+    const source = readFileSync(fixture.sourcePath, "utf8");
+    if (/<script\b/i.test(source)) errors.push(`${prefix} authored scripts are forbidden in animation fixtures`);
+    if (/<(?:audio|video|iframe|object|embed|canvas)\b/i.test(source))
+      errors.push(`${prefix} active media and embedded browsing content are forbidden`);
+    if (/\son[a-z]+\s*=/i.test(source)) errors.push(`${prefix} authored event handlers are forbidden`);
+    if (/\b(?:href|src)\s*=\s*["']https?:\/\//i.test(source) || /url\(\s*["']?https?:\/\//i.test(source))
+      errors.push(`${prefix} network resources are forbidden`);
+    if (/@import\s+(?:url\(\s*)?["']?https?:\/\//i.test(source))
+      errors.push(`${prefix} network stylesheet imports are forbidden`);
+    for (const match of source.matchAll(/<(?:image|feImage)\b[^>]*\b(?:href|xlink:href)\s*=\s*["']([^"']+)["']/gi)) {
+      const href = match[1]!;
+      if (/^(?:data:|#)/i.test(href)) continue;
+      if (!existsSync(resolve(dirname(fixture.sourcePath), href)))
+        errors.push(`${prefix} local image resource does not exist: ${href}`);
+    }
+  }
+  return errors;
+}

--- a/packages/svg-to-swiftui-core/animation-tests/run-animation-tests.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/run-animation-tests.ts
@@ -1,0 +1,553 @@
+#!/usr/bin/env bun
+/** Deterministic SVG animation conformance runner: seek, compile, render, and compare lossless RGBA frames. */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { PNG } from "pngjs";
+import { convertAsync } from "../src/index";
+import type { ResolvedResource } from "../src/types";
+import { outputMode, withPixelViewport } from "../visual-tests/manifest";
+import { type AnimationBatchItem, type AnimationFrameResult, runAnimationBatch } from "./batch-render";
+import {
+  ANIMATION_FIXTURES_DIR,
+  type LoadedAnimationFixture,
+  loadAnimationFixtures,
+  validateAnimationManifest,
+} from "./manifest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = resolve(__dirname, "../../..");
+const RENDERS_DIR = resolve(__dirname, "renders");
+const CACHE_DIR = resolve(RENDERS_DIR, ".cache");
+const REFERENCE_CACHE_PATH = resolve(RENDERS_DIR, ".reference-frame-cache.json");
+const REFERENCE_RENDERER_SOURCE = resolve(__dirname, "webkit-animation-reference.swift");
+const REFERENCE_RENDERER_BINARY = resolve(CACHE_DIR, "webkit-animation-reference");
+const REFERENCE_RENDERER_VERSION = "webkit-explicit-smil-wa-time-v1";
+const VIDEO_ENCODER_SOURCE = resolve(__dirname, "video-encoder.swift");
+const VIDEO_ENCODER_BINARY = resolve(CACHE_DIR, "animation-video-encoder");
+
+interface ReferenceCacheEntry {
+  hash: string;
+}
+
+function hash(...values: (string | Buffer)[]): string {
+  const digest = createHash("sha256");
+  for (const value of values) digest.update(value);
+  return digest.digest("hex");
+}
+
+function resourceMime(path: string): string | undefined {
+  const extension = path.split(/[?#]/, 1)[0]!.split(".").pop()?.toLowerCase();
+  return extension === "png"
+    ? "image/png"
+    : extension === "jpg" || extension === "jpeg"
+      ? "image/jpeg"
+      : extension === "webp"
+        ? "image/webp"
+        : extension === "gif"
+          ? "image/gif"
+          : extension === "svg"
+            ? "image/svg+xml"
+            : extension === "ttf"
+              ? "font/ttf"
+              : extension === "otf"
+                ? "font/otf"
+                : extension === "woff"
+                  ? "font/woff"
+                  : extension === "woff2"
+                    ? "font/woff2"
+                    : undefined;
+}
+
+function collectFixtureResources(
+  source: string,
+  sourceURL: URL,
+): { supplied: Record<string, ResolvedResource>; bytes: Buffer[] } {
+  const supplied: Record<string, ResolvedResource> = {};
+  const bytes: Buffer[] = [];
+  const visited = new Set<string>();
+  const visit = (document: string, documentURL: URL): void => {
+    for (const match of document.matchAll(/<(?:image|feImage)\b[^>]*\b(?:href|xlink:href)\s*=\s*["']([^"']+)["']/gi)) {
+      const href = match[1]!;
+      if (/^(?:data:|#)/i.test(href)) continue;
+      const resourceURL = new URL(href, documentURL);
+      const resourceBytes = readFileSync(fileURLToPath(resourceURL));
+      const resource: ResolvedResource = {
+        bytes: Uint8Array.from(resourceBytes),
+        mimeType: resourceMime(resourceURL.pathname),
+        canonicalURL: resourceURL.href,
+      };
+      supplied[href] ??= resource;
+      supplied[resourceURL.href] = resource;
+      if (visited.has(resourceURL.href)) continue;
+      visited.add(resourceURL.href);
+      bytes.push(resourceBytes);
+      if (resource.mimeType === "image/svg+xml") visit(resourceBytes.toString("utf8"), resourceURL);
+    }
+  };
+  visit(source, sourceURL);
+  return { supplied, bytes };
+}
+
+function inlineFixtureImages(source: string, sourceURL: URL): string {
+  return source.replace(
+    /(<(?:image|feImage)\b[^>]*\b(?:href|xlink:href)\s*=\s*)(["'])([^"']+)\2/gi,
+    (match, prefix: string, quote: string, href: string) => {
+      if (/^(?:data:|#|https?:)/i.test(href)) return match;
+      const resourceURL = new URL(href, sourceURL);
+      const mimeType = resourceMime(resourceURL.pathname);
+      if (!mimeType) return match;
+      let bytes = readFileSync(fileURLToPath(resourceURL));
+      if (mimeType === "image/svg+xml")
+        bytes = Buffer.from(inlineFixtureImages(bytes.toString("utf8"), resourceURL), "utf8");
+      return `${prefix}${quote}data:${mimeType};base64,${bytes.toString("base64")}${quote}`;
+    },
+  );
+}
+
+function inlineFixtureFonts(source: string, fixture: LoadedAnimationFixture): string {
+  if (fixture.fonts.length === 0) return source;
+  const rules = fixture.fonts.map((font, index) => {
+    const path = resolve(__dirname, font);
+    const mime = resourceMime(path);
+    const family = (
+      fixture.fontFamilies[index] ??
+      fixture.fontFamilies[0] ??
+      `AnimationFixtureFont${index}`
+    ).replaceAll("'", "\\'");
+    return `@font-face{font-family:'${family}';src:url(data:${mime};base64,${readFileSync(path).toString("base64")})}`;
+  });
+  return source.replace(/<svg\b([^>]*)>/i, (match) => `${match}<style>${rules.join("")}</style>`);
+}
+
+function optionValue(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function changedFixtureNames(): Set<string> {
+  const paths = new Set<string>();
+  for (const args of [
+    ["diff", "--name-only", "origin/main...HEAD"],
+    ["diff", "--name-only", "HEAD"],
+    ["ls-files", "--others", "--exclude-standard"],
+  ]) {
+    try {
+      const output = execFileSync("git", args, { cwd: REPOSITORY_ROOT, encoding: "utf8" });
+      for (const line of output.split("\n")) if (line.trim()) paths.add(line.trim());
+    } catch {}
+  }
+  const fixturePrefix = relative(REPOSITORY_ROOT, ANIMATION_FIXTURES_DIR).replaceAll("\\", "/");
+  return new Set(
+    [...paths]
+      .map((path) => path.replaceAll("\\", "/"))
+      .filter((path) => path.startsWith(`${fixturePrefix}/`) && path.endsWith(".svg"))
+      .map((path) => path.slice(fixturePrefix.length + 1, -4)),
+  );
+}
+
+function ensureReferenceRenderer(): void {
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const source = readFileSync(REFERENCE_RENDERER_SOURCE);
+  const stampPath = `${REFERENCE_RENDERER_BINARY}.sha256`;
+  const expectedHash = hash(REFERENCE_RENDERER_VERSION, source);
+  let actualHash = "";
+  try {
+    actualHash = readFileSync(stampPath, "utf8");
+  } catch {}
+  if (existsSync(REFERENCE_RENDERER_BINARY) && actualHash === expectedHash) return;
+  execFileSync(
+    "xcrun",
+    [
+      "swiftc",
+      "-module-cache-path",
+      resolve(CACHE_DIR, "module-cache"),
+      REFERENCE_RENDERER_SOURCE,
+      "-framework",
+      "WebKit",
+      "-framework",
+      "AppKit",
+      "-o",
+      REFERENCE_RENDERER_BINARY,
+    ],
+    { stdio: "pipe" },
+  );
+  writeFileSync(stampPath, expectedHash);
+}
+
+function ensureVideoEncoder(): void {
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const source = readFileSync(VIDEO_ENCODER_SOURCE);
+  const stampPath = `${VIDEO_ENCODER_BINARY}.sha256`;
+  const expectedHash = hash("animation-review-video-v1", source);
+  let actualHash = "";
+  try {
+    actualHash = readFileSync(stampPath, "utf8");
+  } catch {}
+  if (existsSync(VIDEO_ENCODER_BINARY) && actualHash === expectedHash) return;
+  execFileSync(
+    "xcrun",
+    [
+      "swiftc",
+      "-module-cache-path",
+      resolve(CACHE_DIR, "module-cache"),
+      VIDEO_ENCODER_SOURCE,
+      "-framework",
+      "AVFoundation",
+      "-framework",
+      "AppKit",
+      "-o",
+      VIDEO_ENCODER_BINARY,
+    ],
+    { stdio: "pipe" },
+  );
+  writeFileSync(stampPath, expectedHash);
+}
+
+function referencePath(fixture: LoadedAnimationFixture, stem: string): string {
+  return resolve(RENDERS_DIR, fixture.name, "frames", `${stem}-svg.png`);
+}
+
+function sourceWithBackground(source: string, fixture: LoadedAnimationFixture): string {
+  const sized = withPixelViewport(source, fixture.width, fixture.height);
+  if (!fixture.background) return sized;
+  return sized.replace(/<svg\b([^>]*)>/i, (match) => `${match}<style>:root{background:${fixture.background}}</style>`);
+}
+
+function renderReferenceFrames(fixture: LoadedAnimationFixture, source: string): void {
+  ensureReferenceRenderer();
+  const fixtureDirectory = resolve(RENDERS_DIR, fixture.name);
+  const framesDirectory = resolve(fixtureDirectory, "frames");
+  mkdirSync(framesDirectory, { recursive: true });
+  const inputPath = resolve(CACHE_DIR, `${fixture.name}-${hash(source).slice(0, 12)}.svg`);
+  const taskPath = resolve(CACHE_DIR, `${fixture.name}-reference-task.json`);
+  writeFileSync(inputPath, sourceWithBackground(source, fixture));
+  writeFileSync(
+    taskPath,
+    JSON.stringify({
+      input: inputPath,
+      width: fixture.width,
+      height: fixture.height,
+      pixelWidth: Math.round(fixture.width * fixture.scale),
+      pixelHeight: Math.round(fixture.height * fixture.scale),
+      frames: fixture.frames.map((frame) => ({
+        timeMicroseconds: frame.timeMicroseconds,
+        output: referencePath(fixture, frame.stem),
+      })),
+    }),
+  );
+  execFileSync(REFERENCE_RENDERER_BINARY, [taskPath], { stdio: "pipe", timeout: 120_000 });
+}
+
+function verifyDistinctReferenceFrames(fixture: LoadedAnimationFixture): void {
+  if (!fixture.expectDistinctReferenceFrames) return;
+  const hashes = fixture.frames.map((frame) => hash(readFileSync(referencePath(fixture, frame.stem))));
+  if (new Set(hashes).size !== hashes.length)
+    throw new Error(
+      `Reference seek probe produced only ${new Set(hashes).size}/${hashes.length} distinct frame hashes`,
+    );
+}
+
+function reviewSequence(fixture: LoadedAnimationFixture, paths: string[]): string[] {
+  const videoFrameCount = Math.max(
+    1,
+    Math.round((fixture.timeline.durationMicroseconds * fixture.timeline.framesPerSecond) / 1_000_000),
+  );
+  return Array.from({ length: videoFrameCount + 1 }, (_, index) => {
+    const time = Math.min(
+      fixture.timeline.durationMicroseconds,
+      Math.floor((index * 1_000_000) / fixture.timeline.framesPerSecond),
+    );
+    let nearest = 0;
+    for (let frame = 1; frame < fixture.frames.length; frame++) {
+      if (
+        Math.abs(fixture.frames[frame]!.timeMicroseconds - time) <
+        Math.abs(fixture.frames[nearest]!.timeMicroseconds - time)
+      )
+        nearest = frame;
+    }
+    return paths[nearest]!;
+  });
+}
+
+function encodeReviewVideo(
+  output: string,
+  width: number,
+  height: number,
+  framesPerSecond: number,
+  frames: string[],
+): void {
+  ensureVideoEncoder();
+  const taskPath = resolve(CACHE_DIR, `${hash(output).slice(0, 12)}-video-task.json`);
+  writeFileSync(taskPath, JSON.stringify({ output, width, height, framesPerSecond, frames }));
+  execFileSync(VIDEO_ENCODER_BINARY, [taskPath], { stdio: "pipe", timeout: 120_000 });
+}
+
+function sideBySideFrame(reference: string, swift: string, output: string): void {
+  const left = PNG.sync.read(readFileSync(reference));
+  const right = PNG.sync.read(readFileSync(swift));
+  if (left.width !== right.width || left.height !== right.height)
+    throw new Error(`Cannot compose review frame with mismatched dimensions: ${reference} and ${swift}`);
+  const gap = 8;
+  const result = new PNG({ width: left.width * 2 + gap, height: left.height });
+  result.data.fill(255);
+  PNG.bitblt(left, result, 0, 0, left.width, left.height, 0, 0);
+  PNG.bitblt(right, result, 0, 0, right.width, right.height, left.width + gap, 0);
+  writeFileSync(output, PNG.sync.write(result));
+}
+
+function generateReviewVideos(fixtures: LoadedAnimationFixture[], comparisonItems: AnimationBatchItem[]): void {
+  const compared = new Map(comparisonItems.map((item) => [item.name, item]));
+  for (const fixture of fixtures) {
+    const fixtureDirectory = resolve(RENDERS_DIR, fixture.name);
+    const pixelWidth = Math.round(fixture.width * fixture.scale);
+    const pixelHeight = Math.round(fixture.height * fixture.scale);
+    const references = fixture.frames.map((frame) => referencePath(fixture, frame.stem));
+    encodeReviewVideo(
+      resolve(fixtureDirectory, "reference.mp4"),
+      pixelWidth,
+      pixelHeight,
+      fixture.timeline.framesPerSecond,
+      reviewSequence(fixture, references),
+    );
+    const item = compared.get(fixture.name);
+    if (!item) continue;
+    const swiftFrames = fixture.frames.map((frame) => resolve(fixtureDirectory, "frames", `${frame.stem}-swift.png`));
+    encodeReviewVideo(
+      resolve(fixtureDirectory, "swiftui.mp4"),
+      pixelWidth,
+      pixelHeight,
+      fixture.timeline.framesPerSecond,
+      reviewSequence(fixture, swiftFrames),
+    );
+    const sideBySide = fixture.frames.map((frame, index) => {
+      const output = resolve(fixtureDirectory, "frames", `${frame.stem}-side-by-side.png`);
+      sideBySideFrame(references[index]!, swiftFrames[index]!, output);
+      return output;
+    });
+    encodeReviewVideo(
+      resolve(fixtureDirectory, "side-by-side.mp4"),
+      pixelWidth * 2 + 8,
+      pixelHeight,
+      fixture.timeline.framesPerSecond,
+      reviewSequence(fixture, sideBySide),
+    );
+  }
+}
+
+function formatMetrics(result: AnimationFrameResult): string {
+  if (!result.metrics) return result.error ?? "unknown error";
+  return [
+    `outside=${result.metrics.outsidePercent.toFixed(3)}%`,
+    `meanRGB=${result.metrics.meanRgbError.toFixed(3)}`,
+    `meanA=${result.metrics.meanAlphaError.toFixed(3)}`,
+    `max=${result.metrics.maxChannelError}`,
+  ].join(" ");
+}
+
+function worstFrame(
+  results: AnimationFrameResult[],
+  value: (result: AnimationFrameResult) => number | undefined,
+): AnimationFrameResult | undefined {
+  let worst: AnimationFrameResult | undefined;
+  let worstValue = Number.NEGATIVE_INFINITY;
+  for (const result of results) {
+    const candidate = value(result);
+    if (candidate !== undefined && candidate > worstValue) {
+      worst = result;
+      worstValue = candidate;
+    }
+  }
+  return worst;
+}
+
+function frameSummary(result: AnimationFrameResult | undefined): object | null {
+  return result
+    ? {
+        fixture: result.fixture,
+        frameIndex: result.frameIndex,
+        timeMicroseconds: result.timeMicroseconds,
+        metrics: result.metrics,
+      }
+    : null;
+}
+
+async function main(): Promise<void> {
+  const manifestErrors = validateAnimationManifest();
+  if (manifestErrors.length > 0) {
+    console.error(`Animation fixture manifest failed with ${manifestErrors.length} error(s):`);
+    for (const error of manifestErrors) console.error(`  - ${error}`);
+    process.exit(1);
+  }
+
+  const fresh = process.argv.includes("--fresh");
+  const videos = process.argv.includes("--videos");
+  const requestedFixture = optionValue("--fixture");
+  const requestedTag = optionValue("--tag");
+  const changed = process.argv.includes("--changed") ? changedFixtureNames() : undefined;
+  const fixtures = loadAnimationFixtures().filter(
+    (fixture) =>
+      (!requestedFixture || fixture.name.includes(requestedFixture)) &&
+      (!requestedTag || fixture.tags.includes(requestedTag)) &&
+      (!changed || changed.has(fixture.name)),
+  );
+  if (fixtures.length === 0) {
+    console.error("No animation fixtures matched the requested fixture/tag/changed filters.");
+    process.exit(1);
+  }
+  const frameCount = fixtures.reduce((total, fixture) => total + fixture.frames.length, 0);
+  if (process.platform !== "darwin") {
+    console.log(
+      `Animation manifest valid (${fixtures.length} fixtures, ${frameCount} frames selected); rendering requires macOS.`,
+    );
+    return;
+  }
+
+  mkdirSync(RENDERS_DIR, { recursive: true });
+  let referenceCache: Record<string, ReferenceCacheEntry> = {};
+  try {
+    referenceCache = JSON.parse(readFileSync(REFERENCE_CACHE_PATH, "utf8"));
+  } catch {}
+
+  console.log(`Processing ${fixtures.length} animation fixture(s), ${frameCount} exact frame time(s)...`);
+  const comparisonItems: AnimationBatchItem[] = [];
+  const preparationErrors: { fixture: string; error: string }[] = [];
+  let referenceProbesPassed = 0;
+  for (const fixture of fixtures) {
+    try {
+      const source = readFileSync(fixture.sourcePath, "utf8");
+      const sourceURL = pathToFileURL(fixture.sourcePath);
+      const fixtureResources = collectFixtureResources(source, sourceURL);
+      const referenceSource = inlineFixtureFonts(inlineFixtureImages(source, sourceURL), fixture);
+      const referenceHash = hash(
+        REFERENCE_RENDERER_VERSION,
+        readFileSync(REFERENCE_RENDERER_SOURCE),
+        source,
+        JSON.stringify({
+          width: fixture.width,
+          height: fixture.height,
+          scale: fixture.scale,
+          background: fixture.background,
+          referenceBackend: fixture.referenceBackend,
+          frames: fixture.frames,
+        }),
+        ...fixture.fonts.map((font) => readFileSync(resolve(__dirname, font))),
+        ...fixtureResources.bytes,
+      );
+      const allFramesExist = fixture.frames.every((frame) => existsSync(referencePath(fixture, frame.stem)));
+      if (fresh || referenceCache[fixture.name]?.hash !== referenceHash || !allFramesExist) {
+        renderReferenceFrames(fixture, referenceSource);
+        referenceCache[fixture.name] = { hash: referenceHash };
+      }
+      verifyDistinctReferenceFrames(fixture);
+      if (fixture.mode === "reference-probe") referenceProbesPassed++;
+
+      if (fixture.mode === "comparison") {
+        const expectedMode = fixture.expectedMode!;
+        const swiftTypeName = `AnimationFixture${comparisonItems.length}`;
+        const swiftCode = await convertAsync(source, {
+          structName: swiftTypeName,
+          precision: 5,
+          preserveColors: expectedMode === "view",
+          fonts: {
+            availableFamilies: fixture.fontFamilies,
+            fallbackFamily: fixture.fontFamilies[0] ?? "Helvetica",
+          },
+          resources: {
+            baseURL: sourceURL.href,
+            supplied: fixtureResources.supplied,
+          },
+        });
+        const actualMode = outputMode(swiftCode);
+        if (actualMode !== expectedMode)
+          throw new Error(`Manifest expects ${expectedMode}; converter generated ${actualMode ?? "unknown"}`);
+        comparisonItems.push({
+          name: fixture.name,
+          swiftCode,
+          swiftTypeName,
+          width: fixture.width,
+          height: fixture.height,
+          scale: fixture.scale,
+          background: fixture.background,
+          fonts: fixture.fonts,
+          expectedMode,
+          tolerance: fixture.tolerance,
+          frames: fixture.frames.map((frame) => ({
+            ...frame,
+            referencePath: referencePath(fixture, frame.stem),
+          })),
+        });
+      }
+    } catch (error) {
+      preparationErrors.push({ fixture: fixture.name, error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+  writeFileSync(REFERENCE_CACHE_PATH, JSON.stringify(referenceCache, null, 2));
+
+  const results = await runAnimationBatch(comparisonItems, RENDERS_DIR, fresh);
+  if (videos && preparationErrors.length === 0 && results.every((result) => result.status === "pass")) {
+    console.log("  Encoding review-only MP4 artifacts...");
+    generateReviewVideos(fixtures, comparisonItems);
+  }
+  const failures = results.filter((result) => result.status !== "pass");
+  if (preparationErrors.length > 0 || failures.length > 0) {
+    console.log("\nFailures:");
+    for (const failure of preparationErrors) console.log(`  [ERR ] ${failure.fixture}: ${failure.error}`);
+    for (const result of failures) {
+      console.log(
+        `  [${result.status === "fail" ? "FAIL" : "ERR "}] ${result.fixture} frame ${result.frameIndex} ` +
+          `at ${result.timeMicroseconds}us: ${formatMetrics(result)}`,
+      );
+      console.log(`         reference: ${result.referencePath}`);
+      console.log(`         SwiftUI:   ${result.swiftPath}`);
+      console.log(`         diff:      ${result.diffPath}`);
+    }
+  }
+
+  const worstFrames = {
+    outsidePercent: worstFrame(results, (result) => result.metrics?.outsidePercent),
+    meanRgbError: worstFrame(results, (result) => result.metrics?.meanRgbError),
+    meanAlphaError: worstFrame(results, (result) => result.metrics?.meanAlphaError),
+    maxChannelError: worstFrame(results, (result) => result.metrics?.maxChannelError),
+  };
+  const passed = results.filter((result) => result.status === "pass").length;
+  const failed = results.filter((result) => result.status === "fail").length;
+  const errors = results.filter((result) => result.status === "error").length + preparationErrors.length;
+  writeFileSync(
+    resolve(RENDERS_DIR, "summary.json"),
+    JSON.stringify(
+      {
+        comparison: "lossless-frame-sequence-premultiplied-srgb-rgba",
+        fixtureCount: fixtures.length,
+        selectedFrameCount: frameCount,
+        comparedFrameCount: results.length,
+        passed,
+        failed,
+        errors,
+        worstFrames: Object.fromEntries(
+          Object.entries(worstFrames).map(([metric, result]) => [metric, frameSummary(result)]),
+        ),
+        preparationErrors,
+        results,
+      },
+      null,
+      2,
+    ),
+  );
+
+  console.log("\n---");
+  console.log(`Reference probes: ${referenceProbesPassed} passed`);
+  console.log(`Compared frames: ${passed} passed, ${failed} failed, ${errors} errors`);
+  if (worstFrames.outsidePercent)
+    console.log(
+      `Worst frame: ${worstFrames.outsidePercent.fixture} #${worstFrames.outsidePercent.frameIndex} ` +
+        `at ${worstFrames.outsidePercent.timeMicroseconds}us (${formatMetrics(worstFrames.outsidePercent)})`,
+    );
+  console.log("Oracle: lossless premultiplied-sRGB RGBA frames; encoded video is review-only");
+  console.log(`Artifacts: ${RENDERS_DIR}`);
+  if (failed > 0 || errors > 0) process.exit(1);
+}
+
+main();

--- a/packages/svg-to-swiftui-core/animation-tests/verify-manifest.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/verify-manifest.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { convert } from "../src/index";
+import { outputMode } from "../visual-tests/manifest";
+import { loadAnimationFixtures, validateAnimationManifest } from "./manifest";
+
+export function verifyAnimationFixtureManifest(): string[] {
+  const errors = validateAnimationManifest();
+  if (errors.length > 0) return errors;
+  for (const [index, fixture] of loadAnimationFixtures().entries()) {
+    if (fixture.mode !== "comparison") continue;
+    try {
+      const swift = convert(readFileSync(fixture.sourcePath, "utf8"), {
+        structName: `AnimationManifestFixture${index}`,
+        precision: 5,
+        preserveColors: fixture.expectedMode === "view",
+      });
+      const actualMode = outputMode(swift);
+      if (actualMode !== fixture.expectedMode)
+        errors.push(`${fixture.name}: expected ${fixture.expectedMode}, generated ${actualMode ?? "unknown"}`);
+    } catch (error) {
+      errors.push(`${fixture.name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return errors;
+}
+
+if (import.meta.main) {
+  const errors = verifyAnimationFixtureManifest();
+  if (errors.length > 0) {
+    console.error(`Animation fixture manifest failed with ${errors.length} error(s):`);
+    for (const error of errors) console.error(`  - ${error}`);
+    process.exit(1);
+  }
+  const fixtures = loadAnimationFixtures();
+  const frames = fixtures.reduce((total, fixture) => total + fixture.frames.length, 0);
+  console.log(`Animation fixture manifest valid: ${fixtures.length} fixtures, ${frames} deterministic frames.`);
+}

--- a/packages/svg-to-swiftui-core/animation-tests/video-encoder.swift
+++ b/packages/svg-to-swiftui-core/animation-tests/video-encoder.swift
@@ -1,0 +1,126 @@
+import AppKit
+import AVFoundation
+import CoreVideo
+
+struct VideoTask: Decodable {
+    let output: String
+    let width: Int
+    let height: Int
+    let framesPerSecond: Int32
+    let frames: [String]
+}
+enum VideoEncodingError: Error, CustomStringConvertible {
+    case invalidTask
+    case image(String)
+    case pixelBuffer
+    case append(Int)
+    case writer(String)
+
+    var description: String {
+        switch self {
+        case .invalidTask: return "Video task has invalid dimensions, frame rate, or no frames"
+        case .image(let path): return "Could not decode review frame: \(path)"
+        case .pixelBuffer: return "Could not allocate the review-video pixel buffer"
+        case .append(let index): return "Could not append review-video frame \(index)"
+        case .writer(let message): return "Review-video writer failed: \(message)"
+        }
+    }
+}
+
+func pixelBuffer(path: String, width: Int, height: Int, pool: CVPixelBufferPool?) throws -> CVPixelBuffer {
+    guard let image = NSImage(contentsOfFile: path),
+          let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+        throw VideoEncodingError.image(path)
+    }
+    var optionalBuffer: CVPixelBuffer?
+    let status = pool.map { CVPixelBufferPoolCreatePixelBuffer(nil, $0, &optionalBuffer) }
+        ?? CVPixelBufferCreate(
+            nil,
+            width,
+            height,
+            kCVPixelFormatType_32BGRA,
+            [kCVPixelBufferCGImageCompatibilityKey: true, kCVPixelBufferCGBitmapContextCompatibilityKey: true] as CFDictionary,
+            &optionalBuffer
+        )
+    guard status == kCVReturnSuccess, let buffer = optionalBuffer else { throw VideoEncodingError.pixelBuffer }
+    CVPixelBufferLockBaseAddress(buffer, [])
+    defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+    guard let context = CGContext(
+        data: CVPixelBufferGetBaseAddress(buffer),
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: CVPixelBufferGetBytesPerRow(buffer),
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+    ) else { throw VideoEncodingError.pixelBuffer }
+    context.setFillColor(NSColor.white.cgColor)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    context.interpolationQuality = .high
+    context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+    return buffer
+}
+
+func encode(_ task: VideoTask) throws {
+    guard task.width > 0, task.height > 0, task.framesPerSecond > 0, !task.frames.isEmpty else {
+        throw VideoEncodingError.invalidTask
+    }
+    let output = URL(fileURLWithPath: task.output)
+    try? FileManager.default.removeItem(at: output)
+    let writer = try AVAssetWriter(outputURL: output, fileType: .mp4)
+    let input = AVAssetWriterInput(
+        mediaType: .video,
+        outputSettings: [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: task.width,
+            AVVideoHeightKey: task.height,
+        ]
+    )
+    input.expectsMediaDataInRealTime = false
+    let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+        assetWriterInput: input,
+        sourcePixelBufferAttributes: [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferWidthKey as String: task.width,
+            kCVPixelBufferHeightKey as String: task.height,
+        ]
+    )
+    guard writer.canAdd(input) else { throw VideoEncodingError.writer("cannot add H.264 input") }
+    writer.add(input)
+    guard writer.startWriting() else {
+        throw VideoEncodingError.writer(writer.error?.localizedDescription ?? "could not start")
+    }
+    writer.startSession(atSourceTime: .zero)
+    for (index, frame) in task.frames.enumerated() {
+        while !input.isReadyForMoreMediaData {
+            if writer.status == .failed {
+                throw VideoEncodingError.writer(writer.error?.localizedDescription ?? "failed while waiting")
+            }
+            Thread.sleep(forTimeInterval: 0.001)
+        }
+        let buffer = try pixelBuffer(path: frame, width: task.width, height: task.height, pool: adaptor.pixelBufferPool)
+        let time = CMTime(value: Int64(index), timescale: task.framesPerSecond)
+        guard adaptor.append(buffer, withPresentationTime: time) else { throw VideoEncodingError.append(index) }
+    }
+    input.markAsFinished()
+    let semaphore = DispatchSemaphore(value: 0)
+    writer.finishWriting { semaphore.signal() }
+    semaphore.wait()
+    guard writer.status == .completed else {
+        throw VideoEncodingError.writer(writer.error?.localizedDescription ?? "did not complete")
+    }
+}
+
+let arguments = CommandLine.arguments
+guard arguments.count == 2 else {
+    fputs("usage: animation-video-encoder task.json\n", stderr)
+    exit(2)
+}
+
+do {
+    let data = try Data(contentsOf: URL(fileURLWithPath: arguments[1]))
+    try encode(JSONDecoder().decode(VideoTask.self, from: data))
+} catch {
+    fputs("\(error)\n", stderr)
+    exit(1)
+}

--- a/packages/svg-to-swiftui-core/animation-tests/webkit-animation-reference.swift
+++ b/packages/svg-to-swiftui-core/animation-tests/webkit-animation-reference.swift
@@ -1,0 +1,153 @@
+import AppKit
+import WebKit
+
+struct AnimationFrameTask: Decodable {
+    let timeMicroseconds: Int64
+    let output: String
+}
+
+struct AnimationRenderTask: Decodable {
+    let input: String
+    let width: Int
+    let height: Int
+    let pixelWidth: Int
+    let pixelHeight: Int
+    let frames: [AnimationFrameTask]
+}
+
+final class AnimationSnapshotRenderer: NSObject, WKNavigationDelegate {
+    private let task: AnimationRenderTask
+    private let webView: WKWebView
+    private var frameIndex = 0
+
+    init(task: AnimationRenderTask) {
+        self.task = task
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        self.webView = WKWebView(
+            frame: NSRect(x: 0, y: 0, width: task.width, height: task.height),
+            configuration: configuration
+        )
+        super.init()
+        webView.navigationDelegate = self
+        webView.setValue(false, forKey: "drawsBackground")
+        let input = URL(fileURLWithPath: task.input)
+        webView.loadFileURL(input, allowingReadAccessTo: input.deletingLastPathComponent())
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        fail("WebKit animation fixture failed to load: \(error)")
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        fail("WebKit animation fixture failed provisional navigation: \(error)")
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        renderNextFrame()
+    }
+
+    private func renderNextFrame() {
+        guard frameIndex < task.frames.count else { exit(0) }
+        let frame = task.frames[frameIndex]
+        let seconds = Double(frame.timeMicroseconds) / 1_000_000
+        let milliseconds = Double(frame.timeMicroseconds) / 1_000
+        let script = """
+        (() => {
+          const root = document.documentElement;
+          if (typeof root.pauseAnimations === 'function') root.pauseAnimations();
+          if (typeof root.setCurrentTime === 'function') root.setCurrentTime(\(seconds));
+          for (const animation of document.getAnimations()) {
+            animation.pause();
+            try { animation.currentTime = \(milliseconds); } catch (_) {}
+          }
+          document.documentElement.getBoundingClientRect();
+          getComputedStyle(document.documentElement).opacity;
+          return true;
+        })()
+        """
+        webView.evaluateJavaScript(script) { _, error in
+            if let error {
+                self.fail("Could not seek WebKit animation to \(frame.timeMicroseconds)us: \(error)")
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
+                self.snapshot(frame)
+            }
+        }
+    }
+
+    private func snapshot(_ frame: AnimationFrameTask) {
+        let configuration = WKSnapshotConfiguration()
+        configuration.rect = webView.bounds
+        configuration.snapshotWidth = NSNumber(value: task.pixelWidth)
+        webView.takeSnapshot(with: configuration) { image, error in
+            guard error == nil, let image,
+                  let bitmap = NSBitmapImageRep(
+                    bitmapDataPlanes: nil,
+                    pixelsWide: self.task.pixelWidth,
+                    pixelsHigh: self.task.pixelHeight,
+                    bitsPerSample: 8,
+                    samplesPerPixel: 4,
+                    hasAlpha: true,
+                    isPlanar: false,
+                    colorSpaceName: .deviceRGB,
+                    bytesPerRow: 0,
+                    bitsPerPixel: 0
+                  ),
+                  let context = NSGraphicsContext(bitmapImageRep: bitmap) else {
+                self.fail("WebKit animation snapshot failed at \(frame.timeMicroseconds)us: \(String(describing: error))")
+                return
+            }
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = context
+            context.imageInterpolation = .high
+            image.draw(
+                in: NSRect(x: 0, y: 0, width: self.task.pixelWidth, height: self.task.pixelHeight),
+                from: NSRect(origin: .zero, size: image.size),
+                operation: .copy,
+                fraction: 1
+            )
+            context.flushGraphics()
+            NSGraphicsContext.restoreGraphicsState()
+            guard let png = bitmap.representation(using: .png, properties: [:]) else {
+                self.fail("Could not encode WebKit animation frame at \(frame.timeMicroseconds)us")
+                return
+            }
+            do {
+                try png.write(to: URL(fileURLWithPath: frame.output))
+                self.frameIndex += 1
+                self.renderNextFrame()
+            } catch {
+                self.fail("Could not write WebKit animation frame at \(frame.timeMicroseconds)us: \(error)")
+            }
+        }
+    }
+
+    private func fail(_ message: String) {
+        fputs("\(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let arguments = CommandLine.arguments
+guard arguments.count == 2 else {
+    fputs("usage: webkit-animation-reference task.json\n", stderr)
+    exit(2)
+}
+
+do {
+    let data = try Data(contentsOf: URL(fileURLWithPath: arguments[1]))
+    let task = try JSONDecoder().decode(AnimationRenderTask.self, from: data)
+    guard task.width > 0, task.height > 0, task.pixelWidth > 0, task.pixelHeight > 0, !task.frames.isEmpty else {
+        fputs("Animation reference task has invalid dimensions or no frames\n", stderr)
+        exit(2)
+    }
+    let application = NSApplication.shared
+    application.setActivationPolicy(.prohibited)
+    let renderer = AnimationSnapshotRenderer(task: task)
+    withExtendedLifetime(renderer) { application.run() }
+} catch {
+    fputs("Could not decode animation reference task: \(error)\n", stderr)
+    exit(2)
+}

--- a/packages/svg-to-swiftui-core/package.json
+++ b/packages/svg-to-swiftui-core/package.json
@@ -39,6 +39,8 @@
     "test": "jest",
     "visual-test": "bun run visual-tests/run-visual-tests.ts",
     "visual-test:verify": "bun visual-tests/verify-manifest.ts",
+    "animation-test": "bun run animation-tests/run-animation-tests.ts",
+    "animation-test:verify": "bun animation-tests/verify-manifest.ts",
     "visual-test:update-manifest": "bun visual-tests/update-manifest.ts",
     "conformance:verify": "bun conformance/verify.ts",
     "conformance:report": "bun conformance/generate-report.ts",

--- a/packages/svg-to-swiftui-core/src/tests/animationVisualHarness.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/animationVisualHarness.test.ts
@@ -1,0 +1,51 @@
+import {
+  animationFrameStem,
+  loadAnimationFixtures,
+  timelineFrames,
+  validateAnimationManifest,
+} from "../../animation-tests/manifest";
+
+describe("deterministic animation visual harness", () => {
+  test("derives frame times from integer frame indices without accumulated drift", () => {
+    const frames = timelineFrames({
+      durationMicroseconds: 1_000_000,
+      framesPerSecond: 30,
+    });
+    expect(frames).toHaveLength(30);
+    expect(frames[0]).toEqual({ index: 0, timeMicroseconds: 0, stem: "000000-000000000000000" });
+    expect(frames[1]?.timeMicroseconds).toBe(33_333);
+    expect(frames[29]?.timeMicroseconds).toBe(966_666);
+  });
+
+  test("includes the exact loop endpoint only when requested", () => {
+    const frames = timelineFrames({
+      durationMicroseconds: 1_000_000,
+      framesPerSecond: 10,
+      includeEndFrame: true,
+    });
+    expect(frames).toHaveLength(11);
+    expect(frames[frames.length - 1]?.timeMicroseconds).toBe(1_000_000);
+  });
+
+  test("uses explicit microsecond schedules and lexically sortable names", () => {
+    const frames = timelineFrames({
+      durationMicroseconds: 1_000_000,
+      framesPerSecond: 30,
+      sampleTimesMicroseconds: [0, 333_333, 1_000_000],
+    });
+    expect(frames.map((frame) => frame.stem)).toEqual([
+      "000000-000000000000000",
+      "000001-000000000333333",
+      "000002-000000001000000",
+    ]);
+    expect(animationFrameStem(12, 42)).toBe("000012-000000000000042");
+  });
+
+  test("ships valid comparison and independent reference probe fixtures", () => {
+    expect(validateAnimationManifest()).toEqual([]);
+    const fixtures = loadAnimationFixtures();
+    expect(fixtures.some((fixture) => fixture.mode === "comparison")).toBe(true);
+    expect(fixtures.some((fixture) => fixture.tags.includes("smil"))).toBe(true);
+    expect(fixtures.some((fixture) => fixture.tags.includes("css-animation"))).toBe(true);
+  });
+});

--- a/packages/svg-to-swiftui-core/visual-tests/swiftui-renderer-support.swift
+++ b/packages/svg-to-swiftui-core/visual-tests/swiftui-renderer-support.swift
@@ -3,6 +3,17 @@ import AppKit
 import CoreText
 import SwiftUI
 
+private struct _SVGDocumentTimeMicrosecondsKey: EnvironmentKey {
+    static let defaultValue: Int64 = 0
+}
+
+extension EnvironmentValues {
+    var _svgDocumentTimeMicroseconds: Int64 {
+        get { self[_SVGDocumentTimeMicrosecondsKey.self] }
+        set { self[_SVGDocumentTimeMicrosecondsKey.self] = newValue }
+    }
+}
+
 // Generated shapes use these helpers to preserve SVG winding semantics. The
 // production output stays self-contained while this host supplies the same
 // operations against the real SwiftUI.Path type.
@@ -135,6 +146,8 @@ struct _VisualTask: Decodable {
     let backgroundA: Double
     let fonts: [String]
     let output: String
+    let timeMicroseconds: Int64?
+    let timeReceipt: String?
 }
 
 enum _VisualRenderError: Error, CustomStringConvertible {
@@ -182,6 +195,7 @@ func _renderVisualTask(_ task: _VisualTask, factories: [() -> AnyView]) throws {
         .frame(width: task.width, height: task.height, alignment: .topLeading)
         .background(background)
         .environment(\.colorScheme, .light)
+        .environment(\._svgDocumentTimeMicroseconds, task.timeMicroseconds ?? 0)
     let renderer = ImageRenderer(content: content)
     renderer.proposedSize = ProposedViewSize(width: task.width, height: task.height)
     renderer.scale = task.scale
@@ -214,4 +228,11 @@ func _renderVisualTask(_ task: _VisualTask, factories: [() -> AnyView]) throws {
         throw _VisualRenderError.pngEncodingFailed
     }
     try png.write(to: URL(fileURLWithPath: task.output))
+    if let receipt = task.timeReceipt {
+        try String(task.timeMicroseconds ?? 0).write(
+            to: URL(fileURLWithPath: receipt),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
 }


### PR DESCRIPTION
Closes #95.

## What changed

- adds a versioned animation fixture manifest with exact integer-microsecond schedules, tags, rendering configuration, and RGBA tolerances
- adds a WebKit reference renderer that explicitly freezes and seeks SVG/SMIL and CSS animation timelines
- extends the shared SwiftUI render host with an injected exact document time and time receipts
- compiles generated Swift once, batch-renders all requested timestamps, and compares every lossless premultiplied-sRGB RGBA frame
- records per-frame metrics plus the worst timestamp for outside-pixel, RGB, alpha, and maximum-channel errors
- adds deterministic cache validation, fixture/tag/changed/fresh filtering, and structured JSON summaries
- adds optional reference, SwiftUI, and side-by-side MP4 review artifacts; encoded video never affects pass/fail
- adds independent SMIL and CSS reference-seeking probes plus a complete static SVG -> Swift -> swiftc -> SwiftUI multi-frame control fixture
- runs temporal manifest verification cross-platform and the real frame suite on macOS CI
- documents the test model and links the new animated SVG roadmap

## Why

Animation implementation needs a trustworthy temporal oracle before compiler semantics are added. Comparing compressed videos would introduce codec noise, so this harness compares exact lossless frames first and produces videos only for human review.

## Validation

- `bun run animation-test -- --fresh --videos` — 2 reference probes and 3 generated-Swift comparison frames pass
- warm-cache rerun produces identical reference, SwiftUI, and summary hashes
- `bun run visual-test -- --fixture harness-multicolor-view --fresh` — existing static host path passes
- core test suite — 28 suites / 293 tests pass
- full monorepo build passes
- core typecheck passes
- static manifest: 1,909 fixtures valid
- animation manifest: 3 fixtures / 9 exact frames valid
- static conformance: 449 entries, zero blockers
- targeted Biome checks and `git diff --check` pass

Repository-wide lint/typecheck still report pre-existing issues in Next.js formatting/import order and the shared Prettier tooling's Node type configuration; this PR does not touch those files.
