### PR TITLE
Implement deterministic SMIL timing

### DIFF
--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -248,6 +248,8 @@ The animation harness extends the same compiler pipeline across an exact microse
 
 Generated animated views expose deterministic and production clock paths. See the [animation clock contract](docs/animation-clock.md) for restart, pause/resume, Reduced Motion, and exact-time behavior.
 
+SMIL scheduling is compiled separately from drawing. See the [SMIL timing contract](docs/smil-timing.md) for supported syntax, state samples, deterministic events, dependency ordering, and strict/permissive fallbacks.
+
 Optional MP4 files are review artifacts only. They are encoded after the lossless comparisons and never decide whether a test passes. Animation compiler support is being implemented in dependency order under the [Animated SVG roadmap](https://github.com/bring-shrubbery/SVG-to-SwiftUI/issues/94).
 
 ## Migration from 0.4

--- a/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
@@ -39,6 +39,72 @@
       },
       "expectDistinctReferenceFrames": true
     },
+    "reference-smil-clock-controls": {
+      "mode": "reference-probe",
+      "referenceBackend": "webkit",
+      "width": 96,
+      "height": 48,
+      "tags": [
+        "clock-values",
+        "fill",
+        "fractional-repeat",
+        "full-partial-clock",
+        "instance-time-list",
+        "min-max",
+        "negative-begin",
+        "repeat",
+        "repeat-count",
+        "repeat-duration",
+        "restart",
+        "restart-always",
+        "restart-when-not-active",
+        "smil-timing"
+      ],
+      "timeline": {
+        "durationMicroseconds": 2100000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [
+          0, 199999, 200000, 499999, 500000, 699999, 700000, 1199999, 1200000, 1499999, 1500000, 2099999, 2100000
+        ]
+      }
+    },
+    "reference-smil-dependencies": {
+      "mode": "reference-probe",
+      "referenceBackend": "webkit",
+      "width": 96,
+      "height": 48,
+      "tags": ["repeat-reference", "smil-timing", "syncbase"],
+      "timeline": {
+        "durationMicroseconds": 1600000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [0, 499999, 500000, 999999, 1000000, 1099999, 1100000, 1599999, 1600000]
+      }
+    },
+    "reference-smil-eventbase": {
+      "mode": "reference-probe",
+      "referenceBackend": "webkit",
+      "width": 96,
+      "height": 48,
+      "tags": ["deterministic-events", "eventbase", "smil-timing"],
+      "events": [{ "timeMicroseconds": 300000, "targetId": "trigger", "name": "click" }],
+      "timeline": {
+        "durationMicroseconds": 800000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [0, 299999, 300000, 399999, 400000, 799999, 800000]
+      }
+    },
+    "reference-smil-edge-cases": {
+      "mode": "reference-probe",
+      "referenceBackend": "webkit",
+      "width": 96,
+      "height": 48,
+      "tags": ["end-list", "indefinite", "instance-time-list", "restart-never", "smil-timing", "zero-duration"],
+      "timeline": {
+        "durationMicroseconds": 500000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [0, 99999, 100000, 199999, 200000, 399999, 400000, 499999, 500000]
+      }
+    },
     "benchmark-01-numeric-cx": {
       "mode": "comparison",
       "referenceBackend": "webkit",
@@ -52,6 +118,49 @@
         "sampleTimesMicroseconds": [0, 500000, 1000000]
       },
       "expectDistinctReferenceFrames": true
+    },
+    "benchmark-02-smil-timing": {
+      "mode": "comparison",
+      "referenceBackend": "webkit",
+      "width": 96,
+      "height": 48,
+      "expectedMode": "view",
+      "tags": ["animate", "benchmark-02", "boundaries", "discrete", "repeat", "smil-timing"],
+      "timeline": {
+        "durationMicroseconds": 1400000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [
+          0, 199999, 200000, 399999, 400000, 599999, 600000, 799999, 800000, 999999, 1000000, 1199999, 1200000, 1399999,
+          1400000
+        ]
+      }
+    },
+    "benchmark-03-advanced-timing": {
+      "mode": "comparison",
+      "referenceBackend": "webkit",
+      "width": 96,
+      "height": 48,
+      "expectedMode": "view",
+      "tags": [
+        "benchmark-03",
+        "discrete",
+        "fractional-repeat",
+        "min-max",
+        "multiple-intervals",
+        "repeat-duration",
+        "smil-timing",
+        "syncbase"
+      ],
+      "timeline": {
+        "durationMicroseconds": 2700000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [
+          0, 133333, 133334, 266666, 266667, 399999, 400000, 533333, 533334, 666666, 666667, 799999, 800000, 899999,
+          900000, 999999, 1000000, 1199999, 1200000, 1249999, 1250000, 1333333, 1333334, 1466666, 1466667, 1499999,
+          1500000, 1599999, 1600000, 1733333, 1733334, 1866666, 1866667, 1999999, 2000000, 2099999, 2100000, 2199999,
+          2200000, 2449999, 2450000, 2699999, 2700000
+        ]
+      }
     }
   }
 }

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-02-smil-timing.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-02-smil-timing.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="48" viewBox="0 0 96 48">
+  <rect width="96" height="48" rx="8" fill="#0f172a"/>
+  <path d="M16 24H80" stroke="#334155" stroke-width="2"/>
+  <circle id="timed-dot" cx="16" cy="24" r="9" fill="#f59e0b">
+    <animate attributeName="cx" values="16;48;80" calcMode="discrete" begin="200ms" dur="600ms" repeatCount="2" fill="freeze"/>
+  </circle>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-03-advanced-timing.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-03-advanced-timing.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="48" viewBox="0 0 96 48">
+  <rect width="96" height="48" rx="8" fill="#0f172a"/>
+  <path d="M12 16H84M12 32H84" stroke="#334155" stroke-width="2"/>
+  <circle id="lead-dot" cx="12" cy="16" r="6" fill="#22c55e">
+    <animate id="lead-timing" attributeName="cx" values="12;48;84" calcMode="discrete"
+      begin="0s;1.2s" dur="400ms" repeatCount="2.5" repeatDur="900ms"
+      min="300ms" max="1s" restart="always" fill="freeze"/>
+  </circle>
+  <circle id="dependent-dot" cx="12" cy="32" r="6" fill="#f472b6">
+    <animate attributeName="cx" values="12;84" calcMode="discrete"
+      begin="lead-timing.end+100ms" dur="500ms" fill="freeze"/>
+  </circle>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-smil-clock-controls.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-smil-clock-controls.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="48" viewBox="0 0 96 48">
+  <rect width="96" height="48" rx="8" fill="#111827"/>
+  <path d="M12 16H84M12 32H84" stroke="#374151" stroke-width="2"/>
+  <circle cx="12" cy="16" r="6" fill="#22c55e">
+    <animate attributeName="cx" values="12;48;84" calcMode="discrete"
+      begin="-200ms;00:00:01.2;00:01.2" dur="400ms" repeatCount="2.5" repeatDur="900ms"
+      min="300ms" max="1s" restart="always" fill="freeze"/>
+  </circle>
+  <circle cx="12" cy="32" r="6" fill="#a78bfa">
+    <animate attributeName="cx" from="12" to="84" begin="200ms;500ms;1.5s"
+      dur="600ms" restart="whenNotActive" fill="freeze"/>
+  </circle>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-smil-dependencies.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-smil-dependencies.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="48" viewBox="0 0 96 48">
+  <rect width="96" height="48" rx="8" fill="#0f172a"/>
+  <circle cx="12" cy="12" r="5" fill="#38bdf8">
+    <animate id="source-timing" attributeName="cx" from="12" to="84" dur="500ms" repeatCount="2" fill="freeze"/>
+  </circle>
+  <circle cx="12" cy="24" r="5" fill="#f59e0b">
+    <animate attributeName="cx" from="12" to="84" begin="source-timing.repeat(1)" dur="500ms" fill="freeze"/>
+  </circle>
+  <circle cx="12" cy="36" r="5" fill="#f472b6">
+    <animate attributeName="cx" from="12" to="84" begin="source-timing.end+100ms" dur="500ms" fill="freeze"/>
+  </circle>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-smil-edge-cases.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-smil-edge-cases.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="48" viewBox="0 0 96 48">
+  <rect width="96" height="48" rx="8" fill="#111827"/>
+  <circle cx="12" cy="12" r="5" fill="#34d399">
+    <animate attributeName="cx" from="12" to="84" begin="200ms;400ms" dur="0s" restart="never" fill="freeze"/>
+  </circle>
+  <circle cx="12" cy="24" r="5" fill="#60a5fa">
+    <animate attributeName="cx" from="12" to="84" begin="100ms" dur="indefinite" end="500ms;indefinite" fill="freeze"/>
+  </circle>
+  <circle cx="48" cy="36" r="5" fill="#94a3b8">
+    <set attributeName="fill" to="#f43f5e" begin="indefinite"/>
+  </circle>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-smil-eventbase.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/reference-smil-eventbase.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="48" viewBox="0 0 96 48">
+  <rect width="96" height="48" rx="8" fill="#172033"/>
+  <circle id="trigger" cx="16" cy="24" r="8" fill="#64748b"/>
+  <rect x="32" y="16" width="16" height="16" rx="3" fill="#ef4444">
+    <animate attributeName="x" values="32;56;72" calcMode="discrete"
+      begin="trigger.click+100ms" dur="400ms" fill="freeze"/>
+  </rect>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/manifest.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/manifest.ts
@@ -5,10 +5,33 @@ import type { RgbaTolerance } from "../visual-tests/rgba-compare";
 const ANIMATION_TESTS_DIR = __dirname;
 export const ANIMATION_FIXTURES_DIR = resolve(ANIMATION_TESTS_DIR, "fixtures");
 export const ANIMATION_MANIFEST_PATH = resolve(ANIMATION_TESTS_DIR, "animation-fixture-manifest.json");
+export const SMIL_TIMING_EXPECTATIONS_PATH = resolve(ANIMATION_TESTS_DIR, "smil-timing-expectations.json");
 
 export type AnimationFixtureMode = "comparison" | "reference-probe";
 export type ExpectedOutputMode = "shape" | "view";
 export type AnimationReferenceBackend = "webkit";
