### PR TITLE
Add animation IR and deterministic SwiftUI clock

### DIFF
--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -246,6 +246,8 @@ The default antialiasing allowance is 24/255 per channel, at most 3% pixels outs
 
 The animation harness extends the same compiler pipeline across an exact microsecond schedule. WebKit is paused and explicitly seeks both the SVG/SMIL document timeline and CSS Web Animations timeline. Generated Swift is compiled once, then SwiftUI renders every matching timestamp through an injected deterministic time value. Each lossless frame is compared with the same premultiplied-RGBA metrics, and summaries identify the worst frame and timestamp.
 
+Generated animated views expose deterministic and production clock paths. See the [animation clock contract](docs/animation-clock.md) for restart, pause/resume, Reduced Motion, and exact-time behavior.
+
 Optional MP4 files are review artifacts only. They are encoded after the lossless comparisons and never decide whether a test passes. Animation compiler support is being implemented in dependency order under the [Animated SVG roadmap](https://github.com/bring-shrubbery/SVG-to-SwiftUI/issues/94).
 
 ## Migration from 0.4

--- a/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
@@ -39,12 +39,13 @@
       },
       "expectDistinctReferenceFrames": true
     },
-    "reference-smil-seek": {
-      "mode": "reference-probe",
+    "benchmark-01-numeric-cx": {
+      "mode": "comparison",
       "referenceBackend": "webkit",
       "width": 96,
       "height": 48,
-      "tags": ["animate", "reference-seek", "smil"],
+      "expectedMode": "view",
+      "tags": ["animate", "benchmark-01", "numeric", "smil"],
       "timeline": {
         "durationMicroseconds": 1000000,
         "framesPerSecond": 30,

--- a/packages/svg-to-swiftui-core/animation-tests/batch-render.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/batch-render.ts
@@ -32,6 +32,7 @@ export interface AnimationBatchItem {
   background: string | null;
   fonts: string[];
   expectedMode: ExpectedOutputMode;
+  usesDocumentTime: boolean;
   tolerance: RgbaTolerance;
   frames: AnimationBatchFrame[];
 }
@@ -71,17 +72,18 @@ function generatedSource(support: string, items: AnimationBatchItem[]): string {
     )
     .join("\n\n");
   const factories = items
-    .map((item) =>
-      item.expectedMode === "shape"
-        ? `    { AnyView(${item.swiftTypeName}().fill(Color.black)) }`
-        : `    { AnyView(${item.swiftTypeName}()) }`,
-    )
+    .map((item) => {
+      if (item.expectedMode === "shape") return `    { _ in AnyView(${item.swiftTypeName}().fill(Color.black)) }`;
+      return item.usesDocumentTime
+        ? `    { time in AnyView(${item.swiftTypeName}(documentTime: Double(time) / 1_000_000)) }`
+        : `    { _ in AnyView(${item.swiftTypeName}()) }`;
+    })
     .join(",\n");
   return `${support}
 
 ${declarations}
 
-let _visualFactories: [() -> AnyView] = [
+let _visualFactories: [(Int64) -> AnyView] = [
 ${factories}
 ]
 let _visualTaskData = try Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1]))
@@ -178,6 +180,7 @@ export async function runAnimationBatch(
             background: item.background,
             fonts: item.fonts,
             expectedMode: item.expectedMode,
+            usesDocumentTime: item.usesDocumentTime,
             timeMicroseconds: frame.timeMicroseconds,
           }),
           ...item.fonts.map((font) => readFileSync(resolve(__dirname, font))),

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-01-numeric-cx.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-01-numeric-cx.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="96" height="48" viewBox="0 0 96 48">
   <rect width="96" height="48" rx="8" fill="#0f172a"/>
-  <circle cx="16" cy="24" r="10" fill="#38bdf8">
+  <circle id="dot" cx="16" cy="24" r="10" fill="#38bdf8">
     <animate attributeName="cx" from="16" to="80" dur="1s" fill="freeze"/>
   </circle>
 </svg>

--- a/packages/svg-to-swiftui-core/animation-tests/run-animation-tests.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/run-animation-tests.ts
@@ -473,6 +473,7 @@ async function main(): Promise<void> {
           background: fixture.background,
           fonts: fixture.fonts,
           expectedMode,
+          usesDocumentTime: swiftCode.includes("init(documentTime: Double? = nil"),
           tolerance: fixture.tolerance,
           frames: fixture.frames.map((frame) => ({
             ...frame,

--- a/packages/svg-to-swiftui-core/docs/animation-clock.md
+++ b/packages/svg-to-swiftui-core/docs/animation-clock.md
@@ -1,0 +1,12 @@
+# Animation clock contract
+
+Animated generated declarations are SwiftUI `View` values with two clock paths:
+
+- `View()` uses one production `TimelineView(.animation)` clock. Time starts at zero when that view identity first samples, pauses while the scene is inactive, and resumes without a jump. Recreating the view with a new identity restarts it.
+- `View(documentTime: seconds)` bypasses the production clock and samples the complete SVG document at exactly that time. The temporal test harness uses this initializer for every frame.
+
+One timestamp is passed through the entire generated document. Animation evaluation never reads wall-clock time.
+
+Finite negative values are preserved for pre-begin sampling, large finite values are allowed, and non-finite values become zero. Reduced Motion does not change SVG semantics by default. Call `View(respectsReducedMotion: true)` to freeze production playback at time zero when the system setting is active; explicit document-time sampling remains exact.
+
+Static SVGs keep their existing generated `Shape` or `View` output and contain no animation clock code.

--- a/packages/svg-to-swiftui-core/src/index.ts
+++ b/packages/svg-to-swiftui-core/src/index.ts
@@ -16,6 +16,17 @@ import { getSVGElement, resolveSVGProperties } from "./utils";
 export * from "./conformance";
 export * from "./lengths";
 export type {
+  AnimationDefinition,
+  AnimationDuration,
+  AnimationKind,
+  AnimationProgram,
+  AnimationTarget,
+  AnimationTime,
+  AnimationTiming,
+  AnimationValue,
+} from "./renderTree/animation";
+export { sampleNumericAnimation } from "./renderTree/animation";
+export type {
   DiagnosticSeverity,
   OutputMode,
   RenderDiagnostic,

--- a/packages/svg-to-swiftui-core/src/renderTree/animation.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/animation.ts
@@ -1,0 +1,555 @@
+import type { ElementNode } from "svg-parser";
+import type { RenderDiagnostic, SourceLocation } from "./types";
+
+export type AnimationKind = "animate" | "set" | "animateTransform" | "animateMotion" | "discard";
+
+export type AnimationTime =
+  | { type: "offset"; seconds: number }
+  | { type: "syncbase"; animationId: string; phase: "begin" | "end"; offsetSeconds: number }
+  | { type: "event"; targetId?: string; event: string; offsetSeconds: number }
+  | { type: "indefinite" }
+  | { type: "invalid"; syntax: string };
+
+export type AnimationDuration =
+  | { type: "seconds"; seconds: number }
+  | { type: "indefinite" }
+  | { type: "media" }
+  | { type: "invalid"; syntax: string };
+
+export type AnimationValue =
+  | {
+      type: "number";
+      base: number;
+      from?: number;
+      to?: number;
+      by?: number;
+      values?: readonly number[];
+    }
+  | {
+      type: "unsupported";
+      base?: string;
+      from?: string;
+      to?: string;
+      by?: string;
+      values?: readonly string[];
+    };
+
+export interface AnimationTiming {
+  begin: readonly AnimationTime[];
+  duration: AnimationDuration;
+  end: readonly AnimationTime[];
+  min?: AnimationDuration;
+  max?: AnimationDuration;
+  repeatCount: { type: "count"; value: number } | { type: "indefinite" } | { type: "unspecified" };
+  repeatDuration?: AnimationDuration;
+  restart: "always" | "whenNotActive" | "never";
+  fill: "remove" | "freeze";
+}
+
+export interface AnimationTarget {
+  key: string;
+  source: SourceLocation;
+  reference: { type: "parent" } | { type: "local"; id: string };
+  renderable: boolean;
+}
+
+export interface AnimationDefinition {
+  stableId: string;
+  authoredId?: string;
+  source: SourceLocation;
+  target?: AnimationTarget;
+  kind: AnimationKind;
+  attributeName?: string;
+  timing: AnimationTiming;
+  value: AnimationValue;
+  composition: {
+    additive: "replace" | "sum";
+    accumulate: "none" | "sum";
+    calcMode: "discrete" | "linear" | "paced" | "spline";
+  };
+  documentOrder: number;
+  dependencies: readonly string[];
+  runtimeSupport: "numeric-linear" | "pending" | "invalid";
+}
+
+export interface AnimationProgram {
+  animations: readonly AnimationDefinition[];
+  /** Stable dependency order. Presentation sampling must never mutate the static render tree. */
+  evaluationOrder: readonly string[];
+}
+
+const ANIMATION_TAGS = new Map<string, AnimationKind>([
+  ["animate", "animate"],
+  ["set", "set"],
+  ["animatetransform", "animateTransform"],
+  ["animatemotion", "animateMotion"],
+  ["discard", "discard"],
+]);
+
+const NON_RENDERABLE_TARGETS = new Set([
+  "animate",
+  "animatemotion",
+  "animatetransform",
+  "discard",
+  "set",
+  "defs",
+  "style",
+  "script",
+  "metadata",
+  "title",
+  "desc",
+  "lineargradient",
+  "radialgradient",
+  "stop",
+  "pattern",
+  "clippath",
+  "mask",
+  "marker",
+  "filter",
+]);
+
+function children(element: ElementNode): ElementNode[] {
+  return element.children.filter(
+    (child): child is ElementNode => typeof child !== "string" && child.type === "element",
+  );
+}
+
+function source(element: ElementNode): SourceLocation {
+  const id = element.properties?.id;
+  return { element: element.tagName ?? "unknown", ...(id === undefined ? {} : { id: String(id) }) };
+}
+
+function property(element: ElementNode, name: string): string | undefined {
+  const value = element.properties?.[name];
+  return value === undefined || value === null ? undefined : String(value).trim();
+}
+
+function diagnostic(
+  diagnostics: RenderDiagnostic[],
+  element: ElementNode,
+  code: string,
+  message: string,
+  attribute?: string,
+): void {
+  diagnostics.push({
+    code,
+    message,
+    severity: "warning",
+    source: source(element),
+    ...(attribute ? { attribute } : {}),
+  });
+}
+
+function parseClock(raw: string): number | undefined {
+  const value = raw.trim().toLowerCase();
+  const clock = /^(?:(\d+):)?(\d{1,2}):(\d{1,2}(?:\.\d+)?)$/.exec(value);
+  if (clock) return Number(clock[1] ?? 0) * 3600 + Number(clock[2]) * 60 + Number(clock[3]);
+  const unit = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))(ms|s|min|h)?$/.exec(value);
+  if (!unit) return undefined;
+  const number = Number(unit[1]);
+  const multiplier = unit[2] === "ms" ? 0.001 : unit[2] === "min" ? 60 : unit[2] === "h" ? 3600 : 1;
+  return Number.isFinite(number) ? number * multiplier : undefined;
+}
+
+function parseTime(raw: string): AnimationTime {
+  const value = raw.trim();
+  if (value === "indefinite") return { type: "indefinite" };
+  const offset = parseClock(value);
+  if (offset !== undefined) return { type: "offset", seconds: offset };
+  const reference = /^([\w:.-]+)\.(begin|end)([+-].+)?$/i.exec(value);
+  if (reference) {
+    const parsedOffset = reference[3] ? parseClock(reference[3]) : 0;
+    return parsedOffset === undefined
+      ? { type: "invalid", syntax: value }
+      : {
+          type: "syncbase",
+          animationId: reference[1]!,
+          phase: reference[2]!.toLowerCase() as "begin" | "end",
+          offsetSeconds: parsedOffset,
+        };
+  }
+  const event = /^(?:([\w:.-]+)\.)?([a-z][\w-]*)([+-].+)?$/i.exec(value);
+  if (event) {
+    const parsedOffset = event[3] ? parseClock(event[3]) : 0;
+    return parsedOffset === undefined
+      ? { type: "invalid", syntax: value }
+      : {
+          type: "event",
+          ...(event[1] ? { targetId: event[1] } : {}),
+          event: event[2]!,
+          offsetSeconds: parsedOffset,
+        };
+  }
+  return { type: "invalid", syntax: value };
+}
+
+function parseTimes(raw: string | undefined, fallback: readonly AnimationTime[]): readonly AnimationTime[] {
+  if (!raw) return fallback;
+  return raw
+    .split(";")
+    .map(parseTime)
+    .filter((value, index, values) => value.type !== "invalid" || values.length === 1 || index < values.length);
+}
+
+function parseDuration(raw: string | undefined): AnimationDuration {
+  if (!raw) return { type: "invalid", syntax: "" };
+  if (raw === "indefinite") return { type: "indefinite" };
+  if (raw === "media") return { type: "media" };
+  const seconds = parseClock(raw);
+  return seconds !== undefined && seconds >= 0 ? { type: "seconds", seconds } : { type: "invalid", syntax: raw };
+}
+
+function parseOptionalDuration(raw: string | undefined): AnimationDuration | undefined {
+  return raw === undefined ? undefined : parseDuration(raw);
+}
+
+function parseRepeatCount(raw: string | undefined): AnimationTiming["repeatCount"] {
+  if (raw === undefined) return { type: "unspecified" };
+  if (raw === "indefinite") return { type: "indefinite" };
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? { type: "count", value } : { type: "count", value: Number.NaN };
+}
+
+function numeric(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function parseValue(
+  animation: ElementNode,
+  target: ElementNode | undefined,
+  attributeName: string | undefined,
+): AnimationValue {
+  const fromRaw = property(animation, "from");
+  const toRaw = property(animation, "to");
+  const byRaw = property(animation, "by");
+  const valuesRaw = property(animation, "values")
+    ?.split(";")
+    .map((value) => value.trim());
+  const baseRaw = attributeName && target ? property(target, attributeName) : undefined;
+  const base = numeric(baseRaw) ?? 0;
+  const from = numeric(fromRaw);
+  const to = numeric(toRaw);
+  const by = numeric(byRaw);
+  const values = valuesRaw?.map(numeric);
+  if (
+    (fromRaw === undefined || from !== undefined) &&
+    (toRaw === undefined || to !== undefined) &&
+    (byRaw === undefined || by !== undefined) &&
+    (!values || values.every((value) => value !== undefined))
+  ) {
+    return {
+      type: "number",
+      base,
+      ...(from === undefined ? {} : { from }),
+      ...(to === undefined ? {} : { to }),
+      ...(by === undefined ? {} : { by }),
+      ...(values ? { values: values as number[] } : {}),
+    };
+  }
+  return {
+    type: "unsupported",
+    ...(baseRaw === undefined ? {} : { base: baseRaw }),
+    ...(fromRaw === undefined ? {} : { from: fromRaw }),
+    ...(toRaw === undefined ? {} : { to: toRaw }),
+    ...(byRaw === undefined ? {} : { by: byRaw }),
+    ...(valuesRaw ? { values: valuesRaw } : {}),
+  };
+}
+
+function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSupport">): boolean {
+  if (definition.kind !== "animate" || !definition.target?.renderable || !definition.attributeName) return false;
+  if (!definition.target.key.startsWith("id:") || !["cx", "x"].includes(definition.attributeName)) return false;
+  if (definition.value.type !== "number") return false;
+  if (definition.value.from === undefined || definition.value.to === undefined) return false;
+  if (definition.timing.duration.type !== "seconds" || definition.timing.duration.seconds <= 0) return false;
+  if (definition.timing.begin.length !== 1 || definition.timing.begin[0]?.type !== "offset") return false;
+  if (definition.timing.end.length > 0) return false;
+  if (definition.timing.repeatCount.type !== "unspecified" || definition.timing.repeatDuration) return false;
+  return definition.composition.additive === "replace" && definition.composition.accumulate === "none";
+}
+
+/** Parse declarative SVG animation into immutable, typed compiler input. */
+export function buildAnimationProgram(root: ElementNode, diagnostics: RenderDiagnostic[]): AnimationProgram {
+  const parents = new Map<ElementNode, ElementNode>();
+  const order = new Map<ElementNode, number>();
+  const definitions = new Map<string, ElementNode>();
+  const duplicateIds = new Set<string>();
+  const animationElements: Array<{ element: ElementNode; kind: AnimationKind }> = [];
+  let nextOrder = 0;
+  const visit = (element: ElementNode): void => {
+    order.set(element, nextOrder++);
+    const id = property(element, "id");
+    if (id) {
+      if (definitions.has(id)) duplicateIds.add(id);
+      else definitions.set(id, element);
+    }
+    const kind = ANIMATION_TAGS.get((element.tagName ?? "").toLowerCase());
+    if (kind) animationElements.push({ element, kind });
+    for (const child of children(element)) {
+      parents.set(child, element);
+      visit(child);
+    }
+  };
+  visit(root);
+
+  const animations: AnimationDefinition[] = [];
+  for (const { element, kind } of animationElements) {
+    const documentOrder = order.get(element)!;
+    const authoredId = property(element, "id");
+    const stableId = authoredId || `animation-${String(documentOrder).padStart(6, "0")}`;
+    if (authoredId && duplicateIds.has(authoredId))
+      diagnostic(
+        diagnostics,
+        element,
+        "duplicate-animation-id",
+        `Animation id #${authoredId} is duplicated, so timing references to it are ambiguous.`,
+        "id",
+      );
+    const href = property(element, "href") ?? property(element, "xlink:href");
+    let targetElement: ElementNode | undefined;
+    let reference: AnimationTarget["reference"];
+    if (href !== undefined) {
+      const match = /^#([^\s]+)$/.exec(href);
+      reference = { type: "local", id: match?.[1] ?? href };
+      if (!match)
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-animation-target",
+          `Animation target '${href}' must be a local #id reference.`,
+          "href",
+        );
+      else if (duplicateIds.has(match[1]!))
+        diagnostic(
+          diagnostics,
+          element,
+          "duplicate-animation-target-id",
+          `Animation target #${match[1]} is ambiguous because that id is duplicated.`,
+          "href",
+        );
+      else targetElement = definitions.get(match[1]!);
+      if (match && !targetElement)
+        diagnostic(
+          diagnostics,
+          element,
+          "missing-animation-target",
+          `Animation target #${match[1]} does not exist.`,
+          "href",
+        );
+    } else {
+      reference = { type: "parent" };
+      targetElement = parents.get(element);
+      if (!targetElement)
+        diagnostic(
+          diagnostics,
+          element,
+          "missing-animation-target",
+          "An animation without href must be a child of its target element.",
+        );
+    }
+    const renderable = !!targetElement && !NON_RENDERABLE_TARGETS.has((targetElement.tagName ?? "").toLowerCase());
+    if (targetElement && !renderable)
+      diagnostic(
+        diagnostics,
+        element,
+        "wrong-animation-target-type",
+        `Animation target <${targetElement.tagName}> is not a rendered graphics element.`,
+        href === undefined ? undefined : "href",
+      );
+    const target = targetElement
+      ? {
+          key: property(targetElement, "id")
+            ? `id:${property(targetElement, "id")}`
+            : `source:${order.get(targetElement)}`,
+          source: source(targetElement),
+          reference,
+          renderable,
+        }
+      : undefined;
+    const attributeName = property(element, "attributeName");
+    if (kind === "animate" && !attributeName)
+      diagnostic(
+        diagnostics,
+        element,
+        "missing-animation-attribute",
+        "<animate> requires attributeName.",
+        "attributeName",
+      );
+    const timing: AnimationTiming = {
+      begin: parseTimes(property(element, "begin"), [{ type: "offset", seconds: 0 }]),
+      duration: parseDuration(property(element, "dur")),
+      end: parseTimes(property(element, "end"), []),
+      ...(parseOptionalDuration(property(element, "min"))
+        ? { min: parseOptionalDuration(property(element, "min")) }
+        : {}),
+      ...(parseOptionalDuration(property(element, "max"))
+        ? { max: parseOptionalDuration(property(element, "max")) }
+        : {}),
+      repeatCount: parseRepeatCount(property(element, "repeatCount")),
+      ...(parseOptionalDuration(property(element, "repeatDur"))
+        ? { repeatDuration: parseOptionalDuration(property(element, "repeatDur")) }
+        : {}),
+      restart: (property(element, "restart") as AnimationTiming["restart"]) ?? "always",
+      fill: property(element, "fill") === "freeze" ? "freeze" : "remove",
+    };
+    const value = parseValue(element, targetElement, attributeName);
+    const dependencies = timing.begin
+      .filter((time): time is Extract<AnimationTime, { type: "syncbase" }> => time.type === "syncbase")
+      .map((time) => time.animationId);
+    const baseDefinition = {
+      stableId,
+      ...(authoredId ? { authoredId } : {}),
+      source: source(element),
+      ...(target ? { target } : {}),
+      kind,
+      ...(attributeName ? { attributeName } : {}),
+      timing,
+      value,
+      composition: {
+        additive: property(element, "additive") === "sum" ? ("sum" as const) : ("replace" as const),
+        accumulate: property(element, "accumulate") === "sum" ? ("sum" as const) : ("none" as const),
+        calcMode: (property(element, "calcMode") as AnimationDefinition["composition"]["calcMode"]) ?? "linear",
+      },
+      documentOrder,
+      dependencies,
+    };
+    let runtimeSupport: AnimationDefinition["runtimeSupport"] = target ? "pending" : "invalid";
+    if (isRuntimeSupported(baseDefinition)) runtimeSupport = "numeric-linear";
+    const definition: AnimationDefinition = { ...baseDefinition, runtimeSupport };
+    animations.push(definition);
+
+    if (timing.duration.type === "invalid")
+      diagnostic(
+        diagnostics,
+        element,
+        "invalid-animation-duration",
+        "Animation dur must be a non-negative clock value.",
+        "dur",
+      );
+    if (timing.begin.some((time) => time.type === "invalid"))
+      diagnostic(
+        diagnostics,
+        element,
+        "invalid-animation-begin",
+        "Animation begin contains invalid timing syntax.",
+        "begin",
+      );
+    if (timing.repeatCount.type === "count" && !Number.isFinite(timing.repeatCount.value))
+      diagnostic(
+        diagnostics,
+        element,
+        "invalid-animation-repeat-count",
+        "repeatCount must be a positive number or indefinite.",
+        "repeatCount",
+      );
+    const restart = property(element, "restart");
+    if (restart && !["always", "whenNotActive", "never"].includes(restart))
+      diagnostic(diagnostics, element, "invalid-animation-restart", `Invalid restart value '${restart}'.`, "restart");
+    const fill = property(element, "fill");
+    if (fill && !["remove", "freeze"].includes(fill))
+      diagnostic(diagnostics, element, "invalid-animation-fill", `Invalid animation fill value '${fill}'.`, "fill");
+    if (value.type === "unsupported")
+      diagnostic(
+        diagnostics,
+        element,
+        "unsupported-animation-value",
+        "This animation value family is not implemented yet.",
+      );
+    if (runtimeSupport === "pending" && value.type !== "unsupported")
+      diagnostic(
+        diagnostics,
+        element,
+        "unsupported-animation-semantics",
+        `Animation <${element.tagName}> uses timing or composition semantics not implemented by this ticket.`,
+      );
+  }
+
+  const compositions = new Map<string, AnimationDefinition[]>();
+  for (const animation of animations) {
+    if (!animation.target || !animation.attributeName) continue;
+    const key = `${animation.target.key}:${animation.attributeName}`;
+    const group = compositions.get(key) ?? [];
+    group.push(animation);
+    compositions.set(key, group);
+  }
+  for (const group of compositions.values()) {
+    if (group.length < 2) continue;
+    for (const animation of group) animation.runtimeSupport = "pending";
+    const owner = animationElements.find(({ element }) => order.get(element) === group[0]?.documentOrder)?.element;
+    if (owner)
+      diagnostic(
+        diagnostics,
+        owner,
+        "unsupported-animation-composition",
+        "Multiple animations target the same property; deterministic composition is implemented by a later ticket.",
+      );
+  }
+
+  const byId = new Map(animations.map((animation) => [animation.stableId, animation]));
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const evaluationOrder: string[] = [];
+  const visitDependency = (animation: AnimationDefinition, path: string[]): void => {
+    if (visited.has(animation.stableId)) return;
+    if (visiting.has(animation.stableId)) {
+      diagnostic(
+        diagnostics,
+        animationElements.find(({ element }) => property(element, "id") === animation.authoredId)?.element ?? root,
+        "cyclic-animation-dependency",
+        `Animation dependency cycle detected: ${[...path, animation.stableId].join(" -> ")}.`,
+      );
+      return;
+    }
+    visiting.add(animation.stableId);
+    for (const dependencyId of animation.dependencies) {
+      const dependency = byId.get(dependencyId);
+      if (!dependency) {
+        const owner = animationElements.find(
+          ({ element }) => property(element, "id") === animation.authoredId,
+        )?.element;
+        if (owner)
+          diagnostic(
+            diagnostics,
+            owner,
+            "missing-animation-dependency",
+            `Animation timing references missing animation #${dependencyId}.`,
+            "begin",
+          );
+        continue;
+      }
+      visitDependency(dependency, [...path, animation.stableId]);
+    }
+    visiting.delete(animation.stableId);
+    visited.add(animation.stableId);
+    evaluationOrder.push(animation.stableId);
+  };
+  for (const animation of animations) visitDependency(animation, []);
+  return { animations, evaluationOrder };
+}
+
+export function declarativeAnimationTag(tagName: string | undefined): boolean {
+  return ANIMATION_TAGS.has((tagName ?? "").toLowerCase());
+}
+
+/** Reference sampler for the first compiler slice and exact clock-boundary tests. */
+export function sampleNumericAnimation(animation: AnimationDefinition, documentTime: number): number | undefined {
+  if (
+    animation.runtimeSupport !== "numeric-linear" ||
+    animation.value.type !== "number" ||
+    animation.value.from === undefined ||
+    animation.value.to === undefined ||
+    animation.timing.duration.type !== "seconds" ||
+    animation.timing.begin[0]?.type !== "offset"
+  )
+    return undefined;
+  const time = Number.isFinite(documentTime) ? documentTime : 0;
+  const begin = animation.timing.begin[0].seconds;
+  const duration = animation.timing.duration.seconds;
+  if (time < begin) return animation.value.base;
+  if (duration <= 0 || time >= begin + duration)
+    return animation.timing.fill === "freeze" ? animation.value.to : animation.value.base;
+  const progress = (time - begin) / duration;
+  return animation.value.from + (animation.value.to - animation.value.from) * progress;
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -25,6 +25,7 @@ import type { SVGElementProperties, ViewBoxData } from "../types";
 import { getSVGElement, resolveSVGProperties } from "../utils";
 import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio, parseViewBox, viewBoxTransform } from "../viewports";
 import { SVGAccessibilityResolver } from "./accessibility";
+import { buildAnimationProgram, declarativeAnimationTag } from "./animation";
 import { resolveClipPathInstance, resolveClipPathResources } from "./clips";
 import { SVGConditionalProcessor } from "./conditionalProcessing";
 import { resolveFilterInstance, resolveFilterResources } from "./filters";
@@ -2082,7 +2083,7 @@ function buildNode(
   context: BuildContext,
 ): RenderNode[] {
   const tag = element.tagName ?? "unknown";
-  if (NON_RENDERING_ELEMENTS.has(tag)) return [];
+  if (NON_RENDERING_ELEMENTS.has(tag) || declarativeAnimationTag(tag)) return [];
   if (!context.conditional.matches(element)) return [];
   if (tag === "use") return buildUse(element, inherited, coordinate, context);
   if (tag === "svg") return [buildNestedSVG(element, inherited, coordinate, context)];
@@ -2141,6 +2142,7 @@ export function buildRenderDocument(
   const styleResolver = new SVGStyleResolver(svg, diagnostics);
   const conditional = new SVGConditionalProcessor(config.staticEnvironment, diagnostics);
   const accessibility = new SVGAccessibilityResolver(resources, conditional.environment, diagnostics);
+  const animationProgram = buildAnimationProgram(svg, diagnostics);
   const context: BuildContext = {
     resources,
     diagnostics,
@@ -2155,7 +2157,7 @@ export function buildRenderDocument(
     const tag = (element.tagName ?? "").toLowerCase();
     if (tag === "script") {
       addDiagnostic(context, element, "unsupported-script", "SVG scripts are not executed by the static renderer.");
-    } else if (DYNAMIC_ELEMENTS.has(tag)) {
+    } else if (DYNAMIC_ELEMENTS.has(tag) && !declarativeAnimationTag(tag)) {
       addDiagnostic(
         context,
         element,
@@ -2378,6 +2380,7 @@ export function buildRenderDocument(
           },
           resources,
           children: nodes,
+          animationProgram: { animations: [], evaluationOrder: [] },
           diagnostics: [],
         };
         localCandidates.push({
@@ -3148,6 +3151,7 @@ export function buildRenderDocument(
     },
     resources,
     children,
+    animationProgram,
     diagnostics,
   };
 }

--- a/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/capabilities.ts
@@ -122,6 +122,7 @@ function hasIntrinsicAlpha(paint: Paint): boolean {
 export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGeneratorConfig = {}): CapabilityDecision {
   const paints = collectVisiblePaints(document.children);
   const reasons: string[] = [];
+  const hasAnimation = document.animationProgram.animations.length > 0;
   const needsViewportClip = containsViewportClip(document.children);
   const hasGradientPaint = paints.some(({ paint }) => {
     if (paint.type !== "reference") return false;
@@ -143,6 +144,7 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
 
   if (
     config.preserveColors === false &&
+    !hasAnimation &&
     !needsViewportClip &&
     !hasPaintServer &&
     !needsIndependentCompositing &&
@@ -157,6 +159,8 @@ export function analyzeCapabilities(document: RenderDocument, config: SwiftUIGen
       paintCount: paints.length,
     };
   }
+
+  if (hasAnimation) reasons.push("document contains declarative SVG animation");
 
   if (containsGeneralViewContent(document.children)) reasons.push("document contains non-geometry view content");
   if (needsAccessibility) reasons.push("document contains static accessibility semantics");

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -84,6 +84,7 @@ type GeneratedViewNode =
       filter?: GeneratedFilter;
       tileContained?: boolean;
       accessibility?: AccessibilityMetadata;
+      animationOffsetX?: string;
     };
 
 interface GeneratedMask {
@@ -326,6 +327,22 @@ function buildViewNodes(
   ancestorTransforms: RenderNode["transform"][] = [],
 ): GeneratedViewNode[] {
   const generated: GeneratedViewNode[] = [];
+
+  const animationOffsetX = (node: RenderNode): string | undefined => {
+    if (!node.source.id) return undefined;
+    const animation = context.document.animationProgram.animations.find(
+      (candidate) =>
+        candidate.runtimeSupport === "numeric-linear" &&
+        candidate.target?.source.id === node.source.id &&
+        (candidate.attributeName === "cx" || candidate.attributeName === "x"),
+    );
+    if (!animation || animation.value.type !== "number" || animation.timing.duration.type !== "seconds")
+      return undefined;
+    const begin = animation.timing.begin[0];
+    if (begin?.type !== "offset" || animation.value.from === undefined || animation.value.to === undefined)
+      return undefined;
+    return `Self.svgAnimatedNumber(documentTime: documentTime, begin: ${formatNumber(begin.seconds)}, duration: ${formatNumber(animation.timing.duration.seconds)}, from: ${formatNumber(animation.value.from)}, to: ${formatNumber(animation.value.to)}, base: ${formatNumber(animation.value.base)}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"}) - ${formatNumber(animation.value.base)}`;
+  };
 
   const buildFilter = (
     filter: FilterInstance | undefined,
@@ -720,6 +737,7 @@ function buildViewNodes(
         ...(mask ? { mask } : {}),
         ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
+        ...(animationOffsetX(node) ? { animationOffsetX: animationOffsetX(node) } : {}),
       });
       continue;
     }
@@ -929,6 +947,7 @@ function buildViewNodes(
         ...(mask ? { mask } : {}),
         ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
+        ...(animationOffsetX(node) ? { animationOffsetX: animationOffsetX(node) } : {}),
       });
     }
   }
@@ -1998,6 +2017,7 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
   }
   if (node.opacity !== 1) lines.push(`${prefix}.opacity(${swiftNumber(node.opacity)})`);
   if (node.blendMode !== "normal") lines.push(`${prefix}.blendMode(.${swiftBlendMode(node.blendMode)})`);
+  if (node.animationOffsetX) lines.push(`${prefix}.offset(x: ${node.animationOffsetX})`);
   appendAccessibilityModifiers(lines, node.accessibility, prefix);
   return lines;
 }
@@ -3485,13 +3505,79 @@ function createView(
   indentationSize: number,
 ): string[] {
   const indentation = " ".repeat(indentationSize);
-  const body: string[] = [
-    "var body: some View {",
+  const animated = document.animationProgram.animations.length > 0;
+  const content = [
     `${indentation}ZStack {`,
     ...nodes.flatMap((node) => renderViewNode(node, 2, indentation)),
     `${indentation}}`,
-    "}",
   ];
+  const body: string[] = animated
+    ? [
+        "private let documentTime: Double?",
+        "private let respectsReducedMotion: Bool",
+        "@StateObject private var animationClock = AnimationClockState()",
+        "@Environment(\\.scenePhase) private var scenePhase",
+        "@Environment(\\.accessibilityReduceMotion) private var reduceMotion",
+        "",
+        "init(documentTime: Double? = nil, respectsReducedMotion: Bool = false) {",
+        `${indentation}self.documentTime = documentTime`,
+        `${indentation}self.respectsReducedMotion = respectsReducedMotion`,
+        "}",
+        "",
+        "@ViewBuilder",
+        "private func content(at documentTime: Double) -> some View {",
+        ...content,
+        "}",
+        "",
+        "var body: some View {",
+        `${indentation}if let documentTime {`,
+        `${indentation}${indentation}content(at: Self.sanitizedDocumentTime(documentTime))`,
+        `${indentation}} else if respectsReducedMotion && reduceMotion {`,
+        `${indentation}${indentation}content(at: 0)`,
+        `${indentation}} else {`,
+        `${indentation}${indentation}TimelineView(.animation(paused: scenePhase != .active)) { timeline in`,
+        `${indentation}${indentation}${indentation}content(at: animationClock.sample(date: timeline.date, isActive: scenePhase == .active))`,
+        `${indentation}${indentation}}`,
+        `${indentation}}`,
+        "}",
+        "",
+        "private static func sanitizedDocumentTime(_ value: Double) -> Double {",
+        `${indentation}value.isFinite ? value : 0`,
+        "}",
+        "",
+        "private static func svgAnimatedNumber(documentTime: Double, begin: Double, duration: Double, from: Double, to: Double, base: Double, freeze: Bool) -> Double {",
+        `${indentation}let time = sanitizedDocumentTime(documentTime)`,
+        `${indentation}if time < begin { return base }`,
+        `${indentation}if duration <= 0 || time >= begin + duration { return freeze ? to : base }`,
+        `${indentation}let progress = (time - begin) / duration`,
+        `${indentation}return from + (to - from) * progress`,
+        "}",
+        "",
+        "private final class AnimationClockState: ObservableObject {",
+        `${indentation}private var startDate: Date?`,
+        `${indentation}private var pausedAt: Date?`,
+        `${indentation}private var pausedDuration: TimeInterval = 0`,
+        "",
+        `${indentation}func sample(date: Date, isActive: Bool) -> Double {`,
+        `${indentation}${indentation}guard let startDate else {`,
+        `${indentation}${indentation}${indentation}self.startDate = date`,
+        `${indentation}${indentation}${indentation}if !isActive { pausedAt = date }`,
+        `${indentation}${indentation}${indentation}return 0`,
+        `${indentation}${indentation}}`,
+        `${indentation}${indentation}if !isActive {`,
+        `${indentation}${indentation}${indentation}if pausedAt == nil { pausedAt = date }`,
+        `${indentation}${indentation}${indentation}let stoppedAt = pausedAt ?? date`,
+        `${indentation}${indentation}${indentation}return max(0, stoppedAt.timeIntervalSince(startDate) - pausedDuration)`,
+        `${indentation}${indentation}}`,
+        `${indentation}${indentation}if let pausedAt {`,
+        `${indentation}${indentation}${indentation}pausedDuration += max(0, date.timeIntervalSince(pausedAt))`,
+        `${indentation}${indentation}${indentation}self.pausedAt = nil`,
+        `${indentation}${indentation}}`,
+        `${indentation}${indentation}return max(0, date.timeIntervalSince(startDate) - pausedDuration)`,
+        `${indentation}}`,
+        "}",
+      ]
+    : ["var body: some View {", ...content, "}"];
   for (const helper of helpers) {
     const pathFunction = createFunctionTemplate({
       name: "path",
@@ -3574,6 +3660,10 @@ export function generateView(
   };
   const nodes = buildViewNodes(document.children, context);
   const imports = new Set<string>();
+  if (document.animationProgram.animations.length > 0) {
+    imports.add("Foundation");
+    imports.add("SwiftUI");
+  }
   if (containsFilterNode(nodes)) {
     imports.add("Foundation");
     imports.add("SwiftUI");

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -4,6 +4,7 @@ import type { FontMetrics, ParsedSVGLength } from "../lengths";
 import type { AffineTransform } from "../transformUtils";
 import type { ViewBoxData } from "../types";
 import type { PreserveAspectRatio } from "../viewports";
+import type { AnimationProgram } from "./animation";
 
 /** Identifies the SVG source that produced a render-tree node or diagnostic. */
 export interface SourceLocation {
@@ -895,6 +896,8 @@ export interface RenderDocument {
   };
   resources: ResourceRegistry;
   children: RenderNode[];
+  /** Declarative animation stays immutable and separate from base presentation. */
+  animationProgram: AnimationProgram;
   diagnostics: RenderDiagnostic[];
 }
 

--- a/packages/svg-to-swiftui-core/src/tests/animation.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/animation.test.ts
@@ -1,0 +1,107 @@
+import { __testing, convert, convertWithDiagnostics, sampleNumericAnimation } from "../index";
+
+const numericAnimation = `
+  <svg viewBox="0 0 100 40">
+    <circle id="dot" cx="16" cy="20" r="8" fill="#38bdf8">
+      <animate id="move" attributeName="cx" begin="250ms" dur="1s" from="16" to="80" fill="freeze"/>
+    </circle>
+  </svg>`;
+
+describe("typed SVG animation program", () => {
+  test("preserves parent and href targets, typed timing, base values, dependencies, and source order", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20">
+        <circle id="parent" cx="2" cy="2" r="2">
+          <animate id="first" attributeName="cx" from="2" to="10" dur="1s"/>
+        </circle>
+        <animate id="second" href="#parent" attributeName="cx" from="10" to="2" begin="first.end+250ms" dur="2s"/>
+      </svg>`);
+
+    expect(document.animationProgram.animations).toHaveLength(2);
+    expect(document.animationProgram.animations[0]).toMatchObject({
+      stableId: "first",
+      kind: "animate",
+      target: { key: "id:parent", reference: { type: "parent" }, renderable: true },
+      attributeName: "cx",
+      value: { type: "number", base: 2, from: 2, to: 10 },
+      timing: { begin: [{ type: "offset", seconds: 0 }], duration: { type: "seconds", seconds: 1 } },
+      documentOrder: expect.any(Number),
+    });
+    expect(document.animationProgram.animations[1]).toMatchObject({
+      stableId: "second",
+      target: { reference: { type: "local", id: "parent" } },
+      dependencies: ["first"],
+      timing: { begin: [{ type: "syncbase", animationId: "first", phase: "end", offsetSeconds: 0.25 }] },
+    });
+    expect(document.animationProgram.evaluationOrder).toEqual(["first", "second"]);
+  });
+
+  test("assigns deterministic stable ids without changing authored targets", () => {
+    const first = __testing.parseRenderDocument(numericAnimation).animationProgram;
+    const second = __testing.parseRenderDocument(numericAnimation).animationProgram;
+    expect(second).toEqual(first);
+    expect(first.animations[0]?.stableId).toBe("move");
+
+    const anonymous = __testing.parseRenderDocument(
+      `<svg viewBox="0 0 10 10"><rect id="box" width="2" height="2"><animate attributeName="x" from="0" to="8" dur="1s"/></rect></svg>`,
+    );
+    expect(anonymous.animationProgram.animations[0]?.stableId).toMatch(/^animation-\d{6}$/);
+  });
+
+  test("emits structured target, value, dependency, and cycle diagnostics", () => {
+    const result = convertWithDiagnostics(`
+      <svg viewBox="0 0 20 20">
+        <rect id="duplicate" width="2" height="2"/><circle id="duplicate" r="1"/>
+        <animate id="missing" href="#nope" attributeName="x" from="0" to="1" dur="1s"/>
+        <animate id="ambiguous" href="#duplicate" attributeName="x" from="0" to="1" dur="1s"/>
+        <animate id="wrong" href="#missing" attributeName="x" from="0" to="1" dur="1s"/>
+        <animate id="color" href="#duplicate" attributeName="fill" from="red" to="blue" dur="1s"/>
+        <animate id="a" href="#duplicate" attributeName="x" from="0" to="1" begin="b.end" dur="1s"/>
+        <animate id="b" href="#duplicate" attributeName="x" from="0" to="1" begin="a.end" dur="1s"/>
+      </svg>`);
+    const codes = result.diagnostics.map((item) => item.code);
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        "missing-animation-target",
+        "duplicate-animation-target-id",
+        "wrong-animation-target-type",
+        "unsupported-animation-value",
+        "cyclic-animation-dependency",
+      ]),
+    );
+    expect(result.diagnostics.every((item) => item.source && item.fallback)).toBe(true);
+  });
+});
+
+describe("generated animation clock", () => {
+  test("samples negative, zero, fractional, non-finite, and very large exact times deterministically", () => {
+    const animation = __testing.parseRenderDocument(numericAnimation).animationProgram.animations[0]!;
+    expect(sampleNumericAnimation(animation, -1)).toBe(16);
+    expect(sampleNumericAnimation(animation, 0)).toBe(16);
+    expect(sampleNumericAnimation(animation, 0.25)).toBe(16);
+    expect(sampleNumericAnimation(animation, 0.75)).toBe(48);
+    expect(sampleNumericAnimation(animation, Number.NaN)).toBe(16);
+    expect(sampleNumericAnimation(animation, Number.MAX_VALUE)).toBe(80);
+  });
+
+  test("emits one document clock, exact injection, and a production TimelineView adapter", () => {
+    const swift = convert(numericAnimation, { structName: "AnimatedDot", strict: true });
+    expect(swift).toContain("struct AnimatedDot: View");
+    expect(swift).toContain("init(documentTime: Double? = nil, respectsReducedMotion: Bool = false)");
+    expect(swift).toContain("TimelineView(.animation(paused:");
+    expect(swift).toContain("content(at: Self.sanitizedDocumentTime(documentTime))");
+    expect(swift).toContain("svgAnimatedNumber(documentTime: documentTime");
+    expect(swift).toContain(".offset(x:");
+    expect(swift.match(/TimelineView/g)).toHaveLength(1);
+  });
+
+  test("keeps static output on the Shape fast path without animation runtime code", () => {
+    const source = `<svg viewBox="0 0 10 10"><rect width="10" height="10"/></svg>`;
+    const first = convert(source, { structName: "StaticBox" });
+    const second = convert(source, { structName: "StaticBox" });
+    expect(first).toBe(second);
+    expect(first).toContain("struct StaticBox: Shape");
+    expect(first).not.toContain("TimelineView");
+    expect(first).not.toContain("documentTime");
+  });
+});

--- a/packages/svg-to-swiftui-core/src/tests/conformance.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/conformance.test.ts
@@ -29,7 +29,7 @@ describe("static SVG conformance contract", () => {
     );
   });
 
-  test("diagnoses every excluded dynamic element, event handler, and navigation", () => {
+  test("diagnoses excluded runtime content while declarative animation gets precise compiler diagnostics", () => {
     const tags = [
       "animate",
       "animateMotion",
@@ -53,7 +53,13 @@ describe("static SVG conformance contract", () => {
       expect.arrayContaining([
         "dynamic-event-handler",
         "dynamic-navigation",
-        ...tags.map((tag) => (tag === "script" ? "unsupported-script" : `dynamic-${tag.toLowerCase()}`)),
+        "missing-animation-attribute",
+        "unsupported-script",
+        "dynamic-audio",
+        "dynamic-canvas",
+        "dynamic-iframe",
+        "dynamic-mpath",
+        "dynamic-video",
       ]),
     );
     expect(result.diagnostics.every((item) => item.location && item.fallback)).toBe(true);

--- a/packages/svg-to-swiftui-core/visual-tests/batch-render.ts
+++ b/packages/svg-to-swiftui-core/visual-tests/batch-render.ts
@@ -70,15 +70,15 @@ function generatedSource(support: string, items: BatchTestItem[]): string {
   const factories = items
     .map((item) =>
       item.expectedMode === "shape"
-        ? `    { AnyView(${item.swiftTypeName}().fill(Color.black)) }`
-        : `    { AnyView(${item.swiftTypeName}()) }`,
+        ? `    { _ in AnyView(${item.swiftTypeName}().fill(Color.black)) }`
+        : `    { _ in AnyView(${item.swiftTypeName}()) }`,
     )
     .join(",\n");
   return `${support}
 
 ${declarations}
 
-let _visualFactories: [() -> AnyView] = [
+let _visualFactories: [(Int64) -> AnyView] = [
 ${factories}
 ]
 let _visualTaskData = try Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1]))

--- a/packages/svg-to-swiftui-core/visual-tests/swiftui-renderer-support.swift
+++ b/packages/svg-to-swiftui-core/visual-tests/swiftui-renderer-support.swift
@@ -169,7 +169,7 @@ enum _VisualRenderError: Error, CustomStringConvertible {
 }
 
 @MainActor
-func _renderVisualTask(_ task: _VisualTask, factories: [() -> AnyView]) throws {
+func _renderVisualTask(_ task: _VisualTask, factories: [(Int64) -> AnyView]) throws {
     guard factories.indices.contains(task.index) else { throw _VisualRenderError.invalidIndex(task.index) }
 
     for font in task.fonts {
@@ -191,7 +191,7 @@ func _renderVisualTask(_ task: _VisualTask, factories: [() -> AnyView]) throws {
         blue: task.backgroundB,
         opacity: task.backgroundA
     )
-    let content = factories[task.index]()
+    let content = factories[task.index](task.timeMicroseconds ?? 0)
         .frame(width: task.width, height: task.height, alignment: .topLeading)
         .background(background)
         .environment(\.colorScheme, .light)


### PR DESCRIPTION
Closes #96.

## What changed

- Added an immutable typed animation IR with stable IDs, parent/href targets, typed timing/value/composition data, dependency ordering, and structured diagnostics.
- Added generated SwiftUI animation views with a production `TimelineView` clock and exact `documentTime` injection.
- Kept static documents on their existing output path with no animation runtime code.
- Threaded exact microsecond timestamps into compiled SwiftUI test factories.
- Promoted the first SMIL numeric `cx` case into benchmark 01: SVG reference → generated Swift → rendered SwiftUI → lossless RGBA frame comparison.
- Documented restart, pause/resume, Reduced Motion, negative/non-finite/large time behavior.

## Validation

- Core typecheck and Biome checks pass.
- 299 Jest tests pass.
- Animation manifest: 3 fixtures / 9 exact frames.
- Full temporal suite: 6 compared frames and 1 reference probe pass.
- Benchmark 01: all 3 exact frames pass; SVG, SwiftUI, and side-by-side MP4s encode.