+
+const REQUIRED_SMIL_TIMING_PROBE_TAGS = [
+  "clock-values",
+  "deterministic-events",
+  "end-list",
+  "eventbase",
+  "fill",
+  "fractional-repeat",
+  "full-partial-clock",
+  "indefinite",
+  "instance-time-list",
+  "min-max",
+  "negative-begin",
+  "repeat-count",
+  "repeat-duration",
+  "repeat-reference",
+  "restart-always",
+  "restart-never",
+  "restart-when-not-active",
+  "syncbase",
+  "zero-duration",
+] as const;
 
 function validateBackground(value: string | null): void {
   if (value !== null && !/^#([\da-f]{6}|[\da-f]{8})$/i.test(value))
@@ -20,6 +43,12 @@ export interface AnimationTimeline {
   framesPerSecond: number;
   sampleTimesMicroseconds?: number[];
   includeEndFrame?: boolean;
+}
+
+export interface AnimationTimelineEvent {
+  timeMicroseconds: number;
+  name: string;
+  targetId?: string;
 }
 
 interface RawAnimationFixture {
@@ -34,6 +63,7 @@ interface RawAnimationFixture {
   expectedMode?: ExpectedOutputMode;
   tags: string[];
   timeline: AnimationTimeline;
+  events?: AnimationTimelineEvent[];
   expectDistinctReferenceFrames?: boolean;
   tolerance?: Partial<RgbaTolerance>;
   toleranceReason?: string;
@@ -49,6 +79,23 @@ interface AnimationManifestFile {
     tolerance: RgbaTolerance;
   };
   fixtures: Record<string, RawAnimationFixture>;
+}
+
+export interface SMILTimingExpectationSet {
+  beginSeconds: number;
+  durationSeconds: number;
+  repeatCount: number;
+  fill: "remove" | "freeze";
+  values: number[];
+  samples: Array<{
+    timeMicroseconds: number;
+    state: "inactive" | "active" | "frozen" | "completed";
+    iteration: number;
+    value: number;
+    beginBoundary?: boolean;
+    endBoundary?: boolean;
+    repeatBoundary?: boolean;
+  }>;
 }
 
 export interface AnimationFrame {
@@ -72,6 +119,7 @@ export interface LoadedAnimationFixture {
   expectedMode?: ExpectedOutputMode;
   tags: string[];
   timeline: AnimationTimeline;
+  events: AnimationTimelineEvent[];
   frames: AnimationFrame[];
   expectDistinctReferenceFrames: boolean;
   tolerance: RgbaTolerance;
@@ -121,6 +169,10 @@ function readManifest(): AnimationManifestFile {
   return JSON.parse(readFileSync(ANIMATION_MANIFEST_PATH, "utf8")) as AnimationManifestFile;
 }
 
+export function loadSMILTimingExpectations(): Record<string, SMILTimingExpectationSet> {
+  return JSON.parse(readFileSync(SMIL_TIMING_EXPECTATIONS_PATH, "utf8")) as Record<string, SMILTimingExpectationSet>;
+}
+
 export function loadAnimationFixtures(): LoadedAnimationFixture[] {
   const manifest = readManifest();
   if (manifest.version !== 1) throw new Error(`Unsupported animation fixture manifest version: ${manifest.version}`);
@@ -141,6 +193,7 @@ export function loadAnimationFixtures(): LoadedAnimationFixture[] {
       ...(entry.expectedMode ? { expectedMode: entry.expectedMode } : {}),
       tags: entry.tags,
       timeline: entry.timeline,
+      events: entry.events ?? [],
       frames: timelineFrames(entry.timeline),
       expectDistinctReferenceFrames: entry.expectDistinctReferenceFrames ?? false,
       tolerance: { ...manifest.defaults.tolerance, ...entry.tolerance },
@@ -156,9 +209,11 @@ export function validateAnimationManifest(): string[] {
   const errors: string[] = [];
   let manifest: AnimationManifestFile;
   let fixtures: LoadedAnimationFixture[];
+  let timingExpectations: Record<string, SMILTimingExpectationSet>;
   try {
     manifest = readManifest();
     fixtures = loadAnimationFixtures();
+    timingExpectations = loadSMILTimingExpectations();
   } catch (error) {
     return [error instanceof Error ? error.message : String(error)];
   }
@@ -168,6 +223,15 @@ export function validateAnimationManifest(): string[] {
   for (const name of actual)
     if (!declared.has(name)) errors.push(`Animation fixture missing from manifest: ${name}.svg`);
   for (const name of declared) if (!actual.has(name)) errors.push(`Animation manifest entry has no SVG: ${name}.svg`);
+  for (const name of Object.keys(timingExpectations))
+    if (!declared.has(name)) errors.push(`SMIL timing expectations have no manifest fixture: ${name}`);
+  const timingProbeTags = new Set(
+    fixtures
+      .filter((fixture) => fixture.mode === "reference-probe" && fixture.tags.includes("smil-timing"))
+      .flatMap((fixture) => fixture.tags),
+  );
+  for (const tag of REQUIRED_SMIL_TIMING_PROBE_TAGS)
+    if (!timingProbeTags.has(tag)) errors.push(`SMIL timing reference probes do not cover required tag: ${tag}`);
 
   for (const fixture of fixtures) {
     const prefix = `${fixture.name}:`;
@@ -180,9 +244,26 @@ export function validateAnimationManifest(): string[] {
     if (!validPositiveInteger(fixture.timeline.framesPerSecond))
       errors.push(`${prefix} framesPerSecond must be a positive safe integer`);
     if (fixture.timeline.framesPerSecond > 240) errors.push(`${prefix} framesPerSecond must not exceed 240`);
+    if (
+      fixture.events.some(
+        (event, index) =>
+          !Number.isSafeInteger(event.timeMicroseconds) ||
+          event.timeMicroseconds < 0 ||
+          event.timeMicroseconds > fixture.timeline.durationMicroseconds ||
+          event.name.trim() === "" ||
+          (index > 0 && event.timeMicroseconds < fixture.events[index - 1]!.timeMicroseconds),
+      )
+    )
+      errors.push(`${prefix} events must be named, ordered, safe microsecond times inside the timeline`);
     if (fixture.frames.length === 0) errors.push(`${prefix} timeline must produce at least one frame`);
     if (fixture.frames.length > 10_000) errors.push(`${prefix} timeline must not exceed 10,000 frames`);
     const times = fixture.frames.map((frame) => frame.timeMicroseconds);
+    const timingExpectation = timingExpectations[fixture.name];
+    if (
+      timingExpectation &&
+      JSON.stringify(times) !== JSON.stringify(timingExpectation.samples.map((sample) => sample.timeMicroseconds))
+    )
+      errors.push(`${prefix} frame schedule must exactly match its shared SMIL timing expectations`);
     if (times.some((time) => !Number.isSafeInteger(time) || time < 0))
       errors.push(`${prefix} sample times must be non-negative safe integer microseconds`);
     if (new Set(times).size !== times.length) errors.push(`${prefix} sample times must be unique`);

--- a/packages/svg-to-swiftui-core/animation-tests/run-animation-tests.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/run-animation-tests.ts
@@ -232,6 +232,7 @@ function renderReferenceFrames(fixture: LoadedAnimationFixture, source: string):
       height: fixture.height,
       pixelWidth: Math.round(fixture.width * fixture.scale),
       pixelHeight: Math.round(fixture.height * fixture.scale),
+      events: fixture.events,
       frames: fixture.frames.map((frame) => ({
         timeMicroseconds: frame.timeMicroseconds,
         output: referencePath(fixture, frame.stem),
@@ -431,6 +432,7 @@ async function main(): Promise<void> {
           scale: fixture.scale,
           background: fixture.background,
           referenceBackend: fixture.referenceBackend,
+          events: fixture.events,
           frames: fixture.frames,
         }),
         ...fixture.fonts.map((font) => readFileSync(resolve(__dirname, font))),

--- a/packages/svg-to-swiftui-core/animation-tests/smil-timing-expectations.json
+++ b/packages/svg-to-swiftui-core/animation-tests/smil-timing-expectations.json
@@ -1,0 +1,26 @@
+{
+  "benchmark-02-smil-timing": {
+    "beginSeconds": 0.2,
+    "durationSeconds": 0.6,
+    "repeatCount": 2,
+    "fill": "freeze",
+    "values": [16, 48, 80],
+    "samples": [
+      { "timeMicroseconds": 0, "state": "inactive", "iteration": 0, "value": 16 },
+      { "timeMicroseconds": 199999, "state": "inactive", "iteration": 0, "value": 16 },
+      { "timeMicroseconds": 200000, "state": "active", "iteration": 0, "value": 16, "beginBoundary": true },
+      { "timeMicroseconds": 399999, "state": "active", "iteration": 0, "value": 16 },
+      { "timeMicroseconds": 400000, "state": "active", "iteration": 0, "value": 48 },
+      { "timeMicroseconds": 599999, "state": "active", "iteration": 0, "value": 48 },
+      { "timeMicroseconds": 600000, "state": "active", "iteration": 0, "value": 80 },
+      { "timeMicroseconds": 799999, "state": "active", "iteration": 0, "value": 80 },
+      { "timeMicroseconds": 800000, "state": "active", "iteration": 1, "value": 16, "repeatBoundary": true },
+      { "timeMicroseconds": 999999, "state": "active", "iteration": 1, "value": 16 },
+      { "timeMicroseconds": 1000000, "state": "active", "iteration": 1, "value": 48 },
+      { "timeMicroseconds": 1199999, "state": "active", "iteration": 1, "value": 48 },
+      { "timeMicroseconds": 1200000, "state": "active", "iteration": 1, "value": 80 },
+      { "timeMicroseconds": 1399999, "state": "active", "iteration": 1, "value": 80 },
+      { "timeMicroseconds": 1400000, "state": "frozen", "iteration": 1, "value": 80, "endBoundary": true }
+    ]
+  }
+}

--- a/packages/svg-to-swiftui-core/animation-tests/webkit-animation-reference.swift
+++ b/packages/svg-to-swiftui-core/animation-tests/webkit-animation-reference.swift
@@ -6,12 +6,19 @@ struct AnimationFrameTask: Decodable {
     let output: String
 }
 
+struct AnimationEventTask: Decodable {
+    let timeMicroseconds: Int64
+    let name: String
+    let targetId: String?
+}
+
 struct AnimationRenderTask: Decodable {
     let input: String
     let width: Int
     let height: Int
     let pixelWidth: Int
     let pixelHeight: Int
+    let events: [AnimationEventTask]
     let frames: [AnimationFrameTask]
 }
 
@@ -52,10 +59,25 @@ final class AnimationSnapshotRenderer: NSObject, WKNavigationDelegate {
         let frame = task.frames[frameIndex]
         let seconds = Double(frame.timeMicroseconds) / 1_000_000
         let milliseconds = Double(frame.timeMicroseconds) / 1_000
+        let events = task.events
+            .filter { $0.timeMicroseconds <= frame.timeMicroseconds }
+            .map { event in
+                let target = event.targetId.map { "document.getElementById(\(javascriptString($0)))" } ?? "root"
+                let key = "\(event.timeMicroseconds):\(event.targetId ?? ""):\(event.name)"
+                return "{ key: \(javascriptString(key)), time: \(Double(event.timeMicroseconds) / 1_000_000), target: \(target), name: \(javascriptString(event.name)) }"
+            }
+            .joined(separator: ",")
         let script = """
         (() => {
           const root = document.documentElement;
           if (typeof root.pauseAnimations === 'function') root.pauseAnimations();
+          window.__svgTimingEvents = window.__svgTimingEvents || new Set();
+          for (const event of [\(events)]) {
+            if (window.__svgTimingEvents.has(event.key) || !event.target) continue;
+            if (typeof root.setCurrentTime === 'function') root.setCurrentTime(event.time);
+            event.target.dispatchEvent(new Event(event.name));
+            window.__svgTimingEvents.add(event.key);
+          }
           if (typeof root.setCurrentTime === 'function') root.setCurrentTime(\(seconds));
           for (const animation of document.getAnimations()) {
             animation.pause();
@@ -128,6 +150,12 @@ final class AnimationSnapshotRenderer: NSObject, WKNavigationDelegate {
         fputs("\(message)\n", stderr)
         exit(1)
     }
+}
+
+private func javascriptString(_ value: String) -> String {
+    let data = try! JSONSerialization.data(withJSONObject: [value])
+    let array = String(data: data, encoding: .utf8)!
+    return String(array.dropFirst().dropLast())
 }
 
 let arguments = CommandLine.arguments

--- a/packages/svg-to-swiftui-core/docs/smil-timing.md
+++ b/packages/svg-to-swiftui-core/docs/smil-timing.md
@@ -1,0 +1,27 @@
+# SMIL timing contract
+
+The compiler models SVG animation timing independently from interpolation and drawing. A timing sample is a pure function of the immutable animation program, document time, and an ordered deterministic event trace.
+
+The implementation follows the W3C [SMIL timing model](https://www.w3.org/TR/SMIL3/smil-timing.html) for clock values, instance-time lists, active-duration arithmetic, repeats, `min`, `max`, `restart`, and timing `fill`.
+
+## Supported timing input
+
+- offset, full-clock, and partial-clock values, including negative begin offsets
+- semicolon-separated `begin` and `end` lists
+- syncbase `id.begin` and `id.end` references with offsets
+- `id.repeat(n)` references
+- deterministic eventbase references supplied as `{ time, targetId, name, order }`
+- finite or indefinite `dur`, `repeatCount`, and `repeatDur`
+- `min`, `max`, `restart="always|whenNotActive|never"`, and `fill="remove|freeze"`
+
+The sample reports inactive, active, frozen, or completed state; simple time and progress; active/simple duration; repeat iteration; exact begin/end/repeat boundaries; selected begin; and the effective interval. Equal timestamps use dependency order, document order, then event input order.
+
+Dependency cycles and missing references remain unresolved and produce source-located diagnostics. They never recurse at runtime.
+
+## Deterministic fallbacks
+
+`wallclock(...)` and `accessKey(...)` are parsed into explicit typed values but are not reinterpreted. Their instance times stay unresolved. Permissive conversion emits a diagnostic and keeps the animation inactive; strict conversion fails.
+
+Invalid `min`/`max` values are ignored as the specification requires. When numeric `max` is less than `min`, both bounds are ignored. Invalid timing still produces a diagnostic so strict builds can enforce clean source.
+
+The temporal test manifest stores exact microsecond boundary frames. Shared serialized expectations drive the TypeScript sampler, generated Swift timing helper, WebKit reference seek, and SwiftUI frame comparison.

--- a/packages/svg-to-swiftui-core/src/index.ts
+++ b/packages/svg-to-swiftui-core/src/index.ts
@@ -27,6 +27,20 @@ export type {
 } from "./renderTree/animation";
 export { sampleNumericAnimation } from "./renderTree/animation";
 export type {
+  DeterministicTimingEvent,
+  SMILProgramSample,
+  SMILTimingInterval,
+  SMILTimingSample,
+  SMILTimingState,
+} from "./renderTree/smilTiming";
+export {
+  computeSMILActiveDuration,
+  computeSMILRepeatingDuration,
+  resolveSMILIntervals,
+  sampleSMILProgram,
+  sampleSMILTiming,
+} from "./renderTree/smilTiming";
+export type {
   DiagnosticSeverity,
   OutputMode,
   RenderDiagnostic,

--- a/packages/svg-to-swiftui-core/src/renderTree/animation.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/animation.ts
@@ -1,4 +1,5 @@
 import type { ElementNode } from "svg-parser";
+import { sampleSMILTiming } from "./smilTiming";
 import type { RenderDiagnostic, SourceLocation } from "./types";
 
 export type AnimationKind = "animate" | "set" | "animateTransform" | "animateMotion" | "discard";
@@ -6,7 +7,10 @@ export type AnimationKind = "animate" | "set" | "animateTransform" | "animateMot
 export type AnimationTime =
   | { type: "offset"; seconds: number }
   | { type: "syncbase"; animationId: string; phase: "begin" | "end"; offsetSeconds: number }
+  | { type: "repeat"; animationId: string; iteration: number; offsetSeconds: number }
   | { type: "event"; targetId?: string; event: string; offsetSeconds: number }
+  | { type: "accessKey"; key: string; offsetSeconds: number }
+  | { type: "wallclock"; value: string }
   | { type: "indefinite" }
   | { type: "invalid"; syntax: string };
 
@@ -69,13 +73,14 @@ export interface AnimationDefinition {
   };
   documentOrder: number;
   dependencies: readonly string[];
-  runtimeSupport: "numeric-linear" | "pending" | "invalid";
+  runtimeSupport: "numeric-linear" | "numeric-discrete" | "pending" | "invalid";
 }
 
 export interface AnimationProgram {
   animations: readonly AnimationDefinition[];
   /** Stable dependency order. Presentation sampling must never mutate the static render tree. */
   evaluationOrder: readonly string[];
+  dependencyCycles: readonly (readonly string[])[];
 }
 
 const ANIMATION_TAGS = new Map<string, AnimationKind>([
@@ -143,7 +148,12 @@ function diagnostic(
 function parseClock(raw: string): number | undefined {
   const value = raw.trim().toLowerCase();
   const clock = /^(?:(\d+):)?(\d{1,2}):(\d{1,2}(?:\.\d+)?)$/.exec(value);
-  if (clock) return Number(clock[1] ?? 0) * 3600 + Number(clock[2]) * 60 + Number(clock[3]);
+  if (clock) {
+    const minutes = Number(clock[2]);
+    const seconds = Number(clock[3]);
+    if (minutes >= 60 || seconds >= 60) return undefined;
+    return Number(clock[1] ?? 0) * 3600 + minutes * 60 + seconds;
+  }
   const unit = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))(ms|s|min|h)?$/.exec(value);
   if (!unit) return undefined;
   const number = Number(unit[1]);
@@ -153,9 +163,31 @@ function parseClock(raw: string): number | undefined {
 
 function parseTime(raw: string): AnimationTime {
   const value = raw.trim();
+  if (value === "") return { type: "invalid", syntax: value };
   if (value === "indefinite") return { type: "indefinite" };
+  const wallclock = /^wallclock\((.+)\)$/i.exec(value);
+  if (wallclock) return { type: "wallclock", value: wallclock[1]!.trim() };
+  const accessKey = /^accesskey\((.)\)([+-].+)?$/i.exec(value);
+  if (accessKey) {
+    const parsedOffset = accessKey[2] ? parseClock(accessKey[2]) : 0;
+    return parsedOffset === undefined
+      ? { type: "invalid", syntax: value }
+      : { type: "accessKey", key: accessKey[1]!, offsetSeconds: parsedOffset };
+  }
   const offset = parseClock(value);
   if (offset !== undefined) return { type: "offset", seconds: offset };
+  const repeat = /^([\w:.-]+)\.repeat\((\d+)\)([+-].+)?$/i.exec(value);
+  if (repeat) {
+    const parsedOffset = repeat[3] ? parseClock(repeat[3]) : 0;
+    return parsedOffset === undefined || Number(repeat[2]) <= 0
+      ? { type: "invalid", syntax: value }
+      : {
+          type: "repeat",
+          animationId: repeat[1]!,
+          iteration: Number(repeat[2]),
+          offsetSeconds: parsedOffset,
+        };
+  }
   const reference = /^([\w:.-]+)\.(begin|end)([+-].+)?$/i.exec(value);
   if (reference) {
     const parsedOffset = reference[3] ? parseClock(reference[3]) : 0;
@@ -184,15 +216,13 @@ function parseTime(raw: string): AnimationTime {
 }
 
 function parseTimes(raw: string | undefined, fallback: readonly AnimationTime[]): readonly AnimationTime[] {
-  if (!raw) return fallback;
-  return raw
-    .split(";")
-    .map(parseTime)
-    .filter((value, index, values) => value.type !== "invalid" || values.length === 1 || index < values.length);
+  if (raw === undefined) return fallback;
+  return raw.split(";").map(parseTime);
 }
 
 function parseDuration(raw: string | undefined): AnimationDuration {
-  if (!raw) return { type: "invalid", syntax: "" };
+  if (raw === undefined) return { type: "indefinite" };
+  if (raw === "") return { type: "invalid", syntax: raw };
   if (raw === "indefinite") return { type: "indefinite" };
   if (raw === "media") return { type: "media" };
   const seconds = parseClock(raw);
@@ -262,12 +292,26 @@ function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSuppor
   if (definition.kind !== "animate" || !definition.target?.renderable || !definition.attributeName) return false;
   if (!definition.target.key.startsWith("id:") || !["cx", "x"].includes(definition.attributeName)) return false;
   if (definition.value.type !== "number") return false;
+  if (
+    definition.timing.duration.type === "invalid" ||
+    definition.timing.duration.type === "media" ||
+    (definition.timing.duration.type === "seconds" &&
+      (!Number.isFinite(definition.timing.duration.seconds) || definition.timing.duration.seconds < 0))
+  )
+    return false;
+  const deterministicTime = (time: AnimationTime) => ["offset", "syncbase", "repeat", "indefinite"].includes(time.type);
+  if (!definition.timing.begin.every(deterministicTime) || !definition.timing.end.every(deterministicTime))
+    return false;
+  if (
+    definition.timing.repeatCount.type === "count" &&
+    (!Number.isFinite(definition.timing.repeatCount.value) || definition.timing.repeatCount.value <= 0)
+  )
+    return false;
+  if (definition.composition.additive !== "replace" || definition.composition.accumulate !== "none") return false;
+  if (definition.composition.calcMode === "discrete") return (definition.value.values?.length ?? 0) >= 2;
+  if (definition.composition.calcMode !== "linear") return false;
   if (definition.value.from === undefined || definition.value.to === undefined) return false;
-  if (definition.timing.duration.type !== "seconds" || definition.timing.duration.seconds <= 0) return false;
-  if (definition.timing.begin.length !== 1 || definition.timing.begin[0]?.type !== "offset") return false;
-  if (definition.timing.end.length > 0) return false;
-  if (definition.timing.repeatCount.type !== "unspecified" || definition.timing.repeatDuration) return false;
-  return definition.composition.additive === "replace" && definition.composition.accumulate === "none";
+  return true;
 }
 
 /** Parse declarative SVG animation into immutable, typed compiler input. */
@@ -377,6 +421,13 @@ export function buildAnimationProgram(root: ElementNode, diagnostics: RenderDiag
         "<animate> requires attributeName.",
         "attributeName",
       );
+    const restartValue = property(element, "restart");
+    const fillValue = property(element, "fill");
+    const parsedMax = parseOptionalDuration(property(element, "max"));
+    const max =
+      parsedMax?.type === "seconds" && parsedMax.seconds <= 0
+        ? ({ type: "invalid", syntax: property(element, "max") ?? "" } as const)
+        : parsedMax;
     const timing: AnimationTiming = {
       begin: parseTimes(property(element, "begin"), [{ type: "offset", seconds: 0 }]),
       duration: parseDuration(property(element, "dur")),
@@ -384,19 +435,22 @@ export function buildAnimationProgram(root: ElementNode, diagnostics: RenderDiag
       ...(parseOptionalDuration(property(element, "min"))
         ? { min: parseOptionalDuration(property(element, "min")) }
         : {}),
-      ...(parseOptionalDuration(property(element, "max"))
-        ? { max: parseOptionalDuration(property(element, "max")) }
-        : {}),
+      ...(max ? { max } : {}),
       repeatCount: parseRepeatCount(property(element, "repeatCount")),
       ...(parseOptionalDuration(property(element, "repeatDur"))
         ? { repeatDuration: parseOptionalDuration(property(element, "repeatDur")) }
         : {}),
-      restart: (property(element, "restart") as AnimationTiming["restart"]) ?? "always",
-      fill: property(element, "fill") === "freeze" ? "freeze" : "remove",
+      restart: ["always", "whenNotActive", "never"].includes(restartValue ?? "")
+        ? (restartValue as AnimationTiming["restart"])
+        : "always",
+      fill: fillValue === "freeze" ? "freeze" : "remove",
     };
     const value = parseValue(element, targetElement, attributeName);
-    const dependencies = timing.begin
-      .filter((time): time is Extract<AnimationTime, { type: "syncbase" }> => time.type === "syncbase")
+    const dependencies = [...timing.begin, ...timing.end]
+      .filter(
+        (time): time is Extract<AnimationTime, { type: "syncbase" | "repeat" }> =>
+          time.type === "syncbase" || time.type === "repeat",
+      )
       .map((time) => time.animationId);
     const baseDefinition = {
       stableId,
@@ -416,7 +470,8 @@ export function buildAnimationProgram(root: ElementNode, diagnostics: RenderDiag
       dependencies,
     };
     let runtimeSupport: AnimationDefinition["runtimeSupport"] = target ? "pending" : "invalid";
-    if (isRuntimeSupported(baseDefinition)) runtimeSupport = "numeric-linear";
+    if (isRuntimeSupported(baseDefinition))
+      runtimeSupport = baseDefinition.composition.calcMode === "discrete" ? "numeric-discrete" : "numeric-linear";
     const definition: AnimationDefinition = { ...baseDefinition, runtimeSupport };
     animations.push(definition);
 
@@ -436,6 +491,63 @@ export function buildAnimationProgram(root: ElementNode, diagnostics: RenderDiag
         "Animation begin contains invalid timing syntax.",
         "begin",
       );
+    if (timing.end.some((time) => time.type === "invalid"))
+      diagnostic(diagnostics, element, "invalid-animation-end", "Animation end contains invalid timing syntax.", "end");
+    for (const [attribute, duration] of [
+      ["min", timing.min],
+      ["max", timing.max],
+      ["repeatDur", timing.repeatDuration],
+    ] as const) {
+      if (duration?.type === "invalid")
+        diagnostic(
+          diagnostics,
+          element,
+          `invalid-animation-${attribute.toLowerCase()}`,
+          `${attribute} contains an invalid duration and is ignored by the timing model.`,
+          attribute,
+        );
+    }
+    for (const [attribute, duration] of [
+      ["dur", timing.duration],
+      ["min", timing.min],
+      ["max", timing.max],
+      ["repeatDur", timing.repeatDuration],
+    ] as const) {
+      if (duration?.type === "media")
+        diagnostic(
+          diagnostics,
+          element,
+          "unsupported-animation-media-duration",
+          `${attribute}="media" has no intrinsic media duration on an SVG animation element and is ignored.`,
+          attribute,
+        );
+    }
+    if (timing.min?.type === "seconds" && timing.max?.type === "seconds" && timing.max.seconds < timing.min.seconds)
+      diagnostic(
+        diagnostics,
+        element,
+        "invalid-animation-min-max",
+        "max is less than min; SVG timing ignores both constraints.",
+        "max",
+      );
+    for (const time of [...timing.begin, ...timing.end]) {
+      if (time.type === "wallclock")
+        diagnostic(
+          diagnostics,
+          element,
+          "unsupported-animation-wallclock",
+          "wallclock timing is nondeterministic in generated SwiftUI; the instance remains unresolved.",
+          timing.begin.includes(time) ? "begin" : "end",
+        );
+      if (time.type === "accessKey")
+        diagnostic(
+          diagnostics,
+          element,
+          "unsupported-animation-accesskey",
+          "accessKey timing has no deterministic native input mapping; the instance remains unresolved.",
+          timing.begin.includes(time) ? "begin" : "end",
+        );
+    }
     if (timing.repeatCount.type === "count" && !Number.isFinite(timing.repeatCount.value))
       diagnostic(
         diagnostics,
@@ -491,14 +603,19 @@ export function buildAnimationProgram(root: ElementNode, diagnostics: RenderDiag
   const visiting = new Set<string>();
   const visited = new Set<string>();
   const evaluationOrder: string[] = [];
+  const dependencyCycles: string[][] = [];
   const visitDependency = (animation: AnimationDefinition, path: string[]): void => {
     if (visited.has(animation.stableId)) return;
     if (visiting.has(animation.stableId)) {
+      const start = path.indexOf(animation.stableId);
+      const cycle = [...path.slice(Math.max(0, start)), animation.stableId];
+      if (!dependencyCycles.some((candidate) => candidate.join("\0") === cycle.join("\0")))
+        dependencyCycles.push(cycle);
       diagnostic(
         diagnostics,
         animationElements.find(({ element }) => property(element, "id") === animation.authoredId)?.element ?? root,
         "cyclic-animation-dependency",
-        `Animation dependency cycle detected: ${[...path, animation.stableId].join(" -> ")}.`,
+        `Animation dependency cycle detected: ${cycle.join(" -> ")}.`,
       );
       return;
     }
@@ -526,7 +643,7 @@ export function buildAnimationProgram(root: ElementNode, diagnostics: RenderDiag
     evaluationOrder.push(animation.stableId);
   };
   for (const animation of animations) visitDependency(animation, []);
-  return { animations, evaluationOrder };
+  return { animations, evaluationOrder, dependencyCycles };
 }
 
 export function declarativeAnimationTag(tagName: string | undefined): boolean {
@@ -536,20 +653,20 @@ export function declarativeAnimationTag(tagName: string | undefined): boolean {
 /** Reference sampler for the first compiler slice and exact clock-boundary tests. */
 export function sampleNumericAnimation(animation: AnimationDefinition, documentTime: number): number | undefined {
   if (
-    animation.runtimeSupport !== "numeric-linear" ||
+    !["numeric-linear", "numeric-discrete"].includes(animation.runtimeSupport) ||
     animation.value.type !== "number" ||
-    animation.value.from === undefined ||
-    animation.value.to === undefined ||
     animation.timing.duration.type !== "seconds" ||
     animation.timing.begin[0]?.type !== "offset"
   )
     return undefined;
-  const time = Number.isFinite(documentTime) ? documentTime : 0;
-  const begin = animation.timing.begin[0].seconds;
-  const duration = animation.timing.duration.seconds;
-  if (time < begin) return animation.value.base;
-  if (duration <= 0 || time >= begin + duration)
-    return animation.timing.fill === "freeze" ? animation.value.to : animation.value.base;
-  const progress = (time - begin) / duration;
+  const sample = sampleSMILTiming(animation.timing, documentTime, [animation.timing.begin[0].seconds]);
+  if (sample.state === "inactive" || sample.state === "completed") return animation.value.base;
+  if (sample.simpleProgress === undefined) return animation.value.base;
+  const progress = sample.simpleProgress;
+  if (animation.runtimeSupport === "numeric-discrete") {
+    const values = animation.value.values!;
+    return values[Math.min(values.length - 1, Math.floor(progress * values.length + 1e-12))];
+  }
+  if (animation.value.from === undefined || animation.value.to === undefined) return undefined;
   return animation.value.from + (animation.value.to - animation.value.from) * progress;
 }

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -2380,7 +2380,7 @@ export function buildRenderDocument(
           },
           resources,
           children: nodes,
-          animationProgram: { animations: [], evaluationOrder: [] },
+          animationProgram: { animations: [], evaluationOrder: [], dependencyCycles: [] },
           diagnostics: [],
         };
         localCandidates.push({

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -9,6 +9,7 @@ import { viewBoxTransform } from "../viewports";
 import { renderNodeBounds } from "./bounds";
 import { type ResolvedGradient, resolveGradientForShape } from "./gradients";
 import { type ResolvedPattern, resolvePatternForShape } from "./patterns";
+import { computeSMILRepeatingDuration, type SMILTimingInterval, sampleSMILProgram } from "./smilTiming";
 import type {
   AccessibilityMetadata,
   ClipPathInstance,
@@ -133,6 +134,7 @@ interface ViewBuildContext {
   subdocuments: string[][];
   rootName: string;
   config: SwiftUIGeneratorConfig;
+  animationIntervals: ReadonlyMap<string, readonly SMILTimingInterval[]>;
 }
 
 function createOptions(
@@ -277,6 +279,10 @@ function formatNumber(value: number, precision = 10): string {
   return String(Object.is(rounded, -0) ? 0 : rounded);
 }
 
+function swiftDuration(value: number): string {
+  return Number.isFinite(value) ? formatNumber(value) : "Double.infinity";
+}
+
 function colorForStop(stop: GradientStop, opacity: number, precision: number): string {
   const { red, green, blue, alpha } = stop.color;
   const channels = `red: ${formatNumber(red, precision)}, green: ${formatNumber(green, precision)}, blue: ${formatNumber(blue, precision)}`;
@@ -332,16 +338,26 @@ function buildViewNodes(
     if (!node.source.id) return undefined;
     const animation = context.document.animationProgram.animations.find(
       (candidate) =>
-        candidate.runtimeSupport === "numeric-linear" &&
+        ["numeric-linear", "numeric-discrete"].includes(candidate.runtimeSupport) &&
         candidate.target?.source.id === node.source.id &&
         (candidate.attributeName === "cx" || candidate.attributeName === "x"),
     );
-    if (!animation || animation.value.type !== "number" || animation.timing.duration.type !== "seconds")
-      return undefined;
-    const begin = animation.timing.begin[0];
-    if (begin?.type !== "offset" || animation.value.from === undefined || animation.value.to === undefined)
-      return undefined;
-    return `Self.svgAnimatedNumber(documentTime: documentTime, begin: ${formatNumber(begin.seconds)}, duration: ${formatNumber(animation.timing.duration.seconds)}, from: ${formatNumber(animation.value.from)}, to: ${formatNumber(animation.value.to)}, base: ${formatNumber(animation.value.base)}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"}) - ${formatNumber(animation.value.base)}`;
+    if (!animation || animation.value.type !== "number") return undefined;
+    const values =
+      animation.runtimeSupport === "numeric-discrete"
+        ? animation.value.values
+        : animation.value.from === undefined || animation.value.to === undefined
+          ? undefined
+          : [animation.value.from, animation.value.to];
+    if (!values || values.length < 2) return undefined;
+    const intervals = context.animationIntervals.get(animation.stableId) ?? [];
+    const intervalLiteral = intervals
+      .map((interval) => `(begin: ${swiftDuration(interval.begin)}, end: ${swiftDuration(interval.end)})`)
+      .join(", ");
+    const duration =
+      animation.timing.duration.type === "seconds" ? animation.timing.duration.seconds : Number.POSITIVE_INFINITY;
+    const repeatingDuration = computeSMILRepeatingDuration(animation.timing);
+    return `Self.svgAnimatedNumber(documentTime: documentTime, intervals: [${intervalLiteral}], duration: ${swiftDuration(duration)}, repeatingDuration: ${swiftDuration(repeatingDuration)}, values: [${values.map((value) => formatNumber(value)).join(", ")}], discrete: ${animation.runtimeSupport === "numeric-discrete" ? "true" : "false"}, base: ${formatNumber(animation.value.base)}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"}) - ${formatNumber(animation.value.base)}`;
   };
 
   const buildFilter = (
@@ -3545,12 +3561,74 @@ function createView(
         `${indentation}value.isFinite ? value : 0`,
         "}",
         "",
-        "private static func svgAnimatedNumber(documentTime: Double, begin: Double, duration: Double, from: Double, to: Double, base: Double, freeze: Bool) -> Double {",
+        "private enum SVGTimingState: Equatable { case inactive, active, frozen, completed }",
+        "",
+        "private struct SVGTimingSample {",
+        `${indentation}let state: SVGTimingState`,
+        `${indentation}let simpleTime: Double?`,
+        `${indentation}let simpleProgress: Double?`,
+        `${indentation}let activeDuration: Double`,
+        `${indentation}let simpleDuration: Double`,
+        `${indentation}let repeatIteration: Int`,
+        `${indentation}let isBeginBoundary: Bool`,
+        `${indentation}let isEndBoundary: Bool`,
+        `${indentation}let isRepeatBoundary: Bool`,
+        `${indentation}let selectedBegin: Double?`,
+        `${indentation}let intervalBegin: Double?`,
+        `${indentation}let intervalEnd: Double?`,
+        "}",
+        "",
+        "private static func svgTimingSample(documentTime: Double, intervals: [(begin: Double, end: Double)], duration: Double, repeatingDuration: Double, freeze: Bool) -> SVGTimingSample {",
         `${indentation}let time = sanitizedDocumentTime(documentTime)`,
-        `${indentation}if time < begin { return base }`,
-        `${indentation}if duration <= 0 || time >= begin + duration { return freeze ? to : base }`,
-        `${indentation}let progress = (time - begin) / duration`,
-        `${indentation}return from + (to - from) * progress`,
+        `${indentation}let active = intervals.first { time >= $0.begin && time < $0.end }`,
+        `${indentation}let completed = intervals.last { time >= $0.end }`,
+        `${indentation}guard let interval = active ?? completed else {`,
+        `${indentation}${indentation}return SVGTimingSample(state: .inactive, simpleTime: nil, simpleProgress: nil, activeDuration: 0, simpleDuration: duration, repeatIteration: 0, isBeginBoundary: false, isEndBoundary: false, isRepeatBoundary: false, selectedBegin: nil, intervalBegin: nil, intervalEnd: nil)`,
+        `${indentation}}`,
+        `${indentation}let atEnd = active == nil`,
+        `${indentation}let hasFutureInterval = intervals.contains { time < $0.begin }`,
+        `${indentation}let activeDuration = max(0, interval.end - interval.begin)`,
+        `${indentation}let elapsed = max(0, (atEnd ? interval.end : time) - interval.begin)`,
+        `${indentation}if !atEnd && elapsed > repeatingDuration && !freeze {`,
+        `${indentation}${indentation}return SVGTimingSample(state: .active, simpleTime: nil, simpleProgress: nil, activeDuration: activeDuration, simpleDuration: duration, repeatIteration: max(0, Int(ceil(repeatingDuration / max(duration, 1))) - 1), isBeginBoundary: false, isEndBoundary: false, isRepeatBoundary: false, selectedBegin: interval.begin, intervalBegin: interval.begin, intervalEnd: interval.end)`,
+        `${indentation}}`,
+        `${indentation}let presentationElapsed = freeze ? min(elapsed, repeatingDuration) : elapsed`,
+        `${indentation}let quotient = duration > 0 && duration.isFinite ? presentationElapsed / duration : 0`,
+        `${indentation}let rounded = quotient.rounded()`,
+        `${indentation}let exactRepeat = presentationElapsed > 0 && abs(quotient - rounded) <= 0.000000000001`,
+        `${indentation}let iteration: Int`,
+        `${indentation}let simpleTime: Double`,
+        `${indentation}let progress: Double`,
+        `${indentation}if duration <= 0 {`,
+        `${indentation}${indentation}iteration = 0`,
+        `${indentation}${indentation}simpleTime = 0`,
+        `${indentation}${indentation}progress = 1`,
+        `${indentation}} else if !duration.isFinite {`,
+        `${indentation}${indentation}iteration = 0`,
+        `${indentation}${indentation}simpleTime = presentationElapsed`,
+        `${indentation}${indentation}progress = 0`,
+        `${indentation}} else if atEnd && exactRepeat {`,
+        `${indentation}${indentation}iteration = max(0, Int(rounded) - 1)`,
+        `${indentation}${indentation}simpleTime = duration`,
+        `${indentation}${indentation}progress = 1`,
+        `${indentation}} else {`,
+        `${indentation}${indentation}iteration = max(0, Int(floor(quotient + 0.000000000001)))`,
+        `${indentation}${indentation}simpleTime = max(0, presentationElapsed - Double(iteration) * duration)`,
+        `${indentation}${indentation}progress = min(1, max(0, simpleTime / duration))`,
+        `${indentation}}`,
+        `${indentation}return SVGTimingSample(state: atEnd ? (freeze && !hasFutureInterval ? .frozen : .completed) : .active, simpleTime: simpleTime, simpleProgress: progress, activeDuration: activeDuration, simpleDuration: duration, repeatIteration: iteration, isBeginBoundary: intervals.contains { abs(time - $0.begin) <= 0.000000000001 }, isEndBoundary: intervals.contains { abs(time - $0.end) <= 0.000000000001 }, isRepeatBoundary: !atEnd && exactRepeat, selectedBegin: interval.begin, intervalBegin: interval.begin, intervalEnd: interval.end)`,
+        "}",
+        "",
+        "private static func svgAnimatedNumber(documentTime: Double, intervals: [(begin: Double, end: Double)], duration: Double, repeatingDuration: Double, values: [Double], discrete: Bool, base: Double, freeze: Bool) -> Double {",
+        `${indentation}guard let first = values.first, let last = values.last else { return base }`,
+        `${indentation}let sample = svgTimingSample(documentTime: documentTime, intervals: intervals, duration: duration, repeatingDuration: repeatingDuration, freeze: freeze)`,
+        `${indentation}if sample.state == .inactive || sample.state == .completed { return base }`,
+        `${indentation}guard let progress = sample.simpleProgress else { return base }`,
+        `${indentation}if discrete {`,
+        `${indentation}${indentation}let index = min(values.count - 1, Int(floor(progress * Double(values.count) + 0.000000000001)))`,
+        `${indentation}${indentation}return values[index]`,
+        `${indentation}}`,
+        `${indentation}return first + (last - first) * progress`,
         "}",
         "",
         "private final class AnimationClockState: ObservableObject {",
@@ -3657,6 +3735,7 @@ export function generateView(
     subdocuments: [],
     rootName: config.structName ?? "SVGView",
     config,
+    animationIntervals: sampleSMILProgram(document.animationProgram, 0).intervals,
   };
   const nodes = buildViewNodes(document.children, context);
   const imports = new Set<string>();

--- a/packages/svg-to-swiftui-core/src/renderTree/smilTiming.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/smilTiming.ts
@@ -1,0 +1,333 @@
+import type {
+  AnimationDefinition,
+  AnimationDuration,
+  AnimationProgram,
+  AnimationTime,
+  AnimationTiming,
+} from "./animation";
+
+export interface DeterministicTimingEvent {
+  /** Document time in seconds. */
+  time: number;
+  name: string;
+  targetId?: string;
+  /** SMIL repeat event detail, when the event source is a repeat boundary. */
+  repeatIteration?: number;
+  /** Stable order for events with the same timestamp. Input order is used by default. */
+  order?: number;
+}
+
+export type SMILTimingState = "inactive" | "active" | "frozen" | "completed";
+
+export interface SMILTimingInterval {
+  begin: number;
+  end: number;
+  naturalEnd: number;
+  activeDuration: number;
+  beginInstance: number;
+  restartCutoff: boolean;
+}
+
+export interface SMILTimingSample {
+  state: SMILTimingState;
+  simpleTime?: number;
+  simpleProgress?: number;
+  activeDuration?: number;
+  simpleDuration?: number;
+  repeatIteration: number;
+  isBeginBoundary: boolean;
+  isEndBoundary: boolean;
+  isRepeatBoundary: boolean;
+  selectedBegin?: number;
+  interval?: SMILTimingInterval;
+  unresolved: boolean;
+}
+
+export interface SMILProgramSample {
+  samples: ReadonlyMap<string, SMILTimingSample>;
+  intervals: ReadonlyMap<string, readonly SMILTimingInterval[]>;
+}
+
+const EPSILON = 1e-12;
+
+function equal(left: number, right: number): boolean {
+  if (!Number.isFinite(left) || !Number.isFinite(right)) return left === right;
+  return Math.abs(left - right) <= EPSILON;
+}
+
+function finiteDuration(duration: AnimationDuration | undefined): number | undefined {
+  return duration?.type === "seconds" ? duration.seconds : undefined;
+}
+
+function simpleDuration(timing: AnimationTiming): number {
+  if (timing.duration.type === "seconds") return timing.duration.seconds;
+  return Number.POSITIVE_INFINITY;
+}
+
+/** Duration of simple playback/repeats before min/max constraints extend or clamp it. */
+export function computeSMILRepeatingDuration(timing: AnimationTiming): number {
+  const simple = simpleDuration(timing);
+  const repeatCount =
+    timing.repeatCount.type === "count"
+      ? timing.repeatCount.value
+      : timing.repeatCount.type === "indefinite"
+        ? Number.POSITIVE_INFINITY
+        : 1;
+  const repeatDuration =
+    timing.repeatDuration?.type === "seconds"
+      ? timing.repeatDuration.seconds
+      : timing.repeatDuration?.type === "indefinite"
+        ? Number.POSITIVE_INFINITY
+        : undefined;
+
+  if (simple === 0) return 0;
+  if (!Number.isFinite(simple)) return repeatDuration ?? Number.POSITIVE_INFINITY;
+  const counted = Number.isFinite(repeatCount) ? simple * repeatCount : Number.POSITIVE_INFINITY;
+  return repeatDuration === undefined ? counted : Math.min(counted, repeatDuration);
+}
+
+/** SMIL active-duration arithmetic before begin/end interval constraints. */
+export function computeSMILActiveDuration(timing: AnimationTiming): number {
+  let active = computeSMILRepeatingDuration(timing);
+
+  const minimum = finiteDuration(timing.min) ?? 0;
+  const maximum = timing.max?.type === "seconds" ? timing.max.seconds : Number.POSITIVE_INFINITY;
+  // Per SMIL, contradictory min/max values are both ignored.
+  if (maximum >= minimum) active = Math.min(Math.max(active, minimum), maximum);
+  return active;
+}
+
+function sortedUnique(values: readonly number[]): number[] {
+  return [...values]
+    .filter((value) => Number.isFinite(value))
+    .sort((left, right) => left - right)
+    .filter((value, index, array) => index === 0 || !equal(value, array[index - 1]!));
+}
+
+/** Build all deterministic intervals from already-resolved begin/end instance lists. */
+export function resolveSMILIntervals(
+  timing: AnimationTiming,
+  beginInstances: readonly number[],
+  endInstances: readonly number[] = [],
+): SMILTimingInterval[] {
+  const begins = sortedUnique(beginInstances);
+  const ends = sortedUnique(endInstances);
+  const activeDuration = computeSMILActiveDuration(timing);
+  const intervals: SMILTimingInterval[] = [];
+
+  for (const begin of begins) {
+    const previous = intervals[intervals.length - 1];
+    if (previous) {
+      if (timing.restart === "never") continue;
+      const previousActive = begin < previous.end && !equal(begin, previous.end);
+      if (previousActive && timing.restart === "whenNotActive") continue;
+      if (previousActive && timing.restart === "always") {
+        previous.end = begin;
+        previous.activeDuration = Math.max(0, begin - previous.begin);
+        previous.restartCutoff = true;
+      }
+    }
+
+    const naturalEnd = Number.isFinite(activeDuration) ? begin + activeDuration : Number.POSITIVE_INFINITY;
+    const explicitEnd = ends.find((candidate) => candidate >= begin || equal(candidate, begin));
+    const end = explicitEnd === undefined ? naturalEnd : Math.min(naturalEnd, explicitEnd);
+    intervals.push({
+      begin,
+      end,
+      naturalEnd,
+      activeDuration: Math.max(0, end - begin),
+      beginInstance: begin,
+      restartCutoff: false,
+    });
+  }
+  return intervals;
+}
+
+function progressAt(
+  timing: AnimationTiming,
+  interval: SMILTimingInterval,
+  documentTime: number,
+  atEnd: boolean,
+): Pick<SMILTimingSample, "simpleTime" | "simpleProgress" | "repeatIteration" | "isRepeatBoundary"> {
+  const simple = simpleDuration(timing);
+  const elapsed = Math.max(0, (atEnd ? interval.end : documentTime) - interval.begin);
+  const repeatingDuration = computeSMILRepeatingDuration(timing);
+  if (Number.isFinite(repeatingDuration) && elapsed > repeatingDuration && !equal(elapsed, repeatingDuration)) {
+    if (timing.fill === "remove")
+      return {
+        simpleTime: undefined,
+        simpleProgress: undefined,
+        repeatIteration: Math.max(0, Math.ceil(repeatingDuration / (simple || 1)) - 1),
+        isRepeatBoundary: false,
+      };
+    return progressAt(
+      timing,
+      { ...interval, end: interval.begin + repeatingDuration },
+      interval.begin + repeatingDuration,
+      true,
+    );
+  }
+  if (!Number.isFinite(simple)) {
+    return { simpleTime: elapsed, simpleProgress: 0, repeatIteration: 0, isRepeatBoundary: false };
+  }
+  if (simple <= 0) {
+    return { simpleTime: 0, simpleProgress: 1, repeatIteration: 0, isRepeatBoundary: false };
+  }
+
+  const quotient = elapsed / simple;
+  const exactRepeat = elapsed > 0 && equal(quotient, Math.round(quotient));
+  if (atEnd && exactRepeat) {
+    return {
+      simpleTime: simple,
+      simpleProgress: 1,
+      repeatIteration: Math.max(0, Math.round(quotient) - 1),
+      isRepeatBoundary: false,
+    };
+  }
+  const iteration = Math.max(0, Math.floor(quotient + EPSILON));
+  const time = Math.max(0, elapsed - iteration * simple);
+  return {
+    simpleTime: time,
+    simpleProgress: Math.min(1, Math.max(0, time / simple)),
+    repeatIteration: iteration,
+    isRepeatBoundary: exactRepeat,
+  };
+}
+
+/** Pure sample of a compiled timing definition and resolved instance times. */
+export function sampleSMILTiming(
+  timing: AnimationTiming,
+  documentTime: number,
+  beginInstances: readonly number[],
+  endInstances: readonly number[] = [],
+  unresolved = false,
+): SMILTimingSample {
+  const time = Number.isFinite(documentTime) ? documentTime : 0;
+  const intervals = resolveSMILIntervals(timing, beginInstances, endInstances);
+  const beginBoundary = intervals.some((interval) => equal(time, interval.begin));
+  const endBoundary = intervals.some((interval) => equal(time, interval.end));
+  const active = intervals.find(
+    (interval) => time >= interval.begin && (time < interval.end || !Number.isFinite(interval.end)),
+  );
+  if (active) {
+    return {
+      state: "active",
+      ...progressAt(timing, active, time, false),
+      activeDuration: active.activeDuration,
+      simpleDuration: simpleDuration(timing),
+      isBeginBoundary: beginBoundary,
+      isEndBoundary: false,
+      selectedBegin: active.begin,
+      interval: active,
+      unresolved,
+    };
+  }
+
+  const completed = [...intervals].reverse().find((interval) => time >= interval.end);
+  if (completed) {
+    const hasFutureInterval = intervals.some((interval) => interval.begin > time);
+    return {
+      state: !hasFutureInterval && timing.fill === "freeze" ? "frozen" : "completed",
+      ...progressAt(timing, completed, completed.end, true),
+      activeDuration: completed.activeDuration,
+      simpleDuration: simpleDuration(timing),
+      isBeginBoundary: beginBoundary,
+      isEndBoundary: endBoundary,
+      selectedBegin: completed.begin,
+      interval: completed,
+      unresolved,
+    };
+  }
+
+  return {
+    state: "inactive",
+    repeatIteration: 0,
+    isBeginBoundary: false,
+    isEndBoundary: false,
+    isRepeatBoundary: false,
+    unresolved,
+  };
+}
+
+function eventTimes(time: Extract<AnimationTime, { type: "event" }>, events: readonly DeterministicTimingEvent[]) {
+  return events
+    .map((event, index) => ({ event, index }))
+    .filter(
+      ({ event }) => event.name === time.event && (time.targetId === undefined || event.targetId === time.targetId),
+    )
+    .sort(
+      (left, right) =>
+        left.event.time - right.event.time || (left.event.order ?? left.index) - (right.event.order ?? right.index),
+    )
+    .map(({ event }) => event.time + time.offsetSeconds);
+}
+
+function resolveTimes(
+  values: readonly AnimationTime[],
+  intervals: ReadonlyMap<string, readonly SMILTimingInterval[]>,
+  definitions: ReadonlyMap<string, AnimationDefinition>,
+  events: readonly DeterministicTimingEvent[],
+): { times: number[]; unresolved: boolean } {
+  const times: number[] = [];
+  let unresolved = false;
+  for (const value of values) {
+    if (value.type === "offset") times.push(value.seconds);
+    else if (value.type === "syncbase") {
+      const referenced = intervals.get(value.animationId);
+      if (!referenced) unresolved = true;
+      else
+        for (const interval of referenced) {
+          const base = value.phase === "begin" ? interval.begin : interval.end;
+          if (Number.isFinite(base)) times.push(base + value.offsetSeconds);
+        }
+    } else if (value.type === "repeat") {
+      const referenced = intervals.get(value.animationId);
+      const definition = definitions.get(value.animationId);
+      const duration = definition ? simpleDuration(definition.timing) : Number.POSITIVE_INFINITY;
+      if (!referenced || !Number.isFinite(duration)) unresolved = true;
+      else {
+        for (const interval of referenced) {
+          const repeatTime = interval.begin + duration * value.iteration;
+          if (repeatTime < interval.end && !equal(repeatTime, interval.end))
+            times.push(repeatTime + value.offsetSeconds);
+        }
+      }
+    } else if (value.type === "event") {
+      const resolved = eventTimes(value, events);
+      if (resolved.length === 0) unresolved = true;
+      times.push(...resolved);
+    } else if (value.type !== "indefinite") unresolved = true;
+  }
+  return { times: sortedUnique(times), unresolved };
+}
+
+/** Evaluate the dependency graph in stable topological/document order. */
+export function sampleSMILProgram(
+  program: AnimationProgram,
+  documentTime: number,
+  events: readonly DeterministicTimingEvent[] = [],
+): SMILProgramSample {
+  const definitions = new Map(program.animations.map((animation) => [animation.stableId, animation]));
+  const intervals = new Map<string, readonly SMILTimingInterval[]>();
+  const samples = new Map<string, SMILTimingSample>();
+  const cyclic = new Set<string>();
+  for (const cycle of program.dependencyCycles) for (const id of cycle) cyclic.add(id);
+  for (const id of program.evaluationOrder) {
+    const animation = definitions.get(id);
+    if (!animation) continue;
+    if (cyclic.has(id)) {
+      intervals.set(id, []);
+      samples.set(id, sampleSMILTiming(animation.timing, documentTime, [], [], true));
+      continue;
+    }
+    const begins = resolveTimes(animation.timing.begin, intervals, definitions, events);
+    const ends = resolveTimes(animation.timing.end, intervals, definitions, events);
+    const resolved = resolveSMILIntervals(animation.timing, begins.times, ends.times);
+    intervals.set(id, resolved);
+    samples.set(
+      id,
+      sampleSMILTiming(animation.timing, documentTime, begins.times, ends.times, begins.unresolved || ends.unresolved),
+    );
+  }
+  return { samples, intervals };
+}

--- a/packages/svg-to-swiftui-core/src/tests/smilTiming.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/smilTiming.test.ts
@@ -1,0 +1,312 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  __testing,
+  type AnimationTiming,
+  computeSMILActiveDuration,
+  convert,
+  convertWithDiagnostics,
+  resolveSMILIntervals,
+  sampleNumericAnimation,
+  sampleSMILProgram,
+  sampleSMILTiming,
+} from "../index";
+
+function timing(overrides: Partial<AnimationTiming> = {}): AnimationTiming {
+  return {
+    begin: [{ type: "offset", seconds: 0 }],
+    duration: { type: "seconds", seconds: 1 },
+    end: [],
+    repeatCount: { type: "unspecified" },
+    restart: "always",
+    fill: "remove",
+    ...overrides,
+  };
+}
+
+describe("SMIL timing syntax and graph", () => {
+  test("parses clock, syncbase, repeat, eventbase, accessKey, wallclock, and all duration controls", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 10 10"><rect id="box" width="1" height="1"/>
+        <animate id="other" href="#box" attributeName="x" from="0" to="1" dur="1s"/>
+        <animate id="timed" href="#box" attributeName="x" from="0" to="1"
+          begin="01:02:03.5;02:03.25;-250ms;other.end-200ms;other.repeat(2)+1s;button.click+1s;accessKey(a);wallclock(2026-01-01T00:00:00Z)"
+          end="other.begin+2s" dur="1.5min" min="500ms" max="2h" repeatCount="2.5"
+          repeatDur="3min" restart="whenNotActive" fill="freeze"/>
+      </svg>`);
+    const animation = document.animationProgram.animations[1]!;
+
+    expect(animation.timing).toMatchObject({
+      begin: [
+        { type: "offset", seconds: 3723.5 },
+        { type: "offset", seconds: 123.25 },
+        { type: "offset", seconds: -0.25 },
+        { type: "syncbase", animationId: "other", phase: "end", offsetSeconds: -0.2 },
+        { type: "repeat", animationId: "other", iteration: 2, offsetSeconds: 1 },
+        { type: "event", targetId: "button", event: "click", offsetSeconds: 1 },
+        { type: "accessKey", key: "a", offsetSeconds: 0 },
+        { type: "wallclock", value: "2026-01-01T00:00:00Z" },
+      ],
+      end: [{ type: "syncbase", animationId: "other", phase: "begin", offsetSeconds: 2 }],
+      duration: { type: "seconds", seconds: 90 },
+      min: { type: "seconds", seconds: 0.5 },
+      max: { type: "seconds", seconds: 7200 },
+      repeatCount: { type: "count", value: 2.5 },
+      repeatDuration: { type: "seconds", seconds: 180 },
+      restart: "whenNotActive",
+      fill: "freeze",
+    });
+    expect(animation.dependencies).toEqual(["other", "other", "other"]);
+    expect(document.diagnostics.map((item) => item.code)).toEqual(
+      expect.arrayContaining(["unsupported-animation-accesskey", "unsupported-animation-wallclock"]),
+    );
+  });
+
+  test("topologically resolves syncbase, repeat, and deterministic eventbase instances", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20">
+        <circle id="one" cx="1" r="1"/><circle id="two" cx="1" r="1"/>
+        <circle id="three" cx="1" r="1"/><circle id="four" cx="1" r="1"/>
+        <animate id="a" href="#one" attributeName="cx" from="1" to="2" dur="1s" repeatCount="2"/>
+        <animate id="b" href="#two" attributeName="cx" from="1" to="2" begin="a.end+200ms" dur="1s"/>
+        <animate id="c" href="#three" attributeName="cx" from="1" to="2" begin="a.repeat(1)-100ms" dur="1s"/>
+        <animate id="d" href="#four" attributeName="cx" from="1" to="2" begin="button.click+100ms" dur="1s"/>
+      </svg>`);
+    const result = sampleSMILProgram(document.animationProgram, 2.3, [
+      { targetId: "button", name: "click", time: 0.5 },
+    ]);
+
+    expect(document.animationProgram.evaluationOrder).toEqual(["a", "b", "c", "d"]);
+    expect(result.intervals.get("a")?.[0]).toMatchObject({ begin: 0, end: 2 });
+    expect(result.intervals.get("b")?.[0]?.begin).toBeCloseTo(2.2);
+    expect(result.intervals.get("c")?.[0]?.begin).toBeCloseTo(0.9);
+    expect(result.intervals.get("d")?.[0]?.begin).toBeCloseTo(0.6);
+    expect(result.samples.get("b")?.state).toBe("active");
+    expect(result.intervals.get("c")).toHaveLength(1);
+  });
+
+  test("terminates dependency cycles as unresolved with stable diagnostics", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 10 10"><rect id="box" width="1" height="1"/>
+        <animate id="a" href="#box" attributeName="x" from="0" to="1" begin="b.end" dur="1s"/>
+        <animate id="b" href="#box" attributeName="y" from="0" to="1" begin="a.end" dur="1s"/>
+      </svg>`);
+    const sampled = sampleSMILProgram(document.animationProgram, 100);
+    expect(document.animationProgram.dependencyCycles).toEqual([["a", "b", "a"]]);
+    expect(sampled.samples.get("a")).toMatchObject({ state: "inactive", unresolved: true });
+    expect(sampled.samples.get("b")).toMatchObject({ state: "inactive", unresolved: true });
+    expect(document.diagnostics.map((item) => item.code)).toContain("cyclic-animation-dependency");
+  });
+
+  test("keeps nondeterministic timing inactive in permissive mode and rejects it in strict mode", () => {
+    const source = `<svg viewBox="0 0 10 10"><rect id="box" width="1" height="1"><animate attributeName="x" from="0" to="1" begin="wallclock(2026-01-01T00:00:00Z);accessKey(a)" dur="1s"/></rect></svg>`;
+    const permissive = convertWithDiagnostics(source);
+    expect(permissive.diagnostics.map((item) => item.code)).toEqual(
+      expect.arrayContaining(["unsupported-animation-wallclock", "unsupported-animation-accesskey"]),
+    );
+    expect(permissive.swift).not.toContain(".offset(x:");
+    expect(() => convert(source, { strict: true })).toThrow(/unsupported-animation-(wallclock|accesskey)/);
+  });
+});
+
+describe("pure SMIL state machine", () => {
+  test("samples one microsecond around begin, repeat, and end boundaries", () => {
+    const spec = timing({
+      begin: [{ type: "offset", seconds: 0.2 }],
+      duration: { type: "seconds", seconds: 0.6 },
+      repeatCount: { type: "count", value: 2 },
+      fill: "freeze",
+    });
+    const cases = [
+      [0.199999, "inactive", 0, false, false, false],
+      [0.2, "active", 0, true, false, false],
+      [0.799999, "active", 0, false, false, false],
+      [0.8, "active", 1, false, false, true],
+      [1.399999, "active", 1, false, false, false],
+      [1.4, "frozen", 1, false, true, false],
+    ] as const;
+    for (const [time, state, iteration, begin, end, repeat] of cases) {
+      expect(sampleSMILTiming(spec, time, [0.2])).toMatchObject({
+        state,
+        repeatIteration: iteration,
+        isBeginBoundary: begin,
+        isEndBoundary: end,
+        isRepeatBoundary: repeat,
+      });
+    }
+  });
+
+  test("computes fractional repeats, repeatDur, zero/indefinite duration, and min/max constraints", () => {
+    expect(computeSMILActiveDuration(timing({ repeatCount: { type: "count", value: 2.5 } }))).toBe(2.5);
+    expect(
+      computeSMILActiveDuration(
+        timing({ repeatCount: { type: "indefinite" }, repeatDuration: { type: "seconds", seconds: 3.25 } }),
+      ),
+    ).toBe(3.25);
+    expect(
+      computeSMILActiveDuration(
+        timing({ duration: { type: "indefinite" }, repeatDuration: { type: "seconds", seconds: 4 } }),
+      ),
+    ).toBe(4);
+    expect(computeSMILActiveDuration(timing({ duration: { type: "seconds", seconds: 0 } }))).toBe(0);
+    expect(
+      computeSMILActiveDuration(
+        timing({
+          repeatCount: { type: "count", value: 10 },
+          min: { type: "seconds", seconds: 2 },
+          max: { type: "seconds", seconds: 3 },
+        }),
+      ),
+    ).toBe(3);
+    expect(
+      computeSMILActiveDuration(
+        timing({
+          repeatCount: { type: "count", value: 10 },
+          min: { type: "seconds", seconds: 5 },
+          max: { type: "seconds", seconds: 2 },
+        }),
+      ),
+    ).toBe(10);
+  });
+
+  test("covers the behavior-changing repeat/fill/restart/min/max cross product", () => {
+    const constraints = [
+      { name: "none", overrides: {}, counts: { always: 3, whenNotActive: 2, never: 1 } },
+      {
+        name: "min",
+        overrides: { min: { type: "seconds", seconds: 2 } as const },
+        counts: { always: 3, whenNotActive: 2, never: 1 },
+      },
+      {
+        name: "max",
+        overrides: { max: { type: "seconds", seconds: 0.25 } as const },
+        counts: { always: 3, whenNotActive: 3, never: 1 },
+      },
+    ];
+    for (const fill of ["remove", "freeze"] as const) {
+      for (const restart of ["always", "whenNotActive", "never"] as const) {
+        for (const constraint of constraints) {
+          const spec = timing({
+            repeatCount: { type: "count", value: 1 },
+            fill,
+            restart,
+            ...constraint.overrides,
+          });
+          const intervals = resolveSMILIntervals(spec, [0, 0.5, 2]);
+          expect(intervals).toHaveLength(constraint.counts[restart]);
+          expect(sampleSMILTiming(spec, 10, [0, 0.5, 2]).state).toBe(fill === "freeze" ? "frozen" : "completed");
+        }
+      }
+    }
+  });
+
+  test("keeps min-extended timing active while applying fill to the ended simple presentation", () => {
+    const remove = timing({ min: { type: "seconds", seconds: 2 }, fill: "remove" });
+    const freeze = timing({ min: { type: "seconds", seconds: 2 }, fill: "freeze" });
+    expect(sampleSMILTiming(remove, 1.5, [0])).toMatchObject({ state: "active", simpleProgress: undefined });
+    expect(sampleSMILTiming(freeze, 1.5, [0])).toMatchObject({ state: "active", simpleProgress: 1 });
+  });
+
+  test("applies defaults and diagnoses invalid or conflicting duration controls", () => {
+    const defaults = __testing.parseRenderDocument(
+      `<svg viewBox="0 0 10 10"><rect id="box" width="1" height="1"><animate attributeName="x" from="0" to="1"/></rect></svg>`,
+    );
+    expect(defaults.animationProgram.animations[0]?.timing).toMatchObject({
+      duration: { type: "indefinite" },
+      repeatCount: { type: "unspecified" },
+      restart: "always",
+      fill: "remove",
+    });
+
+    const invalid = __testing.parseRenderDocument(
+      `<svg viewBox="0 0 10 10"><rect id="box" width="1" height="1"><animate attributeName="x" from="0" to="1" dur="1s" min="2s" max="1s"/></rect></svg>`,
+    );
+    expect(invalid.diagnostics.map((item) => item.code)).toContain("invalid-animation-min-max");
+    expect(computeSMILActiveDuration(invalid.animationProgram.animations[0]!.timing)).toBe(1);
+
+    const zeroMax = __testing.parseRenderDocument(
+      `<svg viewBox="0 0 10 10"><rect id="box" width="1" height="1"><animate attributeName="x" from="0" to="1" dur="1s" max="0s"/></rect></svg>`,
+    );
+    expect(zeroMax.diagnostics.map((item) => item.code)).toContain("invalid-animation-max");
+    expect(computeSMILActiveDuration(zeroMax.animationProgram.animations[0]!.timing)).toBe(1);
+  });
+
+  test("applies restart always, whenNotActive, and never deterministically", () => {
+    const begins = [0, 0.5, 2];
+    expect(resolveStates("always", begins)).toEqual([
+      { begin: 0, end: 0.5, restartCutoff: true },
+      { begin: 0.5, end: 1.5, restartCutoff: false },
+      { begin: 2, end: 3, restartCutoff: false },
+    ]);
+    expect(resolveSMILIntervals(timing(), [0, 0.5])[0]?.activeDuration).toBe(0.5);
+    expect(resolveStates("whenNotActive", begins)).toEqual([
+      { begin: 0, end: 1, restartCutoff: false },
+      { begin: 2, end: 3, restartCutoff: false },
+    ]);
+    expect(resolveStates("never", begins)).toEqual([{ begin: 0, end: 1, restartCutoff: false }]);
+  });
+
+  test("removes a completed interval during a scheduled gap and freezes only after the final interval", () => {
+    const spec = timing({ fill: "freeze" });
+    expect(sampleSMILTiming(spec, 1.5, [0, 2])).toMatchObject({ state: "completed", selectedBegin: 0 });
+    expect(sampleSMILTiming(spec, 3, [0, 2])).toMatchObject({ state: "frozen", selectedBegin: 2 });
+  });
+});
+
+function resolveStates(restart: AnimationTiming["restart"], begins: number[]) {
+  return resolveSMILIntervals(timing({ restart }), begins).map(({ begin, end, restartCutoff }) => ({
+    begin,
+    end,
+    restartCutoff,
+  }));
+}
+
+describe("shared timing benchmark expectations", () => {
+  test("drives TypeScript sampling and generated Swift from the same exact frame schedule", () => {
+    const fixturePath = resolve(__dirname, "../../animation-tests/fixtures/benchmark-02-smil-timing.svg");
+    const expectationsPath = resolve(__dirname, "../../animation-tests/smil-timing-expectations.json");
+    const source = readFileSync(fixturePath, "utf8");
+    const expectations = JSON.parse(readFileSync(expectationsPath, "utf8"))["benchmark-02-smil-timing"] as {
+      samples: Array<{
+        timeMicroseconds: number;
+        state: string;
+        iteration: number;
+        value: number;
+        beginBoundary?: boolean;
+        endBoundary?: boolean;
+        repeatBoundary?: boolean;
+      }>;
+    };
+    const animation = __testing.parseRenderDocument(source).animationProgram.animations[0]!;
+    for (const expected of expectations.samples) {
+      const sample = sampleSMILTiming(animation.timing, expected.timeMicroseconds / 1_000_000, [0.2]);
+      expect(sample).toMatchObject({
+        state: expected.state,
+        repeatIteration: expected.iteration,
+        isBeginBoundary: expected.beginBoundary ?? false,
+        isEndBoundary: expected.endBoundary ?? false,
+        isRepeatBoundary: expected.repeatBoundary ?? false,
+      });
+      expect(sampleNumericAnimation(animation, expected.timeMicroseconds / 1_000_000)).toBe(expected.value);
+    }
+
+    const swift = convert(source, { structName: "SMILTimingBenchmark", strict: true });
+    expect(swift).toContain("private struct SVGTimingSample");
+    expect(swift).toContain("intervals: [(begin: 0.2, end: 1.4)]");
+    expect(swift).toContain("repeatingDuration: 1.2");
+    expect(swift).toContain("values: [16, 48, 80]");
+  });
+
+  test("precompiles advanced offset and syncbase intervals into generated Swift", () => {
+    const swift = convert(
+      `<svg viewBox="0 0 100 40">
+        <circle id="source" cx="10" cy="10" r="4"><animate id="lead" attributeName="cx" values="10;20;30" calcMode="discrete" begin="0s;1.2s" dur="400ms" repeatCount="2.5" repeatDur="900ms" min="300ms" max="1s" fill="freeze"/></circle>
+        <circle id="dependent" cx="10" cy="30" r="4"><animate attributeName="cx" from="10" to="90" begin="lead.end+100ms" dur="500ms" fill="freeze"/></circle>
+      </svg>`,
+      { structName: "AdvancedTiming", strict: true },
+    );
+    expect(swift).toContain("intervals: [(begin: 0, end: 0.9), (begin: 1.2, end: 2.1)]");
+    expect(swift).toContain("intervals: [(begin: 1, end: 1.5), (begin: 2.2, end: 2.7)]");
+    expect(swift.match(/Self\.svgAnimatedNumber\(documentTime:/g)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #97.

## What changed

- Adds a pure, deterministic W3C SMIL timing engine independent of SwiftUI drawing and interpolation.
- Supports clock values, instance-time lists, offsets, syncbase and repeat references, deterministic events, duration bounds, repeats, restart modes, and fill behavior.
- Detects dependency cycles and provides explicit strict/permissive fallbacks for unsupported wallclock and access-key timing.
- Precompiles resolved timing intervals into generated Swift so SwiftUI animation APIs do not decide SVG timing semantics.
- Extends the WebKit reference renderer with deterministic event injection and enforced feature probes.
- Adds shared TypeScript/Swift timing expectations and extensive boundary, cross-product, graph, and diagnostics tests.
- Adds compiler video benchmarks 02 and 03, including exact microsecond boundary frames and dependent animations.

## Validation

- 30 test suites / 312 tests pass.
- Type-check, lint, and formatting checks pass.
- 9 animation fixtures / 105 deterministic frames pass.
- 5 WebKit timing probes pass.
- 64 compiler-rendered Swift frames match their SVG references.
- SVG, SwiftUI, and side-by-side videos were generated for all compiler benchmarks.

Timing behavior follows the W3C SMIL timing model and is documented in `docs/smil-timing.md`.
