### PR TITLE
Implement animate and set property rendering

### DIFF
--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -252,6 +252,8 @@ SMIL scheduling is compiled separately from drawing. See the [SMIL timing contra
 
 Typed interpolation, paced/spline sampling, additive composition, and repeat accumulation are documented in the [SVG animation value contract](docs/animation-values.md).
 
+`<animate>` and `<set>` now drive native geometry, presentation, text, viewport, inheritance, and gradient-stop rendering. See the [property contract](docs/animate-set-properties.md) and generated [animation attribute report](conformance/ANIMATION_REPORT.md) for exact implemented and pending properties.
+
 Optional MP4 files are review artifacts only. They are encoded after the lossless comparisons and never decide whether a test passes. Animation compiler support is being implemented in dependency order under the [Animated SVG roadmap](https://github.com/bring-shrubbery/SVG-to-SwiftUI/issues/94).
 
 ## Migration from 0.4

--- a/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
@@ -245,6 +245,37 @@
           1749999, 1750000, 1999999, 2000000
         ]
       }
+    },
+    "benchmark-05-animate-set-properties": {
+      "mode": "comparison",
+      "referenceBackend": "webkit",
+      "width": 160,
+      "height": 120,
+      "expectedMode": "view",
+      "tags": [
+        "animate",
+        "benchmark-05",
+        "computed-presentation",
+        "geometry",
+        "gradient-stop",
+        "href-target",
+        "nested-viewport",
+        "paint",
+        "resource-presentation",
+        "set",
+        "stroke",
+        "text",
+        "use",
+        "viewbox"
+      ],
+      "timeline": {
+        "durationMicroseconds": 2000000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [
+          0, 499999, 500000, 749999, 750000, 999999, 1000000, 1499999, 1500000, 1999999, 2000000
+        ]
+      },
+      "expectDistinctReferenceFrames": true
     }
   }
 }

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-05-animate-set-properties.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-05-animate-set-properties.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 160 120">
+  <rect width="160" height="120" fill="#101827"/>
+  <defs>
+    <linearGradient id="animated-gradient" x1="0" y1="0" x2="1" y2="0">
+      <stop id="animated-gradient-stop" offset="0" stop-color="#f43f5e" stop-opacity="1">
+        <animate attributeName="offset" values="0;.55;0" dur="2s" fill="freeze"/>
+        <animate attributeName="stop-color" values="#f43f5e;#38bdf8;#f43f5e" dur="2s" fill="freeze"/>
+        <animate attributeName="stop-opacity" values="1;.45;1" dur="2s" fill="freeze"/>
+      </stop>
+      <stop offset="1" stop-color="#f8fafc"/>
+    </linearGradient>
+    <g id="shared-symbol">
+      <rect x="0" y="0" width="14" height="10" rx="2" fill="#f8fafc">
+        <animate attributeName="y" values="0;8;0" dur="2s" fill="freeze"/>
+      </rect>
+    </g>
+  </defs>
+  <g opacity="1">
+    <animate attributeName="opacity" values="1;.55;1" dur="2s" fill="freeze"/>
+    <rect id="morphing-rect" x="10" y="10" width="30" height="22" rx="3" fill="#fb7185">
+      <animate attributeName="x" from="10" to="52" dur="2s" fill="freeze"/>
+      <animate attributeName="width" from="30" to="46" dur="2s" fill="freeze"/>
+      <animate attributeName="rx" from="3" to="10" dur="2s" fill="freeze"/>
+      <animate attributeName="fill" values="#fb7185;#60a5fa;#a78bfa" dur="2s" fill="freeze"/>
+      <animate attributeName="fill-opacity" values="1;.55;1" dur="2s" fill="freeze"/>
+    </rect>
+    <circle id="pulsing-circle" cx="28" cy="55" r="10" fill="#34d399">
+      <animate attributeName="cy" values="55;68;55" dur="2s" fill="freeze"/>
+      <animate attributeName="r" values="10;16;10" dur="2s" fill="freeze"/>
+      <set attributeName="visibility" to="hidden" begin=".5s" dur=".25s"/>
+    </circle>
+    <line id="growing-line" x1="10" y1="88" x2="45" y2="88" stroke="#fbbf24" stroke-width="2" stroke-dasharray="4 2">
+      <animate attributeName="x2" from="45" to="105" dur="2s" fill="freeze"/>
+      <animate attributeName="stroke-width" from="2" to="7" dur="2s" fill="freeze"/>
+      <animate attributeName="stroke-dasharray" values="4 2;10 3;4 2" dur="2s" fill="freeze"/>
+      <set attributeName="stroke-linecap" to="round" begin="1s" dur="1s" fill="freeze"/>
+    </line>
+    <polygon id="morphing-polygon" points="112,12 145,12 139,38 118,38" fill="#22d3ee">
+      <animate attributeName="points" values="112,12 145,12 139,38 118,38;108,18 150,8 144,43 114,36;112,12 145,12 139,38 118,38" dur="2s" fill="freeze"/>
+    </polygon>
+    <path id="morphing-path" d="M108 56 L145 56 L138 76 L115 76 Z" fill="#f97316">
+      <animate attributeName="d" values="M108 56 L145 56 L138 76 L115 76 Z;M103 62 L151 51 L142 81 L112 73 Z;M108 56 L145 56 L138 76 L115 76 Z" dur="2s" fill="freeze"/>
+    </path>
+  </g>
+  <text id="animated-text" x="55" y="84" font-family="Helvetica" font-size="8" fill="#f8fafc">SVG
+    <animate attributeName="x" from="55" to="76" dur="2s" fill="freeze"/>
+    <animate attributeName="font-size" from="8" to="12" dur="2s" fill="freeze"/>
+    <animate attributeName="letter-spacing" from="0" to="2" dur="2s" fill="freeze"/>
+    <animate attributeName="fill" from="#f8fafc" to="#38bdf8" dur="2s" fill="freeze"/>
+  </text>
+  <use href="#shared-symbol" x="112" y="91"/>
+  <use xlink:href="#shared-symbol" x="134" y="91"/>
+  <svg id="nested-viewport" x="60" y="90" width="40" height="20" viewBox="0 0 80 40">
+    <rect id="nested-target" x="4" y="8" width="18" height="20" fill="#e879f9"/>
+  </svg>
+  <animate href="#nested-viewport" attributeName="viewBox" values="0 0 80 40;12 4 60 32;0 0 80 40" dur="2s" fill="freeze"/>
+  <animate href="#nested-target" attributeName="x" from="4" to="52" dur="2s" fill="freeze"/>
+  <rect id="href-target" x="10" y="104" width="28" height="8" fill="#94a3b8"/>
+  <set href="#href-target" attributeName="display" to="none" begin=".75s" dur=".25s"/>
+  <rect x="105" y="104" width="45" height="8" rx="2" fill="url(#animated-gradient)"/>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/manifest.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/manifest.ts
@@ -62,6 +62,21 @@ const REQUIRED_SMIL_VALUE_PROBE_TAGS = [
   "viewbox",
 ] as const;
 
+const REQUIRED_ANIMATE_SET_BENCHMARK_TAGS = [
+  "computed-presentation",
+  "geometry",
+  "gradient-stop",
+  "href-target",
+  "nested-viewport",
+  "paint",
+  "resource-presentation",
+  "set",
+  "stroke",
+  "text",
+  "use",
+  "viewbox",
+] as const;
+
 function validateBackground(value: string | null): void {
   if (value !== null && !/^#([\da-f]{6}|[\da-f]{8})$/i.test(value))
     throw new Error(`Background must be null, #RRGGBB, or #RRGGBBAA: ${value}`);
@@ -292,6 +307,14 @@ export function validateAnimationManifest(): string[] {
   );
   for (const tag of REQUIRED_SMIL_VALUE_PROBE_TAGS)
     if (!valueProbeTags.has(tag)) errors.push(`SMIL value reference probes do not cover required tag: ${tag}`);
+  const animateSetBenchmarkTags = new Set(
+    fixtures
+      .filter((fixture) => fixture.mode === "comparison" && fixture.tags.includes("benchmark-05"))
+      .flatMap((fixture) => fixture.tags),
+  );
+  for (const tag of REQUIRED_ANIMATE_SET_BENCHMARK_TAGS)
+    if (!animateSetBenchmarkTags.has(tag))
+      errors.push(`Animate/set comparison benchmark does not cover required tag: ${tag}`);
   if (valueGoldens.version !== 1) errors.push(`Unsupported animation value golden version: ${valueGoldens.version}`);
   if (!Number.isFinite(valueGoldens.tolerance) || valueGoldens.tolerance <= 0)
     errors.push("Animation value golden tolerance must be finite and positive");

--- a/packages/svg-to-swiftui-core/conformance/ANIMATION_REPORT.md
+++ b/packages/svg-to-swiftui-core/conformance/ANIMATION_REPORT.md
@@ -1,0 +1,121 @@
+# Declarative animation attribute report
+
+Generated from `ANIMATION_ATTRIBUTE_REGISTRY`. Do not edit by hand.
+
+This report describes `<animate>` and `<set>` property wiring. Transform, motion, and CSS animation have separate roadmap tickets.
+
+## Summary
+
+| Status | Attributes |
+| --- | ---: |
+| pending follow-up | 29 |
+| pending resource wiring | 35 |
+| implemented | 39 |
+
+## Registry
+
+| Attribute | Value family | Namespace | Invalidation | Target | Runtime |
+| --- | --- | --- | --- | --- | --- |
+| `alignment-baseline` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `amplitude` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `azimuth` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `baseFrequency` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `bias` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `clip-path` | discrete | XML, CSS | resource | any | pending resource wiring |
+| `clip-rule` | discrete | XML, CSS | paint | any | pending follow-up |
+| `color` | color | XML, CSS | paint | any | implemented |
+| `color-interpolation` | discrete | XML, CSS | paint | any | pending follow-up |
+| `color-interpolation-filters` | discrete | XML, CSS | paint | any | pending follow-up |
+| `cx` | length | XML, CSS | geometry, bounds | any | implemented |
+| `cy` | length | XML, CSS | geometry, bounds | any | implemented |
+| `d` | path | XML, CSS | geometry, bounds | any | implemented |
+| `diffuseConstant` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `display` | discrete | XML, CSS | visibility | any | implemented |
+| `divisor` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `dominant-baseline` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `dx` | length | XML, CSS | text-layout, bounds | any | implemented |
+| `dy` | length | XML, CSS | text-layout, bounds | any | implemented |
+| `elevation` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `exponent` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `fill` | paint | XML, CSS | paint | any | implemented |
+| `fill-opacity` | opacity | XML, CSS | paint | any | implemented |
+| `fill-rule` | discrete | XML, CSS | paint | any | pending follow-up |
+| `filter` | discrete | XML, CSS | resource, filter-buffer | any | pending resource wiring |
+| `flood-color` | color | XML, CSS | paint, filter-buffer | filter-primitives | pending resource wiring |
+| `flood-opacity` | opacity | XML, CSS | paint, filter-buffer | filter-primitives | pending resource wiring |
+| `font-family` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `font-size` | length | XML, CSS | text-layout, bounds | any | implemented |
+| `font-style` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `font-weight` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `fx` | length | XML, CSS | paint | any | pending follow-up |
+| `fy` | length | XML, CSS | paint | any | pending follow-up |
+| `glyph-orientation-horizontal` | angle | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `glyph-orientation-vertical` | angle | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `height` | length | XML, CSS | geometry, bounds | any | implemented |
+| `intercept` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `k` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `k1` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `k2` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `k3` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `k4` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `keyPoints` | number-list | XML, CSS | paint | any | pending follow-up |
+| `letter-spacing` | length | XML, CSS | text-layout, bounds | any | implemented |
+| `lighting-color` | color | XML, CSS | paint, filter-buffer | filter-primitives | pending resource wiring |
+| `limitingConeAngle` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `marker-end` | discrete | XML, CSS | resource | any | pending resource wiring |
+| `marker-mid` | discrete | XML, CSS | resource | any | pending resource wiring |
+| `marker-start` | discrete | XML, CSS | resource | any | pending resource wiring |
+| `markerHeight` | length | XML, CSS | paint | any | pending follow-up |
+| `markerWidth` | length | XML, CSS | paint | any | pending follow-up |
+| `mask` | discrete | XML, CSS | resource | any | pending resource wiring |
+| `numOctaves` | integer | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `offset` | opacity | XML, CSS | paint | stop | implemented |
+| `opacity` | opacity | XML, CSS | paint | any | implemented |
+| `order` | integer | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `orient` | angle | XML, CSS | paint | any | pending follow-up |
+| `overflow` | discrete | XML, CSS | paint | any | pending follow-up |
+| `pathLength` | number | XML, CSS | geometry, bounds, filter-buffer | filter-primitives | pending resource wiring |
+| `pointer-events` | discrete | XML, CSS | paint | any | pending follow-up |
+| `points` | points | XML, CSS | geometry, bounds | any | implemented |
+| `preserveAspectRatio` | discrete | XML | viewport, geometry, bounds | svg, symbol, view, marker, pattern | implemented |
+| `r` | length | XML, CSS | geometry, bounds | any | implemented |
+| `refX` | length | XML, CSS | paint | any | pending follow-up |
+| `refY` | length | XML, CSS | paint | any | pending follow-up |
+| `rotate` | number-list | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `rx` | length | XML, CSS | geometry, bounds | any | implemented |
+| `ry` | length | XML, CSS | geometry, bounds | any | implemented |
+| `scale` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `shape-rendering` | discrete | XML, CSS | paint | any | pending follow-up |
+| `slope` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `specularConstant` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `specularExponent` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `startOffset` | length | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `stop-color` | color | XML, CSS | paint | stop | implemented |
+| `stop-opacity` | opacity | XML, CSS | paint | stop | implemented |
+| `stroke` | paint | XML, CSS | paint | any | implemented |
+| `stroke-dasharray` | length-list | XML, CSS | paint | any | implemented |
+| `stroke-dashoffset` | length | XML, CSS | paint | any | implemented |
+| `stroke-linecap` | discrete | XML, CSS | paint | any | implemented |
+| `stroke-linejoin` | discrete | XML, CSS | paint | any | implemented |
+| `stroke-miterlimit` | number | XML, CSS | paint | any | implemented |
+| `stroke-opacity` | opacity | XML, CSS | paint | any | implemented |
+| `stroke-width` | length | XML, CSS | paint | any | implemented |
+| `surfaceScale` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `targetX` | integer | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `targetY` | integer | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `text-anchor` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `text-decoration` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `textLength` | length | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `transform` | transform | XML, CSS | paint | any | pending follow-up |
+| `values` | number-list | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `vector-effect` | discrete | XML, CSS | paint | any | pending follow-up |
+| `viewBox` | viewBox | XML | viewport, geometry, bounds | svg, symbol, view, marker, pattern | implemented |
+| `visibility` | discrete | XML, CSS | visibility | any | implemented |
+| `width` | length | XML, CSS | geometry, bounds | any | implemented |
+| `word-spacing` | length | XML, CSS | text-layout, bounds | any | implemented |
+| `x` | length | XML, CSS | geometry, bounds, text-layout | any | implemented |
+| `x1` | length | XML, CSS | geometry, bounds | any | implemented |
+| `x2` | length | XML, CSS | geometry, bounds | any | implemented |
+| `y` | length | XML, CSS | geometry, bounds, text-layout | any | implemented |
+| `y1` | length | XML, CSS | geometry, bounds | any | implemented |
+| `y2` | length | XML, CSS | geometry, bounds | any | implemented |

--- a/packages/svg-to-swiftui-core/conformance/animation-report.ts
+++ b/packages/svg-to-swiftui-core/conformance/animation-report.ts
@@ -1,0 +1,38 @@
+import { ANIMATION_ATTRIBUTE_REGISTRY } from "../src/renderTree/animationValues";
+
+const labels = {
+  "render-node": "implemented",
+  "gradient-stop": "implemented",
+  "pending-resource": "pending resource wiring",
+  "pending-follow-up": "pending follow-up",
+} as const;
+
+export function renderAnimationReport(): string {
+  const counts = new Map<string, number>();
+  for (const entry of ANIMATION_ATTRIBUTE_REGISTRY)
+    counts.set(labels[entry.runtimeBinding], (counts.get(labels[entry.runtimeBinding]) ?? 0) + 1);
+  const lines = [
+    "# Declarative animation attribute report",
+    "",
+    "Generated from `ANIMATION_ATTRIBUTE_REGISTRY`. Do not edit by hand.",
+    "",
+    "This report describes `<animate>` and `<set>` property wiring. Transform, motion, and CSS animation have separate roadmap tickets.",
+    "",
+    "## Summary",
+    "",
+    "| Status | Attributes |",
+    "| --- | ---: |",
+    ...[...counts].map(([status, count]) => `| ${status} | ${count} |`),
+    "",
+    "## Registry",
+    "",
+    "| Attribute | Value family | Namespace | Invalidation | Target | Runtime |",
+    "| --- | --- | --- | --- | --- | --- |",
+    ...ANIMATION_ATTRIBUTE_REGISTRY.map((entry) => {
+      const target = Array.isArray(entry.targetElements) ? entry.targetElements.join(", ") : entry.targetElements;
+      return `| \`${entry.canonicalName}\` | ${entry.family} | ${entry.namespaces.join(", ")} | ${entry.invalidates.join(", ")} | ${target} | ${labels[entry.runtimeBinding]} |`;
+    }),
+    "",
+  ];
+  return lines.join("\n");
+}

--- a/packages/svg-to-swiftui-core/conformance/generate-animation-report.ts
+++ b/packages/svg-to-swiftui-core/conformance/generate-animation-report.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env bun
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { renderAnimationReport } from "./animation-report";
+
+writeFileSync(resolve(import.meta.dir, "ANIMATION_REPORT.md"), renderAnimationReport());
+console.log("Generated conformance/ANIMATION_REPORT.md");

--- a/packages/svg-to-swiftui-core/conformance/verify-animation-report.ts
+++ b/packages/svg-to-swiftui-core/conformance/verify-animation-report.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { renderAnimationReport } from "./animation-report";
+
+const path = resolve(import.meta.dir, "ANIMATION_REPORT.md");
+if (readFileSync(path, "utf8") !== renderAnimationReport()) {
+  console.error("ANIMATION_REPORT.md is stale; run bun run animation-conformance:report");
+  process.exit(1);
+}
+console.log("Animation conformance report is current");

--- a/packages/svg-to-swiftui-core/docs/animate-set-properties.md
+++ b/packages/svg-to-swiftui-core/docs/animate-set-properties.md
@@ -1,0 +1,15 @@
+# `<animate>` and `<set>` property contract
+
+The compiler resolves each animation to a stable source target, samples it from the immutable computed presentation value, and emits a pure SwiftUI view of `documentTime`. Parent targets, `href`, and `xlink:href` use the same identity model, including anonymous elements and `<use>` instances.
+
+Implemented render wiring covers shape geometry (`x`, `y`, sizes, radii, line endpoints, `points`, and `d`), display and visibility, solid fill/stroke/color, opacity, stroke geometry, group opacity and inherited presentation, text position/size/spacing/paint, root viewport mapping, and gradient stop offset/color/opacity. `<set>` uses the same presentation sandwich with discrete begin/end behavior.
+
+The cascade is resolved before animation parsing. CSS winners, inheritance, explicit `inherit`, and `currentColor` establish the base value; animation never mutates that base. Multiple animations compose in document order and every timestamp is sampled without retained frame state.
+
+`ANIMATION_ATTRIBUTE_REGISTRY` is the source of truth for exact names, XML/CSS namespaces, typed value families, target kinds, invalidation categories, and runtime binding. The generated [animation report](../conformance/ANIMATION_REPORT.md) exposes implemented and pending entries without guessing support.
+
+Resource values that require rebuilding a filter, marker, mask, clip, or paint-server graph remain explicitly `pending-resource` and emit `unsupported-animation-semantics`. Transform lists, motion paths, and CSS keyframes are intentionally handled by the following roadmap tickets.
+
+Diagnostics use stable codes for missing/wrong targets, incompatible `attributeType`, non-applicable properties, malformed values/calculation metadata, unresolved resource URLs, and parsed-but-unwired semantics. Permissive mode keeps the immutable base; strict mode rejects warnings.
+
+Evidence is split between typed unit tests and exact-time video comparison. `benchmark-05-animate-set-properties` compares WebKit SVG frames with generated SwiftUI across interpolation and exact `<set>` boundaries, including inheritance, href targets, `<use>`, nested viewports, text, and animated gradient stops.

--- a/packages/svg-to-swiftui-core/package.json
+++ b/packages/svg-to-swiftui-core/package.json
@@ -9,7 +9,8 @@
   "files": [
     "dist",
     "conformance/svg2-static-profile.json",
-    "conformance/REPORT.md"
+    "conformance/REPORT.md",
+    "conformance/ANIMATION_REPORT.md"
   ],
   "license": "MIT",
   "keywords": [
@@ -41,6 +42,8 @@
     "visual-test:verify": "bun visual-tests/verify-manifest.ts",
     "animation-test": "bun run animation-tests/run-animation-tests.ts",
     "animation-test:verify": "bun animation-tests/verify-manifest.ts",
+    "animation-conformance:report": "bun conformance/generate-animation-report.ts",
+    "animation-conformance:verify": "bun conformance/verify-animation-report.ts",
     "visual-test:update-manifest": "bun visual-tests/update-manifest.ts",
     "conformance:verify": "bun conformance/verify.ts",
     "conformance:report": "bun conformance/generate-report.ts",

--- a/packages/svg-to-swiftui-core/src/index.ts
+++ b/packages/svg-to-swiftui-core/src/index.ts
@@ -21,15 +21,18 @@ export type {
   AnimationKind,
   AnimationProgram,
   AnimationTarget,
+  AnimationTargetSnapshot,
   AnimationTime,
   AnimationTiming,
   AnimationValue,
 } from "./renderTree/animation";
-export { sampleNumericAnimation } from "./renderTree/animation";
+export { sampleAnimatedPresentationValue, sampleNumericAnimation } from "./renderTree/animation";
 export type {
+  AnimationAttributeRegistryEntry,
   AnimationAttributeSpec,
   AnimationCalculation,
   AnimationColor,
+  AnimationInvalidationCategory,
   AnimationSandwichLayer,
   AnimationTransformComponent,
   AnimationValueContext,
@@ -40,6 +43,7 @@ export type {
   TypedAnimationValue,
 } from "./renderTree/animationValues";
 export {
+  ANIMATION_ATTRIBUTE_REGISTRY,
   addAnimationValues,
   animationAttributeSpec,
   animationValueDistance,
@@ -52,6 +56,7 @@ export {
   parseAnimationValueSet,
   parseKeySplines,
   parseKeyTimes,
+  resolveAnimationAttribute,
   sampleAnimationValue,
   serializeAnimationValue,
   swiftAnimationValueLiteral,

--- a/packages/svg-to-swiftui-core/src/renderTree/animation.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/animation.ts
@@ -9,10 +9,11 @@ import {
   parseAnimationValueSet,
   parseKeySplines,
   parseKeyTimes,
+  resolveAnimationAttribute,
   sampleAnimationValue,
   validateAnimationCalculation,
 } from "./animationValues";
-import { sampleSMILTiming } from "./smilTiming";
+import { type DeterministicTimingEvent, sampleSMILProgram, sampleSMILTiming } from "./smilTiming";
 import type { RenderDiagnostic, SourceLocation } from "./types";
 
 export type AnimationKind = "animate" | "set" | "animateTransform" | "animateMotion" | "discard";
@@ -61,6 +62,18 @@ export interface AnimationTarget {
   source: SourceLocation;
   reference: { type: "parent" } | { type: "local"; id: string };
   renderable: boolean;
+  tagName: string;
+  referenceChain: readonly SourceLocation[];
+  binding: "render-node" | "resource";
+}
+
+export interface AnimationTargetSnapshot {
+  key: string;
+  tagName: string;
+  binding?: "render-node" | "resource";
+  context: AnimationValueContext;
+  /** Computed static presentation/geometry values, after cascade and inheritance. */
+  baseValues: Readonly<Record<string, string>>;
 }
 
 export interface AnimationDefinition {
@@ -69,13 +82,15 @@ export interface AnimationDefinition {
   source: SourceLocation;
   target?: AnimationTarget;
   kind: AnimationKind;
+  authoredAttributeName?: string;
   attributeName?: string;
+  attributeType: "auto" | "XML" | "CSS";
   timing: AnimationTiming;
   value: AnimationValue;
   composition: AnimationCalculation;
   documentOrder: number;
   dependencies: readonly string[];
-  runtimeSupport: "scalar" | "pending" | "invalid";
+  runtimeSupport: "typed" | "pending" | "invalid";
 }
 
 export interface AnimationProgram {
@@ -91,28 +106,6 @@ const ANIMATION_TAGS = new Map<string, AnimationKind>([
   ["animatetransform", "animateTransform"],
   ["animatemotion", "animateMotion"],
   ["discard", "discard"],
-]);
-
-const NON_RENDERABLE_TARGETS = new Set([
-  "animate",
-  "animatemotion",
-  "animatetransform",
-  "discard",
-  "set",
-  "defs",
-  "style",
-  "script",
-  "metadata",
-  "title",
-  "desc",
-  "lineargradient",
-  "radialgradient",
-  "stop",
-  "pattern",
-  "clippath",
-  "mask",
-  "marker",
-  "filter",
 ]);
 
 function children(element: ElementNode): ElementNode[] {
@@ -248,11 +241,41 @@ function numeric(raw: string | undefined): number | undefined {
   return Number.isFinite(value) ? value : undefined;
 }
 
+const GEOMETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
+  cx: ["circle", "ellipse", "radialGradient"],
+  cy: ["circle", "ellipse", "radialGradient"],
+  d: ["path"],
+  height: ["rect", "svg", "image", "foreignObject", "pattern", "mask", "filter"],
+  points: ["polygon", "polyline"],
+  r: ["circle", "radialGradient"],
+  rx: ["rect", "ellipse"],
+  ry: ["rect", "ellipse"],
+  width: ["rect", "svg", "image", "foreignObject", "pattern", "mask", "filter"],
+  x: ["rect", "svg", "image", "foreignObject", "text", "tspan", "use", "pattern", "mask", "filter"],
+  x1: ["line", "linearGradient"],
+  x2: ["line", "linearGradient"],
+  y1: ["line", "linearGradient"],
+  y2: ["line", "linearGradient"],
+  y: ["rect", "svg", "image", "foreignObject", "text", "tspan", "use", "pattern", "mask", "filter"],
+};
+
+function propertyAppliesToTarget(attributeName: string | undefined, tagName: string | undefined): boolean {
+  if (!attributeName || !tagName) return false;
+  const allowed = GEOMETRY_TARGETS[attributeName];
+  if (allowed) return allowed.includes(tagName);
+  if (attributeName === "viewBox" || attributeName === "preserveAspectRatio")
+    return ["svg", "symbol", "view", "marker", "pattern"].includes(tagName);
+  if (["dx", "dy", "rotate", "textLength", "startOffset"].includes(attributeName))
+    return ["text", "tspan", "textPath"].includes(tagName);
+  if (attributeName === "offset") return tagName === "stop";
+  return true;
+}
+
 function parseValue(
   animation: ElementNode,
-  target: ElementNode | undefined,
   attributeName: string | undefined,
   context: AnimationValueContext,
+  baseRaw?: string,
 ): AnimationValue {
   const fromRaw = property(animation, "from");
   const toRaw = property(animation, "to");
@@ -260,7 +283,6 @@ function parseValue(
   const valuesRaw = property(animation, "values")
     ?.split(";")
     .map((value) => value.trim());
-  const baseRaw = attributeName && target ? property(target, attributeName) : undefined;
   if (attributeName) {
     const parsed = parseAnimationValueSet(
       attributeName,
@@ -286,9 +308,22 @@ function parseValue(
 }
 
 function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSupport">): boolean {
-  if (definition.kind !== "animate" || !definition.target?.renderable || !definition.attributeName) return false;
-  if (!definition.target.key.startsWith("id:") || !["cx", "x"].includes(definition.attributeName)) return false;
-  if (!["number", "integer", "opacity", "length", "angle"].includes(definition.value.family)) return false;
+  if (!(["animate", "set"] as AnimationKind[]).includes(definition.kind)) return false;
+  const attribute = definition.attributeName ? resolveAnimationAttribute(definition.attributeName) : undefined;
+  const resourceSupported =
+    definition.target?.binding === "resource" &&
+    definition.target.tagName.toLowerCase() === "stop" &&
+    attribute?.runtimeBinding === "gradient-stop";
+  const renderNodeSupported =
+    definition.target?.binding === "render-node" && attribute?.runtimeBinding === "render-node";
+  if (
+    !definition.target?.renderable ||
+    (!renderNodeSupported && !resourceSupported) ||
+    !definition.attributeName ||
+    definition.attributeName === "transform" ||
+    !propertyAppliesToTarget(definition.attributeName, definition.target.tagName)
+  )
+    return false;
   if (
     definition.timing.duration.type === "invalid" ||
     definition.timing.duration.type === "media" ||
@@ -305,16 +340,7 @@ function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSuppor
   )
     return false;
   if (definition.value.family === "unsupported" || definition.value.form === "invalid") return false;
-  const scalar = (value: AnimationValueSet["base"] | undefined) =>
-    value === undefined || ["number", "integer", "opacity", "length", "angle"].includes(value.family);
-  if (
-    !scalar(definition.value.base) ||
-    !scalar(definition.value.from) ||
-    !scalar(definition.value.to) ||
-    !scalar(definition.value.by) ||
-    definition.value.values?.some((value) => !scalar(value))
-  )
-    return false;
+  if (definition.kind === "set" && !definition.value.to && !definition.value.values?.length) return false;
   const count = definition.value.values?.length ?? 2;
   return validateAnimationCalculation(count, definition.composition).length === 0;
 }
@@ -323,7 +349,7 @@ function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSuppor
 export function buildAnimationProgram(
   root: ElementNode,
   diagnostics: RenderDiagnostic[],
-  targetContexts: ReadonlyMap<string, AnimationValueContext> = new Map(),
+  targetSnapshots: ReadonlyMap<string, AnimationTargetSnapshot> = new Map(),
 ): AnimationProgram {
   let parsedRootViewBox: ReturnType<typeof parseViewBox>;
   try {
@@ -422,7 +448,39 @@ export function buildAnimationProgram(
           "An animation without href must be a child of its target element.",
         );
     }
-    const renderable = !!targetElement && !NON_RENDERABLE_TARGETS.has((targetElement.tagName ?? "").toLowerCase());
+    const targetKey = targetElement
+      ? property(targetElement, "id")
+        ? `id:${property(targetElement, "id")}`
+        : `source:${order.get(targetElement)}`
+      : undefined;
+    const targetSnapshot = targetKey ? targetSnapshots.get(targetKey) : undefined;
+    const targetTag = (targetElement?.tagName ?? "").toLowerCase();
+    const resourceTarget = new Set([
+      "stop",
+      "lineargradient",
+      "radialgradient",
+      "fegaussianblur",
+      "fecolormatrix",
+      "fecomponenttransfer",
+      "fefunca",
+      "fefuncb",
+      "fefuncg",
+      "fefuncr",
+      "fecomposite",
+      "feconvolvematrix",
+      "fediffuselighting",
+      "fedisplacementmap",
+      "fedistantlight",
+      "fedropshadow",
+      "feflood",
+      "femorphology",
+      "feoffset",
+      "fepointlight",
+      "fespecularlighting",
+      "fespotlight",
+      "feturbulence",
+    ]).has(targetTag);
+    const renderable = !!targetElement && (!!targetSnapshot || resourceTarget);
     if (targetElement && !renderable)
       diagnostic(
         diagnostics,
@@ -431,24 +489,56 @@ export function buildAnimationProgram(
         `Animation target <${targetElement.tagName}> is not a rendered graphics element.`,
         href === undefined ? undefined : "href",
       );
-    const target = targetElement
+    const target: AnimationTarget | undefined = targetElement
       ? {
-          key: property(targetElement, "id")
-            ? `id:${property(targetElement, "id")}`
-            : `source:${order.get(targetElement)}`,
+          key: targetKey!,
           source: source(targetElement),
           reference,
           renderable,
+          tagName: targetElement.tagName ?? "unknown",
+          binding: targetSnapshot?.binding ?? (targetSnapshot ? "render-node" : "resource"),
+          referenceChain: (() => {
+            const chain: SourceLocation[] = [];
+            let current: ElementNode | undefined = targetElement;
+            while (current) {
+              chain.push(source(current));
+              current = parents.get(current);
+            }
+            return chain;
+          })(),
         }
       : undefined;
-    const attributeName = property(element, "attributeName");
-    if (kind === "animate" && !attributeName)
+    const authoredAttributeName = property(element, "attributeName");
+    const attributeTypeSource = property(element, "attributeType");
+    const attributeType: AnimationDefinition["attributeType"] =
+      attributeTypeSource === "XML" || attributeTypeSource === "CSS" ? attributeTypeSource : "auto";
+    const attributeSpec = authoredAttributeName
+      ? resolveAnimationAttribute(authoredAttributeName, attributeType)
+      : undefined;
+    const attributeName = attributeSpec?.canonicalName;
+    if ((kind === "animate" || kind === "set") && !authoredAttributeName)
       diagnostic(
         diagnostics,
         element,
         "missing-animation-attribute",
-        "<animate> requires attributeName.",
+        `<${element.tagName}> requires attributeName.`,
         "attributeName",
+      );
+    if (attributeTypeSource !== undefined && !["auto", "XML", "CSS"].includes(attributeTypeSource))
+      diagnostic(
+        diagnostics,
+        element,
+        "invalid-animation-attribute-type",
+        `attributeType must be auto, XML, or CSS; received '${attributeTypeSource}'.`,
+        "attributeType",
+      );
+    if (authoredAttributeName && animationAttributeSpec(authoredAttributeName) && !attributeSpec)
+      diagnostic(
+        diagnostics,
+        element,
+        "incompatible-animation-attribute-type",
+        `${authoredAttributeName} is not available in the requested ${attributeType} namespace.`,
+        "attributeType",
       );
     const restartValue = property(element, "restart");
     const fillValue = property(element, "fill");
@@ -476,9 +566,12 @@ export function buildAnimationProgram(
     };
     const value = parseValue(
       element,
-      targetElement,
       attributeName,
-      (target?.source.id ? targetContexts.get(target.source.id) : undefined) ?? animationValueContext,
+      targetSnapshot?.context ?? animationValueContext,
+      attributeName
+        ? (targetSnapshot?.baseValues[attributeName] ??
+            (targetElement ? property(targetElement, attributeName) : undefined))
+        : undefined,
     );
     const calcModeSource = property(element, "calcMode");
     const defaultCalcMode = kind === "set" ? "discrete" : kind === "animateMotion" ? "paced" : "linear";
@@ -508,7 +601,9 @@ export function buildAnimationProgram(
       source: source(element),
       ...(target ? { target } : {}),
       kind,
+      ...(authoredAttributeName ? { authoredAttributeName } : {}),
       ...(attributeName ? { attributeName } : {}),
+      attributeType,
       timing,
       value,
       composition,
@@ -516,7 +611,7 @@ export function buildAnimationProgram(
       dependencies,
     };
     let runtimeSupport: AnimationDefinition["runtimeSupport"] = target ? "pending" : "invalid";
-    if (isRuntimeSupported(baseDefinition)) runtimeSupport = "scalar";
+    if (isRuntimeSupported(baseDefinition)) runtimeSupport = "typed";
     const definition: AnimationDefinition = { ...baseDefinition, runtimeSupport };
     animations.push(definition);
 
@@ -639,14 +734,50 @@ export function buildAnimationProgram(
         "keyPoints must be a semicolon-separated list of values from 0 through 1.",
         "keyPoints",
       );
+    if (attributeName && target && !propertyAppliesToTarget(attributeName, target.tagName))
+      diagnostic(
+        diagnostics,
+        element,
+        "non-animatable-target-property",
+        `${attributeName} does not apply to animation target <${target.tagName}> (${target.referenceChain
+          .map((item) => (item.id ? `<${item.element}#${item.id}>` : `<${item.element}>`))
+          .join(" <- ")}).`,
+        "attributeName",
+      );
+    for (const raw of [
+      property(element, "from"),
+      property(element, "to"),
+      property(element, "by"),
+      ...(property(element, "values")?.split(";") ?? []),
+    ]) {
+      if (!raw || !/url\(/i.test(raw)) continue;
+      const local = /^\s*url\(\s*["']?#([^\s)"']+)["']?\s*\)(?:\s+.+)?\s*$/i.exec(raw);
+      if (!local) {
+        diagnostic(
+          diagnostics,
+          element,
+          "unsupported-animation-resource-reference",
+          `Animated resource value '${raw}' must use one local url(#id) reference.`,
+          "values",
+        );
+      } else if (!definitions.has(local[1]!)) {
+        diagnostic(
+          diagnostics,
+          element,
+          "unresolved-animation-resource-reference",
+          `Animated resource value references missing definition #${local[1]}.`,
+          "values",
+        );
+      }
+    }
     if (value.family === "unsupported")
       diagnostic(
         diagnostics,
         element,
-        animationAttributeSpec(attributeName ?? "") ? "invalid-animation-value" : "unknown-animation-attribute",
-        animationAttributeSpec(attributeName ?? "")
+        animationAttributeSpec(authoredAttributeName ?? "") ? "invalid-animation-value" : "unknown-animation-attribute",
+        animationAttributeSpec(authoredAttributeName ?? "")
           ? "The authored animation values are invalid for the target attribute's value family."
-          : `The animation value family for '${attributeName ?? ""}' is unknown; the compiler will not guess.`,
+          : `The animation value family for '${authoredAttributeName ?? ""}' is unknown; the compiler will not guess.`,
         "attributeName",
       );
     if (value.family !== "unsupported") {
@@ -763,7 +894,7 @@ export function declarativeAnimationTag(tagName: string | undefined): boolean {
 /** Reference sampler for the first compiler slice and exact clock-boundary tests. */
 export function sampleNumericAnimation(animation: AnimationDefinition, documentTime: number): number | undefined {
   if (
-    animation.runtimeSupport !== "scalar" ||
+    animation.runtimeSupport !== "typed" ||
     animation.value.family === "unsupported" ||
     animation.timing.duration.type !== "seconds" ||
     animation.timing.begin[0]?.type !== "offset"
@@ -792,4 +923,52 @@ export function sampleNumericAnimation(animation: AnimationDefinition, documentT
     animation.value.base,
   );
   return result ? scalar(result.value) : undefined;
+}
+
+/** Pure presentation-value sampling for tests, reports, and non-Swift frontends. */
+export function sampleAnimatedPresentationValue(
+  program: AnimationProgram,
+  targetKey: string,
+  attributeName: string,
+  base: AnimationValueSet["base"],
+  documentTime: number,
+  events: readonly DeterministicTimingEvent[] = [],
+): AnimationValueSet["base"] {
+  const timing = sampleSMILProgram(program, documentTime, events);
+  let underlying = base;
+  for (const animation of program.animations
+    .filter(
+      (candidate) =>
+        candidate.runtimeSupport === "typed" &&
+        candidate.target?.key === targetKey &&
+        candidate.attributeName === attributeName &&
+        candidate.value.family !== "unsupported",
+    )
+    .sort((left, right) => left.documentOrder - right.documentOrder)) {
+    if (animation.value.family === "unsupported") continue;
+    const clock = timing.samples.get(animation.stableId);
+    if (!clock || clock.state === "inactive" || clock.state === "completed" || clock.simpleProgress === undefined)
+      continue;
+    const values: AnimationValueSet =
+      animation.kind === "set"
+        ? {
+            ...animation.value,
+            form: "values",
+            values: animation.value.to
+              ? [animation.value.to]
+              : animation.value.values
+                ? [animation.value.values[animation.value.values.length - 1]!]
+                : [],
+          }
+        : animation.value;
+    const sampled = sampleAnimationValue(
+      values,
+      animation.kind === "set" ? { ...animation.composition, calcMode: "discrete" } : animation.composition,
+      clock.simpleProgress,
+      clock.repeatIteration,
+      underlying,
+    );
+    if (sampled) underlying = sampled.value;
+  }
+  return underlying;
 }

--- a/packages/svg-to-swiftui-core/src/renderTree/animationValues.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/animationValues.ts
@@ -22,11 +22,29 @@ export type AnimationValueFamily =
   | "discrete";
 
 export interface AnimationAttributeSpec {
+  canonicalName: string;
   family: AnimationValueFamily;
   animatable: boolean;
   additive: boolean;
   axis?: LengthAxis;
   clamp?: "unit" | "nonnegative";
+  namespaces: readonly ("XML" | "CSS")[];
+  invalidates: readonly AnimationInvalidationCategory[];
+}
+
+export type AnimationInvalidationCategory =
+  | "visibility"
+  | "geometry"
+  | "paint"
+  | "bounds"
+  | "resource"
+  | "filter-buffer"
+  | "text-layout"
+  | "viewport";
+
+export interface AnimationAttributeRegistryEntry extends AnimationAttributeSpec {
+  targetElements: readonly string[] | "graphics" | "text" | "filter-primitives" | "any";
+  runtimeBinding: "render-node" | "gradient-stop" | "pending-resource" | "pending-follow-up";
 }
 
 export interface AnimationValueContext {
@@ -187,43 +205,223 @@ const DISCRETE_ATTRIBUTES = new Set([
   "visibility",
 ]);
 
-/** Registry shared by SMIL and CSS frontends. Unknown properties are never guessed. */
+const GEOMETRY_ATTRIBUTES = new Set([
+  "cx",
+  "cy",
+  "d",
+  "height",
+  "pathLength",
+  "points",
+  "r",
+  "rx",
+  "ry",
+  "width",
+  "x",
+  "x1",
+  "x2",
+  "y",
+  "y1",
+  "y2",
+]);
+const TEXT_ATTRIBUTES = new Set([
+  "alignment-baseline",
+  "dominant-baseline",
+  "dx",
+  "dy",
+  "font-family",
+  "font-size",
+  "font-style",
+  "font-weight",
+  "glyph-orientation-horizontal",
+  "glyph-orientation-vertical",
+  "letter-spacing",
+  "rotate",
+  "startOffset",
+  "text-anchor",
+  "text-decoration",
+  "textLength",
+  "word-spacing",
+  "x",
+  "y",
+]);
+const FILTER_ATTRIBUTES = new Set([
+  ...NUMBER_ATTRIBUTES,
+  ...INTEGER_ATTRIBUTES,
+  "flood-color",
+  "flood-opacity",
+  "lighting-color",
+  "values",
+]);
+const PAINT_ATTRIBUTES = new Set([
+  "color",
+  "fill",
+  "fill-opacity",
+  "fill-rule",
+  "flood-color",
+  "flood-opacity",
+  "lighting-color",
+  "opacity",
+  "stop-color",
+  "stop-opacity",
+  "stroke",
+  "stroke-dasharray",
+  "stroke-dashoffset",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "stroke-miterlimit",
+  "stroke-opacity",
+  "stroke-width",
+]);
+const RESOURCE_ATTRIBUTES = new Set(["clip-path", "filter", "marker-end", "marker-mid", "marker-start", "mask"]);
+const CSS_ONLY_ATTRIBUTES = new Set(["mix-blend-mode", "isolation"]);
+const XML_ONLY_ATTRIBUTES = new Set(["viewBox", "preserveAspectRatio"]);
+const ANIMATE_SET_RENDER_ATTRIBUTES = new Set([
+  "color",
+  "cx",
+  "cy",
+  "d",
+  "display",
+  "dx",
+  "dy",
+  "fill",
+  "fill-opacity",
+  "font-size",
+  "height",
+  "letter-spacing",
+  "opacity",
+  "points",
+  "preserveAspectRatio",
+  "r",
+  "rx",
+  "ry",
+  "stroke",
+  "stroke-dasharray",
+  "stroke-dashoffset",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "stroke-miterlimit",
+  "stroke-opacity",
+  "stroke-width",
+  "viewBox",
+  "visibility",
+  "width",
+  "word-spacing",
+  "x",
+  "x1",
+  "x2",
+  "y",
+  "y1",
+  "y2",
+]);
+const GRADIENT_STOP_ATTRIBUTES = new Set(["offset", "stop-color", "stop-opacity"]);
+
+function registryEntry(
+  canonicalName: string,
+  family: AnimationValueFamily,
+  additive: boolean,
+  options: Pick<AnimationAttributeSpec, "axis" | "clamp"> = {},
+): AnimationAttributeRegistryEntry {
+  const invalidates = new Set<AnimationInvalidationCategory>();
+  if (canonicalName === "display" || canonicalName === "visibility") invalidates.add("visibility");
+  if (GEOMETRY_ATTRIBUTES.has(canonicalName)) {
+    invalidates.add("geometry");
+    invalidates.add("bounds");
+  }
+  if (TEXT_ATTRIBUTES.has(canonicalName)) {
+    invalidates.add("text-layout");
+    invalidates.add("bounds");
+  }
+  if (PAINT_ATTRIBUTES.has(canonicalName)) invalidates.add("paint");
+  if (RESOURCE_ATTRIBUTES.has(canonicalName)) invalidates.add("resource");
+  if (FILTER_ATTRIBUTES.has(canonicalName) || canonicalName === "filter") invalidates.add("filter-buffer");
+  if (canonicalName === "viewBox" || canonicalName === "preserveAspectRatio") {
+    invalidates.add("viewport");
+    invalidates.add("geometry");
+    invalidates.add("bounds");
+  }
+  if (invalidates.size === 0) invalidates.add("paint");
+  return {
+    canonicalName,
+    family,
+    animatable: true,
+    additive,
+    namespaces: CSS_ONLY_ATTRIBUTES.has(canonicalName)
+      ? ["CSS"]
+      : XML_ONLY_ATTRIBUTES.has(canonicalName)
+        ? ["XML"]
+        : ["XML", "CSS"],
+    invalidates: [...invalidates],
+    targetElements: GRADIENT_STOP_ATTRIBUTES.has(canonicalName)
+      ? ["stop"]
+      : FILTER_ATTRIBUTES.has(canonicalName)
+        ? "filter-primitives"
+        : TEXT_ATTRIBUTES.has(canonicalName)
+          ? "any"
+          : canonicalName === "viewBox" || canonicalName === "preserveAspectRatio"
+            ? ["svg", "symbol", "view", "marker", "pattern"]
+            : "any",
+    runtimeBinding: ANIMATE_SET_RENDER_ATTRIBUTES.has(canonicalName)
+      ? "render-node"
+      : GRADIENT_STOP_ATTRIBUTES.has(canonicalName)
+        ? "gradient-stop"
+        : FILTER_ATTRIBUTES.has(canonicalName) || RESOURCE_ATTRIBUTES.has(canonicalName)
+          ? "pending-resource"
+          : "pending-follow-up",
+    ...options,
+  };
+}
+
+const registry = new Map<string, AnimationAttributeRegistryEntry>();
+const register = (
+  names: Iterable<string>,
+  family: AnimationValueFamily,
+  additive: boolean,
+  options: (name: string) => Pick<AnimationAttributeSpec, "axis" | "clamp"> = () => ({}),
+) => {
+  for (const name of names) registry.set(name, registryEntry(name, family, additive, options(name)));
+};
+register(NUMBER_ATTRIBUTES, "number", true);
+register(INTEGER_ATTRIBUTES, "integer", true);
+register(OPACITY_ATTRIBUTES, "opacity", true, () => ({ clamp: "unit" }));
+register(HORIZONTAL_LENGTH_ATTRIBUTES, "length", true, () => ({ axis: "horizontal" }));
+register(VERTICAL_LENGTH_ATTRIBUTES, "length", true, () => ({ axis: "vertical" }));
+register(OTHER_LENGTH_ATTRIBUTES, "length", true, (name) => ({
+  axis: "other",
+  ...(["r", "rx", "ry", "stroke-width"].includes(name) ? { clamp: "nonnegative" as const } : {}),
+}));
+register(ANGLE_ATTRIBUTES, "angle", true);
+register(COLOR_ATTRIBUTES, "color", true);
+register(LENGTH_LIST_ATTRIBUTES, "length-list", true, () => ({ axis: "other" }));
+register(DISCRETE_ATTRIBUTES, "discrete", false);
+registry.set("stroke-miterlimit", registryEntry("stroke-miterlimit", "number", true, { clamp: "nonnegative" }));
+registry.set("offset", registryEntry("offset", "opacity", true, { clamp: "unit" }));
+registry.set("points", registryEntry("points", "points", true));
+registry.set("d", registryEntry("d", "path", false));
+registry.set("viewBox", registryEntry("viewBox", "viewBox", true));
+registry.set("transform", registryEntry("transform", "transform", true));
+registry.set("fill", registryEntry("fill", "paint", true));
+registry.set("stroke", registryEntry("stroke", "paint", true));
+registry.set("values", registryEntry("values", "number-list", true));
+registry.set("keyPoints", registryEntry("keyPoints", "number-list", true));
+registry.set("rotate", registryEntry("rotate", "number-list", true));
+
+/** Machine-readable registry shared by SMIL, CSS animation, code generation, and conformance reporting. */
+export const ANIMATION_ATTRIBUTE_REGISTRY: readonly AnimationAttributeRegistryEntry[] = [...registry.values()].sort(
+  (left, right) => left.canonicalName.localeCompare(right.canonicalName),
+);
+
+/** Unknown properties are never guessed or normalized by accidental casing. */
 export function animationAttributeSpec(attributeName: string): AnimationAttributeSpec | undefined {
-  if (attributeName === "stroke-miterlimit")
-    return { family: "number", animatable: true, additive: true, clamp: "nonnegative" };
-  if (attributeName === "offset") return { family: "opacity", animatable: true, additive: true, clamp: "unit" };
-  if (NUMBER_ATTRIBUTES.has(attributeName)) return { family: "number", animatable: true, additive: true };
-  if (INTEGER_ATTRIBUTES.has(attributeName)) return { family: "integer", animatable: true, additive: true };
-  if (OPACITY_ATTRIBUTES.has(attributeName))
-    return { family: "opacity", animatable: true, additive: true, clamp: "unit" };
-  if (HORIZONTAL_LENGTH_ATTRIBUTES.has(attributeName))
-    return { family: "length", animatable: true, additive: true, axis: "horizontal" };
-  if (VERTICAL_LENGTH_ATTRIBUTES.has(attributeName))
-    return { family: "length", animatable: true, additive: true, axis: "vertical" };
-  if (OTHER_LENGTH_ATTRIBUTES.has(attributeName))
-    return {
-      family: "length",
-      animatable: true,
-      additive: true,
-      axis: "other",
-      ...(["r", "rx", "ry", "stroke-width", "stroke-miterlimit"].includes(attributeName)
-        ? { clamp: "nonnegative" as const }
-        : {}),
-    };
-  if (ANGLE_ATTRIBUTES.has(attributeName)) return { family: "angle", animatable: true, additive: true };
-  if (COLOR_ATTRIBUTES.has(attributeName)) return { family: "color", animatable: true, additive: true };
-  if (LENGTH_LIST_ATTRIBUTES.has(attributeName))
-    return { family: "length-list", animatable: true, additive: true, axis: "other" };
-  if (attributeName === "points") return { family: "points", animatable: true, additive: true };
-  if (attributeName === "d") return { family: "path", animatable: true, additive: false };
-  if (attributeName === "viewBox") return { family: "viewBox", animatable: true, additive: true };
-  if (attributeName === "transform") return { family: "transform", animatable: true, additive: true };
-  if (attributeName === "fill" || attributeName === "stroke")
-    return { family: "paint", animatable: true, additive: true };
-  if (attributeName === "values" || attributeName === "keyPoints")
-    return { family: "number-list", animatable: true, additive: true };
-  if (DISCRETE_ATTRIBUTES.has(attributeName)) return { family: "discrete", animatable: true, additive: false };
-  return undefined;
+  return registry.get(attributeName);
+}
+
+export function resolveAnimationAttribute(
+  attributeName: string,
+  attributeType: "auto" | "XML" | "CSS" = "auto",
+): AnimationAttributeRegistryEntry | undefined {
+  const spec = registry.get(attributeName);
+  if (!spec) return undefined;
+  return attributeType === "auto" || spec.namespaces.includes(attributeType) ? spec : undefined;
 }
 
 function numbers(source: string): number[] | undefined {

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -25,8 +25,7 @@ import type { SVGElementProperties, ViewBoxData } from "../types";
 import { getSVGElement, resolveSVGProperties } from "../utils";
 import { DEFAULT_PRESERVE_ASPECT_RATIO, parsePreserveAspectRatio, parseViewBox, viewBoxTransform } from "../viewports";
 import { SVGAccessibilityResolver } from "./accessibility";
-import { buildAnimationProgram, declarativeAnimationTag } from "./animation";
-import type { AnimationValueContext } from "./animationValues";
+import { type AnimationTargetSnapshot, buildAnimationProgram, declarativeAnimationTag } from "./animation";
 import { resolveClipPathInstance, resolveClipPathResources } from "./clips";
 import { SVGConditionalProcessor } from "./conditionalProcessing";
 import { resolveFilterInstance, resolveFilterResources } from "./filters";
@@ -79,6 +78,7 @@ interface BuildContext {
   conditional: SVGConditionalProcessor;
   accessibility: SVGAccessibilityResolver;
   includeAccessibility: boolean;
+  animationTargetKeys: WeakMap<ElementNode, string>;
 }
 
 const GEOMETRY_ELEMENTS = new Set(["path", "circle", "ellipse", "rect", "line", "polyline", "polygon"]);
@@ -118,6 +118,10 @@ const NON_RENDERING_ELEMENTS = new Set([
 function sourceLocation(element: ElementNode): SourceLocation {
   const id = element.properties?.id;
   return { element: element.tagName ?? "unknown", ...(id === undefined ? {} : { id: String(id) }) };
+}
+
+function animationTargetKey(element: ElementNode, context: BuildContext): string {
+  return context.animationTargetKeys.get(element) ?? `unindexed:${element.tagName ?? "unknown"}`;
 }
 
 function addDiagnostic(
@@ -482,6 +486,8 @@ function computeStyle(
   element: ElementNode,
   context: BuildContext,
   isLine = false,
+  inheritedProperties: StyleResolution["inheritedProperties"] = {},
+  currentColorProperties: StyleResolution["currentColorProperties"] = {},
 ): ComputedStyle {
   effective["font-size"] = fontMetrics.fontSize;
   const styleCoordinate = { ...coordinate, fontMetrics };
@@ -619,6 +625,8 @@ function computeStyle(
     },
     presentation: effective,
     provenance,
+    inheritedProperties,
+    currentColorProperties,
   };
 }
 
@@ -657,6 +665,8 @@ function resolvedPresentation(
       element,
       context,
       element.tagName === "line",
+      resolution.inheritedProperties,
+      resolution.currentColorProperties,
     ),
     provenance: resolution.provenance,
   };
@@ -1530,6 +1540,7 @@ function buildText(
 
   return {
     type: "text",
+    animationTargetKey: animationTargetKey(element, context),
     text: textContent(element),
     chunks,
     attributes: { ...(element.properties ?? {}) } as Record<string, string | number>,
@@ -1725,6 +1736,7 @@ function buildImage(
   )!;
   return {
     type: "image",
+    animationTargetKey: animationTargetKey(element, context),
     href,
     viewport: { x, y, width, height },
     preserveAspectRatio,
@@ -1778,6 +1790,7 @@ function buildForeignObject(
 
   return {
     type: "foreignObject",
+    animationTargetKey: animationTargetKey(element, context),
     key,
     viewport,
     snapshotDocument: snapshot.document,
@@ -1878,6 +1891,7 @@ function buildGroup(
   const childCoordinate = { ...coordinate, fontMetrics: resolved.fontMetrics };
   return {
     type: "group",
+    animationTargetKey: animationTargetKey(element, context),
     children: children.flatMap((child) => buildNode(child, resolved.effective, childCoordinate, context)),
     style: resolved.style,
     transform: transform ?? computedTransform(element, resolved, context),
@@ -1913,6 +1927,7 @@ function buildNestedSVG(
   };
   return {
     type: "group",
+    animationTargetKey: animationTargetKey(element, context),
     children: zeroSized
       ? []
       : childElements(element).flatMap((child) => buildNode(child, resolved.effective, childCoordinate, context)),
@@ -1973,6 +1988,7 @@ function buildViewportUse(
   };
   const referencedGroup: RenderGroup = {
     type: "group",
+    animationTargetKey: animationTargetKey(referenced, childContext),
     children: zeroSized
       ? []
       : childElements(referenced).flatMap((child) =>
@@ -1991,6 +2007,7 @@ function buildViewportUse(
   };
   return {
     type: "group",
+    animationTargetKey: animationTargetKey(use, context),
     children: zeroSized ? [] : [referencedGroup],
     style: useResolved.style,
     transform,
@@ -2057,6 +2074,7 @@ function buildUse(
   return [
     {
       type: "group",
+      animationTargetKey: animationTargetKey(element, context),
       children: buildNode(
         referenced,
         resolved.effective,
@@ -2104,7 +2122,9 @@ function buildNode(
       ? [
           {
             type: "shape",
+            animationTargetKey: animationTargetKey(element, context),
             geometry: resolvedGeometry,
+            geometryAuthored: { ...(element.properties ?? {}) } as Record<string, string | number>,
             style: resolved.style,
             transform,
             source: sourceLocation(element),
@@ -2140,6 +2160,15 @@ export function buildRenderDocument(
 ): RenderDocument {
   const resources = createRegistry(svg);
   const diagnostics = [...initialDiagnostics];
+  const animationTargetKeys = new WeakMap<ElementNode, string>();
+  let sourceOrder = 0;
+  const indexAnimationTargets = (element: ElementNode): void => {
+    const id = element.properties?.id;
+    animationTargetKeys.set(element, id === undefined ? `source:${sourceOrder}` : `id:${String(id)}`);
+    sourceOrder++;
+    for (const child of childElements(element)) indexAnimationTargets(child);
+  };
+  indexAnimationTargets(svg);
   const styleResolver = new SVGStyleResolver(svg, diagnostics);
   const conditional = new SVGConditionalProcessor(config.staticEnvironment, diagnostics);
   const accessibility = new SVGAccessibilityResolver(resources, conditional.environment, diagnostics);
@@ -2152,6 +2181,7 @@ export function buildRenderDocument(
     conditional,
     accessibility,
     includeAccessibility: true,
+    animationTargetKeys,
   };
   const diagnoseDynamicContent = (element: ElementNode): void => {
     const tag = (element.tagName ?? "").toLowerCase();
@@ -2202,6 +2232,7 @@ export function buildRenderDocument(
     styleResolver,
     resolved.effective,
     diagnostics,
+    (element) => animationTargetKeys.get(element),
   );
   for (const [id, paint] of resolvePatternPaintServers(
     svg,
@@ -2435,6 +2466,7 @@ export function buildRenderDocument(
   const childCoordinate = { ...coordinate, fontMetrics: resolved.fontMetrics };
   const root: RenderGroup = {
     type: "group",
+    animationTargetKey: animationTargetKey(svg, context),
     children:
       properties.zeroSized || !conditional.matches(svg)
         ? []
@@ -2623,6 +2655,7 @@ export function buildRenderDocument(
     ].reduce(multiplyTransforms);
     const group: RenderGroup = {
       type: "group",
+      animationTargetKey: animationTargetKey(resource.element, context),
       children: built,
       // display on the marker element is forced to none only for direct rendering;
       // referenced shadow content still consumes all other computed properties.
@@ -2932,6 +2965,7 @@ export function buildRenderDocument(
       }
       const rootGroup: RenderGroup = {
         type: "group",
+        animationTargetKey: animationTargetKey(resource.element, context),
         children: built,
         // display does not apply to the clipPath element itself. Other computed
         // properties still inherit normally into its graphics children.
@@ -3139,25 +3173,112 @@ export function buildRenderDocument(
   }
   diagnosePaintReferences(children);
 
-  const animationTargetContexts = new Map<string, AnimationValueContext>();
-  const collectAnimationTargetContexts = (nodes: RenderNode[]): void => {
+  const paintAnimationSource = (paint: Paint): string => {
+    if (paint.type === "none") return "none";
+    if (paint.type === "solid") return paint.value;
+    if (paint.type === "context") return `context-${paint.source}`;
+    return `url(#${paint.id})${paint.fallback ? ` ${paint.fallback}` : ""}`;
+  };
+  const animationBaseValues = (node: RenderNode): Record<string, string> => {
+    const values: Record<string, string> = {};
+    for (const [name, value] of Object.entries(node.style.presentation)) {
+      if (typeof value === "string" || typeof value === "number") values[name] = String(value);
+    }
+    Object.assign(values, {
+      fill: paintAnimationSource(node.style.fill),
+      stroke: paintAnimationSource(node.style.stroke),
+      color: node.style.color,
+      opacity: String(node.style.opacity),
+      "fill-opacity": String(node.style.fillOpacity),
+      "stroke-opacity": String(node.style.strokeOpacity),
+      display: node.style.display,
+      visibility: node.style.visibility,
+      "fill-rule": node.style.fillRule,
+      "clip-rule": node.style.clipRule,
+      "stroke-width": String(node.style.strokeStyle.width),
+      "stroke-linecap": node.style.strokeStyle.lineCap,
+      "stroke-linejoin": node.style.strokeStyle.lineJoin,
+      "stroke-miterlimit": String(node.style.strokeStyle.miterLimit),
+      "stroke-dashoffset": String(node.style.strokeStyle.dashOffset),
+      "stroke-dasharray": node.style.strokeStyle.dashArray?.join(" ") ?? "none",
+      "vector-effect": node.style.strokeStyle.vectorEffect,
+      "mix-blend-mode": node.style.blendMode,
+      isolation: node.style.isolation,
+    });
+    if (node.type === "shape") {
+      for (const [name, value] of Object.entries(node.geometry)) {
+        if (name !== "type" && value !== undefined) values[name] = String(value);
+      }
+    }
+    if (node.type === "text" || node.type === "image" || node.type === "foreignObject") {
+      for (const [name, value] of Object.entries(node.attributes)) values[name] = String(value);
+    }
+    if (node.type === "image" || node.type === "foreignObject") {
+      for (const [name, value] of Object.entries(node.viewport)) values[name] = String(value);
+    }
+    if (node.type === "group" && node.viewport) {
+      if (node.viewport.viewBox) {
+        const box = node.viewport.viewBox;
+        values.viewBox = `${box.x} ${box.y} ${box.width} ${box.height}`;
+      }
+      values.preserveAspectRatio = `${node.viewport.preserveAspectRatio.align} ${node.viewport.preserveAspectRatio.meetOrSlice}`;
+    }
+    if (node === root) {
+      const box = properties.viewBox;
+      values.viewBox = `${box.x} ${box.y} ${box.width} ${box.height}`;
+      values.preserveAspectRatio = `${properties.preserveAspectRatio.align} ${properties.preserveAspectRatio.meetOrSlice}`;
+    }
+    return values;
+  };
+  const animationTargetSnapshots = new Map<string, AnimationTargetSnapshot>();
+  const collectAnimationTargetSnapshots = (nodes: RenderNode[]): void => {
     for (const node of nodes) {
-      if (node.source.id)
-        animationTargetContexts.set(node.source.id, {
+      if (node.animationTargetKey && !animationTargetSnapshots.has(node.animationTargetKey))
+        animationTargetSnapshots.set(node.animationTargetKey, {
+          key: node.animationTargetKey,
+          tagName: node.source.element,
+          context: {
+            length: {
+              viewport: node.paintContext.viewport,
+              rootViewport: node.paintContext.rootViewport,
+              fontMetrics: node.paintContext.fontMetrics,
+              percentageBasis: "viewport-diagonal",
+              axis: "other",
+            },
+            colorSpace:
+              String(node.style.presentation["color-interpolation"] ?? "sRGB").toLowerCase() === "linearrgb"
+                ? "linearRGB"
+                : "sRGB",
+          },
+          baseValues: animationBaseValues(node),
+        });
+      if (node.type === "group") collectAnimationTargetSnapshots(node.children);
+    }
+  };
+  collectAnimationTargetSnapshots(children);
+  for (const paint of resources.paints.values()) {
+    if (paint.type !== "linearGradient" && paint.type !== "radialGradient") continue;
+    for (const stop of paint.stops) {
+      if (!stop.animationTargetKey || animationTargetSnapshots.has(stop.animationTargetKey)) continue;
+      animationTargetSnapshots.set(stop.animationTargetKey, {
+        key: stop.animationTargetKey,
+        tagName: "stop",
+        binding: "resource",
+        context: {
           length: {
-            viewport: node.paintContext.viewport,
-            rootViewport: node.paintContext.rootViewport,
-            fontMetrics: node.paintContext.fontMetrics,
+            viewport: properties.userViewport,
+            rootViewport: { width: properties.width, height: properties.height },
+            fontMetrics: defaultFontMetrics(),
             percentageBasis: "viewport-diagonal",
             axis: "other",
           },
-          colorSpace: "sRGB",
-        });
-      if (node.type === "group") collectAnimationTargetContexts(node.children);
+          colorSpace: paint.colorInterpolation,
+        },
+        baseValues: stop.animationBaseValues ?? {},
+      });
     }
-  };
-  collectAnimationTargetContexts(children);
-  const animationProgram = buildAnimationProgram(svg, diagnostics, animationTargetContexts);
+  }
+  const animationProgram = buildAnimationProgram(svg, diagnostics, animationTargetSnapshots);
 
   return {
     viewport: {

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -6,7 +6,13 @@ import { createFunctionTemplate, createStructTemplate } from "../templates";
 import { multiplyTransforms, wrapWithTransform } from "../transformUtils";
 import type { SVGElementProperties, SwiftUIGeneratorConfig, TranspilerOptions, ViewBoxData } from "../types";
 import { viewBoxTransform } from "../viewports";
-import type { TypedAnimationValue } from "./animationValues";
+import {
+  addAnimationValues,
+  animationAttributeSpec,
+  parseAnimationValue,
+  swiftAnimationValueLiteral,
+  type TypedAnimationValue,
+} from "./animationValues";
 import { renderNodeBounds } from "./bounds";
 import { type ResolvedGradient, resolveGradientForShape } from "./gradients";
 import { type ResolvedPattern, resolvePatternForShape } from "./patterns";
@@ -38,6 +44,7 @@ export interface GeneratedSwiftUI {
 interface ShapeHelper {
   name: string;
   lines: string[];
+  animated?: boolean;
 }
 
 type GeneratedViewNode =
@@ -46,6 +53,7 @@ type GeneratedViewNode =
       helper: string;
       swiftColor: string;
       cgColor: RGBAColor;
+      cgColorExpression?: string;
       tileContained?: boolean;
       clipUnions?: string[][];
     }
@@ -55,6 +63,7 @@ type GeneratedViewNode =
       gradient: ResolvedGradient;
       paintOpacity: number;
       coordinateSpace: ViewBoxData;
+      stopsExpression?: string;
     }
   | {
       type: "pattern";
@@ -77,7 +86,7 @@ type GeneratedViewNode =
   | {
       type: "group";
       children: GeneratedViewNode[];
-      opacity: number;
+      opacity: number | string;
       isolated: boolean;
       blendMode: SVGBlendMode;
       viewportClip?: string;
@@ -87,6 +96,9 @@ type GeneratedViewNode =
       tileContained?: boolean;
       accessibility?: AccessibilityMetadata;
       animationOffsetX?: string;
+      animationOffsetY?: string;
+      presentationCondition?: string;
+      animationTransform?: string;
     };
 
 interface GeneratedMask {
@@ -124,7 +136,20 @@ interface ViewBuildContext {
   precision: number;
   coordinateSpace: ViewBoxData;
   activePatterns: Set<string>;
-  textHelpers: Array<{ name: string; node: RenderText; transform: RenderNode["transform"] }>;
+  textHelpers: Array<{
+    name: string;
+    node: RenderText;
+    transform: RenderNode["transform"];
+    fillAnimation?: string;
+    fillOpacity?: string;
+    strokeAnimation?: string;
+    strokeOpacity?: string;
+    strokeWidth?: string;
+    fontSize?: string;
+    letterSpacing?: string;
+    wordSpacing?: string;
+    animated: boolean;
+  }>;
   imageHelpers: Array<{
     name: string;
     node: Extract<RenderNode, { type: "image" | "foreignObject" }>;
@@ -302,6 +327,15 @@ function addHelper(context: ViewBuildContext, name: string, lines: string[]): st
   return name;
 }
 
+function addAnimatedHelper(context: ViewBuildContext, name: string, lines: string[]): string {
+  context.helpers.push({ name, lines, animated: true });
+  return `${name}(documentTime: documentTime)`;
+}
+
+function shapeHelperCall(helper: string): string {
+  return helper.includes("(") ? helper : `${helper}()`;
+}
+
 function isContainedInTile(node: RenderNode, pattern: ResolvedPattern): boolean {
   const bounds = renderNodeBounds(node, pattern.contentTransform);
   if (!bounds) return false;
@@ -332,52 +366,95 @@ function buildViewNodes(
   nodes: RenderNode[],
   context: ViewBuildContext,
   ancestorTransforms: RenderNode["transform"][] = [],
+  inheritedAnimationOwners: Readonly<Record<string, RenderNode>> = {},
 ): GeneratedViewNode[] {
   const generated: GeneratedViewNode[] = [];
 
-  const animationOffsetX = (node: RenderNode): string | undefined => {
-    if (!node.source.id) return undefined;
-    const animations = context.document.animationProgram.animations.filter(
-      (candidate) =>
-        candidate.runtimeSupport === "scalar" &&
-        candidate.target?.source.id === node.source.id &&
-        (candidate.attributeName === "cx" || candidate.attributeName === "x"),
-    );
+  const directAnimationsFor = (node: RenderNode, attributeName: string) =>
+    node.animationTargetKey
+      ? context.document.animationProgram.animations.filter(
+          (candidate) =>
+            candidate.runtimeSupport === "typed" &&
+            candidate.target?.key === node.animationTargetKey &&
+            candidate.attributeName === attributeName,
+        )
+      : [];
+
+  const ownedAnimationsFor = (node: RenderNode, attributeName: string) => {
+    const direct = directAnimationsFor(node, attributeName);
+    if (direct.length > 0) return direct;
+    if ((attributeName === "fill" || attributeName === "stroke") && node.style.currentColorProperties[attributeName])
+      return directAnimationsFor(node, "color");
+    return direct;
+  };
+
+  const animationsFor = (node: RenderNode, attributeName: string) => {
+    const direct = ownedAnimationsFor(node, attributeName);
+    if (direct.length > 0 || !node.style.inheritedProperties[attributeName]) return direct;
+    const owner = inheritedAnimationOwners[attributeName];
+    return owner ? ownedAnimationsFor(owner, attributeName) : direct;
+  };
+
+  const inheritedAnimationAttributes = [
+    "color",
+    "fill",
+    "fill-opacity",
+    "font-size",
+    "letter-spacing",
+    "stroke",
+    "stroke-dasharray",
+    "stroke-dashoffset",
+    "stroke-linecap",
+    "stroke-linejoin",
+    "stroke-miterlimit",
+    "stroke-opacity",
+    "stroke-width",
+    "visibility",
+    "word-spacing",
+  ] as const;
+
+  const valueContext = (node: RenderNode) => ({
+    length: {
+      viewport: node.paintContext.viewport,
+      rootViewport: node.paintContext.rootViewport,
+      fontMetrics: node.paintContext.fontMetrics,
+      percentageBasis: "viewport-diagonal" as const,
+      axis: "other" as const,
+    },
+    colorSpace:
+      String(node.style.presentation["color-interpolation"] ?? "sRGB").toLowerCase() === "linearrgb"
+        ? ("linearRGB" as const)
+        : ("sRGB" as const),
+  });
+
+  const animatedValueExpressionFromAnimations = (
+    animations: ReturnType<typeof directAnimationsFor>,
+    base: TypedAnimationValue,
+  ): string | undefined => {
     if (animations.length === 0) return undefined;
-    const scalar = (value: TypedAnimationValue): number | undefined => {
-      switch (value.family) {
-        case "number":
-        case "integer":
-        case "opacity":
-        case "length":
-        case "angle":
-          return value.value;
-        default:
-          return undefined;
-      }
-    };
-    const first = animations[0]!;
-    if (first.value.family === "unsupported") return undefined;
-    const base = scalar(first.value.base);
-    if (base === undefined) return undefined;
-    let expression = formatNumber(base);
+    let expression = swiftAnimationValueLiteral(base, context.precision, `${context.rootName}.`);
     for (const animation of animations) {
       if (animation.value.family === "unsupported") continue;
       const set = animation.value;
-      const authoredValues =
-        set.form === "values"
-          ? set.values
-          : set.form === "from-to"
-            ? [set.from, set.to]
-            : set.form === "from-by"
-              ? [set.from, set.from && set.by ? { ...set.from, value: scalar(set.from)! + scalar(set.by)! } : undefined]
-              : set.form === "by"
-                ? [set.by ? { ...set.by, value: 0 } : undefined, set.by]
-                : set.form === "to"
-                  ? [set.to]
-                  : undefined;
-      const values = authoredValues?.map((value) => (value ? scalar(value) : undefined));
-      if (!values || values.some((value) => value === undefined)) continue;
+      let authoredValues: readonly TypedAnimationValue[] | undefined;
+      let form = set.form;
+      if (animation.kind === "set") {
+        const target = set.to ?? (set.values ? set.values[set.values.length - 1] : undefined);
+        if (!target) continue;
+        authoredValues = [target];
+        form = "values";
+      } else if (set.form === "values") authoredValues = set.values;
+      else if (set.form === "from-to" && set.from && set.to) authoredValues = [set.from, set.to];
+      else if (set.form === "from-by" && set.from && set.by) {
+        const endpoint = addAnimationValues(set.from, set.by);
+        if (endpoint) authoredValues = [set.from, endpoint];
+      } else if (set.form === "by" && set.by) authoredValues = [set.by];
+      else if (set.form === "to" && set.to) authoredValues = [set.to];
+      if (!authoredValues || authoredValues.length === 0) continue;
+      if (base.family === "paint")
+        authoredValues = authoredValues.map((value) =>
+          value.family === "color" ? { family: "paint", value: { type: "color", color: value.value } } : value,
+        );
       const intervals = context.animationIntervals.get(animation.stableId) ?? [];
       const intervalLiteral = intervals
         .map((interval) => `(begin: ${swiftDuration(interval.begin)}, end: ${swiftDuration(interval.end)})`)
@@ -401,9 +478,398 @@ function buildViewNodes(
             : set.attribute.clamp === "nonnegative"
               ? "nonnegative"
               : "none";
-      expression = `Self.svgAnimatedNumber(documentTime: documentTime, intervals: [${intervalLiteral}], duration: ${swiftDuration(duration)}, repeatingDuration: ${swiftDuration(repeatingDuration)}, values: [${values.map((value) => formatNumber(value!)).join(", ")}], form: .${set.form.replace(/-/g, "")}, calcMode: .${animation.composition.calcMode}, keyTimes: [${keyTimes}], keySplines: [${keySplines}], additive: ${animation.composition.additive === "sum" || set.form === "by" ? "true" : "false"}, accumulate: ${animation.composition.accumulate === "sum" ? "true" : "false"}, clamp: .${clampMode}, underlying: ${expression}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"})`;
+      expression = `${context.rootName}.svgAnimatedValue(documentTime: documentTime, intervals: [${intervalLiteral}], duration: ${swiftDuration(duration)}, repeatingDuration: ${swiftDuration(repeatingDuration)}, values: [${authoredValues.map((value) => swiftAnimationValueLiteral(value, context.precision, `${context.rootName}.`)).join(", ")}], form: .${form.replace(/-/g, "")}, calcMode: .${animation.kind === "set" ? "discrete" : animation.composition.calcMode}, keyTimes: [${keyTimes}], keySplines: [${keySplines}], additive: ${animation.composition.additive === "sum" || set.form === "by" ? "true" : "false"}, accumulate: ${animation.composition.accumulate === "sum" ? "true" : "false"}, clamp: .${clampMode}, underlying: ${expression}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"})`;
     }
-    return `${expression} - ${formatNumber(base)}`;
+    return expression;
+  };
+
+  const animatedValueExpression = (
+    node: RenderNode,
+    attributeName: string,
+    base: TypedAnimationValue,
+  ): string | undefined => animatedValueExpressionFromAnimations(animationsFor(node, attributeName), base);
+
+  const numericBase = (
+    node: RenderNode,
+    attributeName: string,
+    source: string | number,
+  ): TypedAnimationValue | undefined => {
+    const spec = animationAttributeSpec(attributeName);
+    return spec ? parseAnimationValue(spec, String(source), valueContext(node)) : undefined;
+  };
+
+  const animatedNumber = (node: RenderNode, attributeName: string, source: string | number): string | undefined => {
+    const base = numericBase(node, attributeName, source);
+    if (!base || !("value" in base) || typeof base.value !== "number") return undefined;
+    const expression = animatedValueExpression(node, attributeName, base);
+    return expression ? `${context.rootName}.svgAnimationNumber(${expression})` : undefined;
+  };
+
+  const animatedPaint = (node: RenderNode, attributeName: "fill" | "stroke", paint: Paint): string | undefined => {
+    const spec = animationAttributeSpec(attributeName)!;
+    const base = parseAnimationValue(spec, paintValue(paint), valueContext(node));
+    if (!base) return undefined;
+    return animatedValueExpression(node, attributeName, base);
+  };
+
+  const animatedDiscrete = (node: RenderNode, attributeName: string, source: string): string | undefined => {
+    const spec = animationAttributeSpec(attributeName);
+    const base = spec ? parseAnimationValue(spec, source, valueContext(node)) : undefined;
+    if (!base) return undefined;
+    const expression = animatedValueExpression(node, attributeName, base);
+    return expression ? `${context.rootName}.svgAnimationSource(${expression})` : undefined;
+  };
+
+  const animatedGradientStopValues = (stop: GradientStop, node: RenderNode) => {
+    const key = stop.animationTargetKey;
+    const animations = (attributeName: string) =>
+      key
+        ? context.document.animationProgram.animations.filter(
+            (candidate) =>
+              candidate.runtimeSupport === "typed" &&
+              candidate.target?.key === key &&
+              candidate.attributeName === attributeName,
+          )
+        : [];
+    const base = stop.animationBaseValues ?? {};
+    const parsedOffset = parseAnimationValue(
+      animationAttributeSpec("offset")!,
+      base.offset ?? String(stop.offset),
+      valueContext(node),
+    );
+    const parsedColor = parseAnimationValue(
+      animationAttributeSpec("stop-color")!,
+      base["stop-color"] ?? `rgba(${stop.color.red * 255} ${stop.color.green * 255} ${stop.color.blue * 255} / 1)`,
+      valueContext(node),
+    );
+    const parsedOpacity = parseAnimationValue(
+      animationAttributeSpec("stop-opacity")!,
+      base["stop-opacity"] ?? String(stop.color.alpha),
+      valueContext(node),
+    );
+    if (!parsedOffset || !parsedColor || !parsedOpacity) return undefined;
+    const offsetAnimations = animations("offset");
+    const colorAnimations = animations("stop-color");
+    const opacityAnimations = animations("stop-opacity");
+    return {
+      animated: offsetAnimations.length + colorAnimations.length + opacityAnimations.length > 0,
+      offset:
+        animatedValueExpressionFromAnimations(offsetAnimations, parsedOffset) ??
+        swiftAnimationValueLiteral(parsedOffset, context.precision, `${context.rootName}.`),
+      color:
+        animatedValueExpressionFromAnimations(colorAnimations, parsedColor) ??
+        swiftAnimationValueLiteral(parsedColor, context.precision, `${context.rootName}.`),
+      opacity:
+        animatedValueExpressionFromAnimations(opacityAnimations, parsedOpacity) ??
+        swiftAnimationValueLiteral(parsedOpacity, context.precision, `${context.rootName}.`),
+    };
+  };
+
+  const animatedGradientStopsExpression = (stops: readonly GradientStop[], node: RenderNode, opacity: number) => {
+    const values = stops.map((stop) => animatedGradientStopValues(stop, node));
+    if (!values.some((value) => value?.animated)) return undefined;
+    return `${context.rootName}.svgNormalizedGradientStops([${values
+      .map((value, index) =>
+        value
+          ? `${context.rootName}.svgAnimatedGradientStop(offset: ${value.offset}, color: ${value.color}, opacity: ${value.opacity}, paintOpacity: ${formatNumber(opacity)})`
+          : gradientStopLiteral(stops[index]!, opacity),
+      )
+      .join(", ")}])`;
+  };
+
+  const presentationCondition = (node: RenderNode): string | undefined => {
+    const display = animatedDiscrete(node, "display", node.style.display);
+    const visibility = animatedDiscrete(node, "visibility", node.style.visibility);
+    const conditions = [
+      ...(display ? [`${display} != "none"`] : []),
+      ...(visibility ? [`${visibility} != "hidden" && ${visibility} != "collapse"`] : []),
+    ];
+    return conditions.length > 0 ? conditions.join(" && ") : undefined;
+  };
+
+  const opacityExpression = (node: RenderNode): number | string =>
+    animatedNumber(node, "opacity", node.style.opacity) ?? node.style.opacity;
+
+  const animationOffset = (
+    node: RenderNode,
+    attributeNames: readonly string[],
+    sources: readonly (string | number | undefined)[],
+  ): string | undefined => {
+    const offsets = attributeNames.flatMap((attributeName, index) => {
+      const source = sources[index];
+      if (source === undefined) return [];
+      const expression = animatedNumber(node, attributeName, source);
+      const base = numericBase(node, attributeName, source);
+      return expression && base && "value" in base && typeof base.value === "number"
+        ? [`(${expression} - ${formatNumber(base.value)})`]
+        : [];
+    });
+    return offsets.length === 0 ? undefined : offsets.join(" + ");
+  };
+
+  const normalizedX = (expression: string) =>
+    `(((${expression}) - ${formatNumber(context.options.viewBox.x)}) / ${formatNumber(context.options.viewBox.width)} * width)`;
+  const normalizedY = (expression: string) =>
+    `(((${expression}) - ${formatNumber(context.options.viewBox.y)}) / ${formatNumber(context.options.viewBox.height)} * height)`;
+  const normalizedWidth = (expression: string) =>
+    `((${expression}) / ${formatNumber(context.options.viewBox.width)} * width)`;
+  const normalizedHeight = (expression: string) =>
+    `((${expression}) / ${formatNumber(context.options.viewBox.height)} * height)`;
+
+  const pathValueCandidates = (node: RenderNode, attributeName: string, base: TypedAnimationValue) => {
+    const candidates: TypedAnimationValue[] = [base];
+    for (const animation of animationsFor(node, attributeName)) {
+      if (animation.value.family === "unsupported") continue;
+      for (const value of [
+        animation.value.base,
+        animation.value.from,
+        animation.value.to,
+        animation.value.by,
+        ...(animation.value.values ?? []),
+      ])
+        if (value) candidates.push(value);
+    }
+    return candidates.filter(
+      (value, index) =>
+        candidates.findIndex(
+          (candidate) =>
+            candidate.family === value.family &&
+            swiftAnimationValueLiteral(candidate) === swiftAnimationValueLiteral(value),
+        ) === index,
+    );
+  };
+
+  const dynamicGeometryLines = (node: RenderShape): string[] | undefined => {
+    const declarations: string[] = [];
+    const scalars = new Map<string, string>();
+    const scalar = (name: string, base: number) => {
+      const cached = scalars.get(name);
+      if (cached) return cached;
+      const animatedValue = animatedNumber(node, name, base);
+      if (!animatedValue) return formatNumber(base);
+      const variable = `svg${name.replace(/(^|-)([a-z])/g, (_match, _prefix, letter: string) => letter.toUpperCase())}`;
+      declarations.push(`let ${variable} = ${animatedValue}`);
+      scalars.set(name, variable);
+      return variable;
+    };
+    const animated = (names: readonly string[]) => names.some((name) => animationsFor(node, name).length > 0);
+    switch (node.geometry.type) {
+      case "circle": {
+        if (!animated(["cx", "cy", "r"])) return undefined;
+        const cx = scalar("cx", node.geometry.cx);
+        const cy = scalar("cy", node.geometry.cy);
+        const radius = scalar("r", node.geometry.r);
+        return [
+          ...declarations,
+          `path.addEllipse(in: CGRect(x: ${normalizedX(`(${cx}) - (${radius})`)}, y: ${normalizedY(`(${cy}) - (${radius})`)}, width: ${normalizedWidth(`2 * (${radius})`)}, height: ${normalizedHeight(`2 * (${radius})`)}))`,
+        ];
+      }
+      case "ellipse": {
+        if (!animated(["cx", "cy", "rx", "ry"])) return undefined;
+        const cx = scalar("cx", node.geometry.cx);
+        const cy = scalar("cy", node.geometry.cy);
+        const authoredRx = node.geometryAuthored?.rx;
+        const authoredRy = node.geometryAuthored?.ry;
+        let rx = scalar("rx", node.geometry.rx);
+        let ry = scalar("ry", node.geometry.ry);
+        if (
+          (authoredRy === undefined || String(authoredRy).toLowerCase() === "auto") &&
+          animationsFor(node, "rx").length
+        )
+          ry = rx;
+        if (
+          (authoredRx === undefined || String(authoredRx).toLowerCase() === "auto") &&
+          animationsFor(node, "ry").length
+        )
+          rx = ry;
+        return [
+          ...declarations,
+          `path.addEllipse(in: CGRect(x: ${normalizedX(`(${cx}) - (${rx})`)}, y: ${normalizedY(`(${cy}) - (${ry})`)}, width: ${normalizedWidth(`2 * (${rx})`)}, height: ${normalizedHeight(`2 * (${ry})`)}))`,
+        ];
+      }
+      case "rect": {
+        if (!animated(["x", "y", "width", "height", "rx", "ry"])) return undefined;
+        const x = scalar("x", node.geometry.x);
+        const y = scalar("y", node.geometry.y);
+        const widthValue = scalar("width", node.geometry.width);
+        const heightValue = scalar("height", node.geometry.height);
+        const rxBase = node.geometry.rx ?? node.geometry.ry ?? 0;
+        const ryBase = node.geometry.ry ?? node.geometry.rx ?? 0;
+        const authoredRx = node.geometryAuthored?.rx;
+        const authoredRy = node.geometryAuthored?.ry;
+        let rx = scalar("rx", rxBase);
+        let ry = scalar("ry", ryBase);
+        if (
+          (authoredRy === undefined || String(authoredRy).toLowerCase() === "auto") &&
+          animationsFor(node, "rx").length
+        )
+          ry = rx;
+        if (
+          (authoredRx === undefined || String(authoredRx).toLowerCase() === "auto") &&
+          animationsFor(node, "ry").length
+        )
+          rx = ry;
+        const rect = `CGRect(x: ${normalizedX(x)}, y: ${normalizedY(y)}, width: ${normalizedWidth(widthValue)}, height: ${normalizedHeight(heightValue)})`;
+        return node.geometry.rx !== undefined || node.geometry.ry !== undefined || animated(["rx", "ry"])
+          ? [
+              ...declarations,
+              `path.addRoundedRect(in: ${rect}, cornerSize: CGSize(width: ${normalizedWidth(`min(abs(${rx}), (${widthValue}) / 2)`)}, height: ${normalizedHeight(`min(abs(${ry}), (${heightValue}) / 2)`)}))`,
+            ]
+          : [...declarations, `path.addRect(${rect})`];
+      }
+      case "line": {
+        if (!animated(["x1", "y1", "x2", "y2"])) return undefined;
+        const x1 = scalar("x1", node.geometry.x1);
+        const y1 = scalar("y1", node.geometry.y1);
+        const x2 = scalar("x2", node.geometry.x2);
+        const y2 = scalar("y2", node.geometry.y2);
+        return [
+          ...declarations,
+          `path.move(to: CGPoint(x: ${normalizedX(x1)}, y: ${normalizedY(y1)}))`,
+          `path.addLine(to: CGPoint(x: ${normalizedX(x2)}, y: ${normalizedY(y2)}))`,
+        ];
+      }
+      case "polyline":
+      case "polygon": {
+        if (!animated(["points"])) return undefined;
+        const spec = animationAttributeSpec("points")!;
+        const base = parseAnimationValue(spec, node.geometry.points, valueContext(node));
+        if (!base || base.family !== "points") return undefined;
+        const expression = animatedValueExpression(node, "points", base);
+        if (!expression) return undefined;
+        const candidates = pathValueCandidates(node, "points", base).filter(
+          (candidate): candidate is Extract<TypedAnimationValue, { family: "points" }> => candidate.family === "points",
+        );
+        const counts = [...new Set(candidates.map((candidate) => candidate.points.length))];
+        const lines = [
+          `let svgGeometry = ${expression}`,
+          "var animatedPath = Path()",
+          "switch svgGeometry.components.count / 2 {",
+        ];
+        for (const count of counts) {
+          lines.push(`case ${count}:`);
+          for (let index = 0; index < count; index++) {
+            const command = index === 0 ? "move" : "addLine";
+            lines.push(
+              `animatedPath.${command}(to: CGPoint(x: ${normalizedX(`svgGeometry.components[${index * 2}]`)}, y: ${normalizedY(`svgGeometry.components[${index * 2 + 1}]`)}))`,
+            );
+          }
+          if (node.geometry.type === "polygon") lines.push("animatedPath.closeSubpath()");
+        }
+        lines.push("default: break", "}", "path.addPath(animatedPath)");
+        return lines;
+      }
+      case "path": {
+        if (!animated(["d"])) return undefined;
+        const spec = animationAttributeSpec("d")!;
+        const base = parseAnimationValue(spec, node.geometry.d, valueContext(node));
+        if (!base || base.family !== "path") return undefined;
+        const expression = animatedValueExpression(node, "d", base);
+        if (!expression) return undefined;
+        const candidates = pathValueCandidates(node, "d", base).filter(
+          (candidate): candidate is Extract<TypedAnimationValue, { family: "path" }> => candidate.family === "path",
+        );
+        const signatures = new Map<string, Extract<TypedAnimationValue, { family: "path" }>>();
+        for (const candidate of candidates) {
+          const signature = candidate.commands.map((command) => `${command.kind}${command.values.length}`).join(";");
+          signatures.set(signature, candidate);
+        }
+        const lines = [
+          `let svgGeometry = ${expression}`,
+          "var animatedPath = Path()",
+          "switch svgGeometry.signature {",
+        ];
+        for (const [signature, candidate] of signatures) {
+          lines.push(`case ${swiftString(signature)}:`);
+          let component = 0;
+          for (const command of candidate.commands) {
+            const value = (offset: number) => `svgGeometry.components[${component + offset}]`;
+            if (command.kind === "M")
+              lines.push(`animatedPath.move(to: CGPoint(x: ${normalizedX(value(0))}, y: ${normalizedY(value(1))}))`);
+            else if (command.kind === "L")
+              lines.push(`animatedPath.addLine(to: CGPoint(x: ${normalizedX(value(0))}, y: ${normalizedY(value(1))}))`);
+            else if (command.kind === "Q")
+              lines.push(
+                `animatedPath.addQuadCurve(to: CGPoint(x: ${normalizedX(value(2))}, y: ${normalizedY(value(3))}), control: CGPoint(x: ${normalizedX(value(0))}, y: ${normalizedY(value(1))}))`,
+              );
+            else if (command.kind === "C")
+              lines.push(
+                `animatedPath.addCurve(to: CGPoint(x: ${normalizedX(value(4))}, y: ${normalizedY(value(5))}), control1: CGPoint(x: ${normalizedX(value(0))}, y: ${normalizedY(value(1))}), control2: CGPoint(x: ${normalizedX(value(2))}, y: ${normalizedY(value(3))}))`,
+              );
+            else lines.push("animatedPath.closeSubpath()");
+            component += command.values.length;
+          }
+        }
+        lines.push("default: break", "}", "path.addPath(animatedPath)");
+        return lines;
+      }
+    }
+  };
+
+  const dynamicStrokeLines = (node: RenderShape, centerline: string[]): string[] => {
+    const style = node.style.strokeStyle;
+    const number = (name: string, base: number) => animatedNumber(node, name, base) ?? formatNumber(base);
+    const discrete = (name: string, base: string) => animatedDiscrete(node, name, base);
+    const width = normalizedWidth(number("stroke-width", style.width));
+    const lineCap = discrete("stroke-linecap", style.lineCap);
+    const lineJoin = discrete("stroke-linejoin", style.lineJoin);
+    const dashSpec = animationAttributeSpec("stroke-dasharray")!;
+    const dashBase = style.dashArray
+      ? parseAnimationValue(dashSpec, style.dashArray.join(" "), valueContext(node))
+      : undefined;
+    const dashValue = dashBase ? animatedValueExpression(node, "stroke-dasharray", dashBase) : undefined;
+    const dash = dashValue
+      ? `${context.rootName}.svgAnimationLengths(${dashValue}, scale: width / ${formatNumber(context.options.viewBox.width)})`
+      : style.dashArray
+        ? `[${style.dashArray.map((value) => normalizedWidth(formatNumber(value))).join(", ")}]`
+        : "[]";
+    const phase = normalizedWidth(number("stroke-dashoffset", style.dashOffset));
+    const cap = lineCap ? `${context.rootName}.svgStrokeLineCap(${lineCap})` : `.${style.lineCap}`;
+    const join = lineJoin ? `${context.rootName}.svgStrokeLineJoin(${lineJoin})` : `.${style.lineJoin}`;
+    return [
+      "var animatedStroke = Path()",
+      ...centerline.map((line) => line.replace(/^path\./, "animatedStroke.")),
+      `path.addPath(animatedStroke.strokedPath(StrokeStyle(lineWidth: ${width}, lineCap: ${cap}, lineJoin: ${join}, miterLimit: ${number("stroke-miterlimit", style.miterLimit)}, dash: ${dash}, dashPhase: ${phase})))`,
+    ];
+  };
+
+  const dynamicShapeLines = (
+    node: RenderShape,
+    kind: "fill" | "stroke",
+    ancestorTransforms: RenderNode["transform"][],
+  ): string[] | undefined => {
+    const geometry = dynamicGeometryLines(node);
+    const strokeAnimated =
+      kind === "stroke" &&
+      [
+        "stroke-width",
+        "stroke-linecap",
+        "stroke-linejoin",
+        "stroke-miterlimit",
+        "stroke-dasharray",
+        "stroke-dashoffset",
+      ].some((name) => animationsFor(node, name).length > 0);
+    if (!geometry && !strokeAnimated) return undefined;
+    let lines =
+      geometry ??
+      renderShape({ ...node, transform: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 } }, context.options, {
+        fill: "black",
+        stroke: "none",
+      });
+    const nonScaling = kind === "stroke" && node.style.strokeStyle.vectorEffect === "non-scaling-stroke";
+    if (kind === "stroke" && nonScaling) {
+      lines = wrapWithTransform(
+        lines,
+        [...ancestorTransforms, node.transform].reduce(multiplyTransforms),
+        context.options,
+      );
+      return dynamicStrokeLines(node, lines);
+    }
+    if (kind === "stroke") lines = dynamicStrokeLines(node, lines);
+    lines = wrapWithTransform(lines, node.transform, context.options);
+    for (let index = ancestorTransforms.length - 1; index >= 0; index--)
+      lines = wrapWithTransform(lines, ancestorTransforms[index]!, context.options);
+    return lines;
   };
 
   const buildFilter = (
@@ -720,8 +1186,29 @@ function buildViewNodes(
   };
 
   for (const node of nodes) {
-    if (node.style.display === "none") continue;
+    if (node.style.display === "none" && animationsFor(node, "display").length === 0) continue;
     if (node.type === "group") {
+      const isRootViewport = ancestorTransforms.length === 0 && node.source.element === "svg";
+      const viewportViewBox =
+        node.viewport?.viewBox ?? (isRootViewport ? context.document.viewport.viewBox : undefined);
+      const viewportRect = node.viewport?.rect ?? (isRootViewport ? context.document.viewport.viewBox : undefined);
+      const viewportPreserve = node.viewport?.preserveAspectRatio ?? context.document.viewport.preserveAspectRatio;
+      const viewBoxBase = viewportViewBox
+        ? parseAnimationValue(
+            animationAttributeSpec("viewBox")!,
+            `${viewportViewBox.x} ${viewportViewBox.y} ${viewportViewBox.width} ${viewportViewBox.height}`,
+            valueContext(node),
+          )
+        : undefined;
+      const animatedViewBox = viewBoxBase ? animatedValueExpression(node, "viewBox", viewBoxBase) : undefined;
+      const preserveSource = `${viewportPreserve.align} ${viewportPreserve.meetOrSlice}`;
+      const animatedPreserve = viewportViewBox
+        ? animatedDiscrete(node, "preserveAspectRatio", preserveSource)
+        : undefined;
+      const animationTransform =
+        viewBoxBase && viewportRect && (animatedViewBox || animatedPreserve)
+          ? `${context.rootName}.svgAnimatedViewBoxTransform(value: ${animatedViewBox ?? swiftAnimationValueLiteral(viewBoxBase, context.precision, `${context.rootName}.`)}, base: ${swiftAnimationValueLiteral(viewBoxBase, context.precision, `${context.rootName}.`)}, rect: CGRect(x: ${formatNumber(viewportRect.x)}, y: ${formatNumber(viewportRect.y)}, width: ${formatNumber(viewportRect.width)}, height: ${formatNumber(viewportRect.height)}), outer: ${swiftTransform(node.viewport?.clipTransform ?? { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 })}, staticTransform: ${swiftTransform(node.transform)}, outputSize: proxy.size, coordinateSpace: CGRect(x: ${formatNumber(context.options.viewBox.x)}, y: ${formatNumber(context.options.viewBox.y)}, width: ${formatNumber(context.options.viewBox.width)}, height: ${formatNumber(context.options.viewBox.height)}), preserveAspectRatio: ${animatedPreserve ?? swiftString(preserveSource)})`
+          : undefined;
       let viewportClip: string | undefined;
       if (node.viewport?.clip) {
         const { rect, clipTransform } = node.viewport;
@@ -748,7 +1235,12 @@ function buildViewNodes(
         viewportClip = addHelper(context, `Clip${context.nextClip++}`, clipLines);
       }
       const targetTransforms = [...ancestorTransforms, node.transform];
-      const children = buildViewNodes(node.children, context, targetTransforms);
+      const childAnimationOwners: Record<string, RenderNode> = { ...inheritedAnimationOwners };
+      for (const attributeName of inheritedAnimationAttributes) {
+        if (ownedAnimationsFor(node, attributeName).length > 0) childAnimationOwners[attributeName] = node;
+        else if (!node.style.inheritedProperties[attributeName]) delete childAnimationOwners[attributeName];
+      }
+      const children = buildViewNodes(node.children, context, targetTransforms, childAnimationOwners);
       if (children.length > 0) {
         const clipPath = buildClipPath(node.clipPath, targetTransforms);
         const mask = buildMask(node.mask, targetTransforms);
@@ -756,9 +1248,9 @@ function buildViewNodes(
         generated.push({
           type: "group",
           children,
-          opacity: node.style.opacity,
+          opacity: opacityExpression(node),
           isolated:
-            node.style.opacity !== 1 ||
+            opacityExpression(node) !== 1 ||
             node.style.isolation === "isolate" ||
             node.style.blendMode !== "normal" ||
             !!clipPath ||
@@ -770,25 +1262,79 @@ function buildViewNodes(
           ...(mask ? { mask } : {}),
           ...(filter ? { filter } : {}),
           ...(node.accessibility ? { accessibility: node.accessibility } : {}),
+          ...(presentationCondition(node) ? { presentationCondition: presentationCondition(node) } : {}),
+          ...(animationTransform ? { animationTransform } : {}),
         });
       }
       continue;
     }
     if (node.type === "text") {
-      if (node.style.visibility === "hidden" || node.style.visibility === "collapse" || node.text === "") continue;
+      if (
+        ((node.style.visibility === "hidden" || node.style.visibility === "collapse") &&
+          animationsFor(node, "visibility").length === 0) ||
+        node.text === ""
+      )
+        continue;
       const completeTransform = [...ancestorTransforms, node.transform].reduce(multiplyTransforms);
       const name = `TextLayer${context.textHelpers.length}`;
-      context.textHelpers.push({ name, node, transform: completeTransform });
+      const fillAnimation = animatedPaint(node, "fill", node.style.fill);
+      const fillOpacity = animatedNumber(node, "fill-opacity", node.style.fillOpacity);
+      const strokeAnimation = animatedPaint(node, "stroke", node.style.stroke);
+      const strokeOpacity = animatedNumber(node, "stroke-opacity", node.style.strokeOpacity);
+      const staticPaintValue = (name: "fill" | "stroke", paint: Paint) => {
+        const value = parseAnimationValue(animationAttributeSpec(name)!, paintValue(paint), valueContext(node));
+        return value ? swiftAnimationValueLiteral(value, context.precision, `${context.rootName}.`) : undefined;
+      };
+      const effectiveFillAnimation =
+        fillAnimation ?? (fillOpacity ? staticPaintValue("fill", node.style.fill) : undefined);
+      const effectiveStrokeAnimation =
+        strokeAnimation ?? (strokeOpacity ? staticPaintValue("stroke", node.style.stroke) : undefined);
+      const strokeWidth = animatedNumber(node, "stroke-width", node.style.strokeStyle.width);
+      const fontSize = animatedNumber(
+        node,
+        "font-size",
+        Number(node.style.presentation["font-size"] ?? node.paintContext.fontMetrics.fontSize),
+      );
+      const letterSpacing = animatedNumber(
+        node,
+        "letter-spacing",
+        Number(node.style.presentation["letter-spacing"] ?? 0),
+      );
+      const wordSpacing = animatedNumber(node, "word-spacing", Number(node.style.presentation["word-spacing"] ?? 0));
+      const textAnimated = !!(
+        effectiveFillAnimation ||
+        fillOpacity ||
+        effectiveStrokeAnimation ||
+        strokeOpacity ||
+        strokeWidth ||
+        fontSize ||
+        letterSpacing ||
+        wordSpacing
+      );
+      context.textHelpers.push({
+        name,
+        node,
+        transform: completeTransform,
+        ...(effectiveFillAnimation ? { fillAnimation: effectiveFillAnimation } : {}),
+        ...(fillOpacity ? { fillOpacity } : {}),
+        ...(effectiveStrokeAnimation ? { strokeAnimation: effectiveStrokeAnimation } : {}),
+        ...(strokeOpacity ? { strokeOpacity } : {}),
+        ...(strokeWidth ? { strokeWidth } : {}),
+        ...(fontSize ? { fontSize } : {}),
+        ...(letterSpacing ? { letterSpacing } : {}),
+        ...(wordSpacing ? { wordSpacing } : {}),
+        animated: textAnimated,
+      });
       const targetTransforms = [...ancestorTransforms, node.transform];
       const clipPath = buildClipPath(node.clipPath, targetTransforms);
       const mask = buildMask(node.mask, targetTransforms);
       const filter = buildFilter(node.filter, targetTransforms);
       generated.push({
         type: "group",
-        children: [{ type: "text", helper: name }],
-        opacity: node.style.opacity,
+        children: [{ type: "text", helper: textAnimated ? `${name}(documentTime: documentTime)` : name }],
+        opacity: opacityExpression(node),
         isolated:
-          node.style.opacity !== 1 ||
+          opacityExpression(node) !== 1 ||
           node.style.isolation === "isolate" ||
           node.style.blendMode !== "normal" ||
           !!clipPath ||
@@ -799,14 +1345,20 @@ function buildViewNodes(
         ...(mask ? { mask } : {}),
         ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
-        ...(animationOffsetX(node) ? { animationOffsetX: animationOffsetX(node) } : {}),
+        ...(animationOffset(node, ["x", "dx"], [node.attributes.x ?? 0, node.attributes.dx ?? 0])
+          ? { animationOffsetX: animationOffset(node, ["x", "dx"], [node.attributes.x ?? 0, node.attributes.dx ?? 0]) }
+          : {}),
+        ...(animationOffset(node, ["y", "dy"], [node.attributes.y ?? 0, node.attributes.dy ?? 0])
+          ? { animationOffsetY: animationOffset(node, ["y", "dy"], [node.attributes.y ?? 0, node.attributes.dy ?? 0]) }
+          : {}),
+        ...(presentationCondition(node) ? { presentationCondition: presentationCondition(node) } : {}),
       });
       continue;
     }
     if (node.type === "image" || node.type === "foreignObject") {
       if (
-        node.style.visibility === "hidden" ||
-        node.style.visibility === "collapse" ||
+        ((node.style.visibility === "hidden" || node.style.visibility === "collapse") &&
+          animationsFor(node, "visibility").length === 0) ||
         node.viewport.width <= 0 ||
         node.viewport.height <= 0 ||
         !node.resource
@@ -848,9 +1400,9 @@ function buildViewNodes(
       generated.push({
         type: "group",
         children: [{ type: "image", helper: name }],
-        opacity: node.style.opacity,
+        opacity: opacityExpression(node),
         isolated:
-          node.style.opacity !== 1 ||
+          opacityExpression(node) !== 1 ||
           node.style.isolation === "isolate" ||
           node.style.blendMode !== "normal" ||
           !!clipPath ||
@@ -861,10 +1413,16 @@ function buildViewNodes(
         ...(mask ? { mask } : {}),
         ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
+        ...(presentationCondition(node) ? { presentationCondition: presentationCondition(node) } : {}),
       });
       continue;
     }
-    if (node.type !== "shape" || node.style.visibility === "hidden" || node.style.visibility === "collapse") continue;
+    if (
+      node.type !== "shape" ||
+      ((node.style.visibility === "hidden" || node.style.visibility === "collapse") &&
+        animationsFor(node, "visibility").length === 0)
+    )
+      continue;
 
     const paints: GeneratedViewNode[] = [];
 
@@ -873,24 +1431,58 @@ function buildViewNodes(
       const completeTransform = nonScalingStroke
         ? [...ancestorTransforms, node.transform].reduce(multiplyTransforms)
         : undefined;
-      let lines = renderShape(
-        node,
-        context.options,
-        kind === "fill" ? { fill: "black", stroke: "none" } : { fill: "none", stroke: "black" },
-        completeTransform,
-      );
-      if (!nonScalingStroke) {
+      const dynamicLines = dynamicShapeLines(node, kind, ancestorTransforms);
+      let lines =
+        dynamicLines ??
+        renderShape(
+          node,
+          context.options,
+          kind === "fill" ? { fill: "black", stroke: "none" } : { fill: "none", stroke: "black" },
+          completeTransform,
+        );
+      if (!dynamicLines && !nonScalingStroke) {
         for (let index = ancestorTransforms.length - 1; index >= 0; index--) {
           lines = wrapWithTransform(lines, ancestorTransforms[index]!, context.options);
         }
       }
       if (lines.length === 0) return;
-      const helper = addHelper(context, `Layer${context.nextLayer++}`, lines);
+      const helperName = `Layer${context.nextLayer++}`;
+      const helper = dynamicLines
+        ? addAnimatedHelper(context, helperName, lines)
+        : addHelper(context, helperName, lines);
+      const animatedColor = animatedPaint(node, kind, paint);
+      const animatedPaintOpacity = animatedNumber(node, `${kind}-opacity`, paintOpacity);
+      if (animatedColor || animatedPaintOpacity) {
+        const baseColor = colorForPaint(paint, 1) ?? "Color.clear";
+        const baseRGBA = rgbaForPaint(paint, 1) ?? { red: 0, green: 0, blue: 0, alpha: 0 };
+        const color = animatedColor ? `${context.rootName}.svgAnimationColor(${animatedColor})` : baseColor;
+        const opacity = animatedPaintOpacity ?? formatNumber(paintOpacity);
+        paints.push({
+          type: "paint",
+          helper,
+          swiftColor: `${color}.opacity(${opacity})`,
+          cgColor: { ...baseRGBA, alpha: baseRGBA.alpha * paintOpacity },
+          cgColorExpression: `${context.rootName}.svgAnimationCGColor(${animatedColor ?? `${context.rootName}.SVGAnimationRuntimeValue(kind: .color, components: [${formatNumber(baseRGBA.red)}, ${formatNumber(baseRGBA.green)}, ${formatNumber(baseRGBA.blue)}, ${formatNumber(baseRGBA.alpha)}], signature: "sRGB", source: "")`}, opacity: ${opacity})`,
+        });
+        return;
+      }
       if (paint.type === "reference") {
         const server = context.document.resources.paints.get(paint.id);
         if (server?.type === "linearGradient" || server?.type === "radialGradient") {
           if (server.stops.length === 0) return;
           if (server.stops.length === 1) {
+            const animatedStop = animatedGradientStopValues(server.stops[0]!, node);
+            if (animatedStop?.animated) {
+              const opacity = `${context.rootName}.svgAnimationNumber(${animatedStop.opacity}) * ${formatNumber(paintOpacity)}`;
+              paints.push({
+                type: "paint",
+                helper,
+                swiftColor: `${context.rootName}.svgAnimationColor(${animatedStop.color}).opacity(${opacity})`,
+                cgColor: rgbaForStop(server.stops[0]!, paintOpacity),
+                cgColorExpression: `${context.rootName}.svgAnimationCGColor(${animatedStop.color}, opacity: ${opacity})`,
+              });
+              return;
+            }
             paints.push({
               type: "paint",
               helper,
@@ -901,6 +1493,18 @@ function buildViewNodes(
           }
           const gradient = resolveGradientForShape(server, node, ancestorTransforms);
           if (gradient.type === "solid") {
+            const animatedStop = animatedGradientStopValues(gradient.stop, node);
+            if (animatedStop?.animated) {
+              const opacity = `${context.rootName}.svgAnimationNumber(${animatedStop.opacity}) * ${formatNumber(paintOpacity)}`;
+              paints.push({
+                type: "paint",
+                helper,
+                swiftColor: `${context.rootName}.svgAnimationColor(${animatedStop.color}).opacity(${opacity})`,
+                cgColor: rgbaForStop(gradient.stop, paintOpacity),
+                cgColorExpression: `${context.rootName}.svgAnimationCGColor(${animatedStop.color}, opacity: ${opacity})`,
+              });
+              return;
+            }
             paints.push({
               type: "paint",
               helper,
@@ -916,6 +1520,9 @@ function buildViewNodes(
             gradient,
             paintOpacity,
             coordinateSpace: context.coordinateSpace,
+            ...(animatedGradientStopsExpression(gradient.stops, node, paintOpacity)
+              ? { stopsExpression: animatedGradientStopsExpression(gradient.stops, node, paintOpacity) }
+              : {}),
           });
           return;
         }
@@ -978,10 +1585,10 @@ function buildViewNodes(
     };
 
     for (const kind of node.style.paintOrder) {
-      if (kind === "fill" && node.style.fill.type !== "none") {
+      if (kind === "fill" && (node.style.fill.type !== "none" || animationsFor(node, "fill").length > 0)) {
         addLayer("fill", node.style.fill, node.style.fillOpacity);
       }
-      if (kind === "stroke" && node.style.stroke.type !== "none") {
+      if (kind === "stroke" && (node.style.stroke.type !== "none" || animationsFor(node, "stroke").length > 0)) {
         addLayer("stroke", node.style.stroke, node.style.strokeOpacity);
       }
       if (kind === "markers" && node.markers && node.markers.length > 0) {
@@ -996,9 +1603,9 @@ function buildViewNodes(
       generated.push({
         type: "group",
         children: paints,
-        opacity: node.style.opacity,
+        opacity: opacityExpression(node),
         isolated:
-          node.style.opacity !== 1 ||
+          opacityExpression(node) !== 1 ||
           node.style.isolation === "isolate" ||
           node.style.blendMode !== "normal" ||
           !!clipPath ||
@@ -1009,7 +1616,7 @@ function buildViewNodes(
         ...(mask ? { mask } : {}),
         ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
-        ...(animationOffsetX(node) ? { animationOffsetX: animationOffsetX(node) } : {}),
+        ...(presentationCondition(node) ? { presentationCondition: presentationCondition(node) } : {}),
       });
     }
   }
@@ -1152,7 +1759,9 @@ function textPaintLiteral(
   node: RenderText,
   document: RenderDocument,
   transform: RenderNode["transform"],
+  animation?: { value: string; opacity: string },
 ): string {
+  if (animation) return `SVGTextSource.color(svgTextColor(${animation.value}, opacity: ${animation.opacity}))`;
   const value = paint.type === "solid" ? paint.value : paint.type === "reference" ? paint.fallback : undefined;
   if (value) {
     const color = parseRGBAColor(value);
@@ -1182,9 +1791,10 @@ function textPaintLiteral(
 }
 
 function createTextHelper(
-  helper: { name: string; node: RenderText; transform: RenderNode["transform"] },
+  helper: ViewBuildContext["textHelpers"][number],
   coordinateSpace: ViewBoxData,
   document: RenderDocument,
+  ownerName: string,
   indentationSize: number,
 ): string[] {
   const indentation = " ".repeat(indentationSize);
@@ -1213,7 +1823,7 @@ function createTextHelper(
             )
             .join(", ");
           const bidi = run.unicodeBidi.replace(/-([a-z])/g, (_match, letter: string) => letter.toUpperCase());
-          return `SVGTextRun(text: ${swiftString(run.text)}, characters: [${characters}], dx: ${formatNumber(run.dx)}, dy: ${formatNumber(run.dy)}, family: ${swiftString(run.font.family)}, size: ${formatNumber(run.font.size)}, weight: ${formatNumber(run.font.weight)}, width: ${formatNumber(run.font.width)}, italic: ${run.font.italic}, smallCaps: ${run.font.smallCaps}, sizeAdjust: ${run.font.sizeAdjust === undefined ? "nil" : formatNumber(run.font.sizeAdjust)}, letterSpacing: ${formatNumber(run.letterSpacing)}, wordSpacing: ${formatNumber(run.wordSpacing)}, kerning: ${run.kerning}, baseline: .${baseline}, baselineShift: ${formatNumber(run.baselineShift)}, decorations: [${decorations}], direction: .${run.direction}, unicodeBidi: .${bidi}, textOrientation: .${run.textOrientation}, fill: ${textPaintLiteral(run.style.fill, run.style.fillOpacity * localOpacity, helper.node, document, transform)}, stroke: ${textPaintLiteral(run.style.stroke, run.style.strokeOpacity * localOpacity, helper.node, document, transform)}, strokeWidth: ${formatNumber(run.style.strokeStyle.width)}, lineCap: .${run.style.strokeStyle.lineCap}, lineJoin: .${run.style.strokeStyle.lineJoin}, miterLimit: ${formatNumber(run.style.strokeStyle.miterLimit)}, paintOrder: [${order}], transform: ${swiftTransform(transform)})`;
+          return `SVGTextRun(text: ${swiftString(run.text)}, characters: [${characters}], dx: ${formatNumber(run.dx)}, dy: ${formatNumber(run.dy)}, family: ${swiftString(run.font.family)}, size: ${helper.fontSize ?? formatNumber(run.font.size)}, weight: ${formatNumber(run.font.weight)}, width: ${formatNumber(run.font.width)}, italic: ${run.font.italic}, smallCaps: ${run.font.smallCaps}, sizeAdjust: ${run.font.sizeAdjust === undefined ? "nil" : formatNumber(run.font.sizeAdjust)}, letterSpacing: ${helper.letterSpacing ?? formatNumber(run.letterSpacing)}, wordSpacing: ${helper.wordSpacing ?? formatNumber(run.wordSpacing)}, kerning: ${run.kerning}, baseline: .${baseline}, baselineShift: ${formatNumber(run.baselineShift)}, decorations: [${decorations}], direction: .${run.direction}, unicodeBidi: .${bidi}, textOrientation: .${run.textOrientation}, fill: ${textPaintLiteral(run.style.fill, run.style.fillOpacity * localOpacity, helper.node, document, transform, helper.fillAnimation ? { value: helper.fillAnimation, opacity: helper.fillOpacity ?? formatNumber(run.style.fillOpacity * localOpacity) } : undefined)}, stroke: ${textPaintLiteral(run.style.stroke, run.style.strokeOpacity * localOpacity, helper.node, document, transform, helper.strokeAnimation ? { value: helper.strokeAnimation, opacity: helper.strokeOpacity ?? formatNumber(run.style.strokeOpacity * localOpacity) } : undefined)}, strokeWidth: ${helper.strokeWidth ?? formatNumber(run.style.strokeStyle.width)}, lineCap: .${run.style.strokeStyle.lineCap}, lineJoin: .${run.style.strokeStyle.lineJoin}, miterLimit: ${formatNumber(run.style.strokeStyle.miterLimit)}, paintOrder: [${order}], transform: ${swiftTransform(transform)})`;
         })
         .join(", ");
       const adjustments = chunk.lengthAdjustments
@@ -1233,6 +1843,7 @@ function createTextHelper(
   return [
     "// CoreText glyph paths preserve SVG metrics; accessibility text is retained, but selection is unavailable.",
     `private struct ${helper.name}: View {`,
+    ...(helper.animated ? [`${indentation}let documentTime: Double`, ""] : []),
     `${indentation}var body: some View {`,
     `${i2}Canvas { context, size in`,
     `${i3}context.withCGContext { graphics in`,
@@ -1284,6 +1895,17 @@ function createTextHelper(
     `${indentation}private struct PreparedChunk { let fonts: [CTFont]; let line: CTLine; let characterRanges: [NSRange]; let runRanges: [NSRange] }`,
     `${indentation}private struct PositionedGlyph { var path: CGPath; let font: CTFont; let glyph: CGGlyph; let runIndex: Int; let characterIndex: Int; var inline: CGFloat; var cross: CGFloat; var advance: CGFloat; var inlineScale: CGFloat }`,
     "",
+    ...(helper.animated
+      ? [
+          `${indentation}private func svgTextColor(_ value: ${ownerName}.SVGAnimationRuntimeValue, opacity: Double) -> SVGTextColor {`,
+          `${i2}func encoded(_ component: Double) -> Double { component <= 0.0031308 ? component * 12.92 : 1.055 * pow(component, 1 / 2.4) - 0.055 }`,
+          `${i2}let components = value.components + [0, 0, 0, 0]`,
+          `${i2}let linear = value.signature == "linearRGB"`,
+          `${i2}return SVGTextColor(red: CGFloat(min(1, max(0, linear ? encoded(components[0]) : components[0]))), green: CGFloat(min(1, max(0, linear ? encoded(components[1]) : components[1]))), blue: CGFloat(min(1, max(0, linear ? encoded(components[2]) : components[2]))), alpha: CGFloat(min(1, max(0, components[3] * opacity))))`,
+          `${indentation}}`,
+          "",
+        ]
+      : []),
     `${indentation}private func font(for run: SVGTextRun) -> CTFont {`,
     `${i2}var symbolic: CTFontSymbolicTraits = []`,
     `${i2}if run.italic { symbolic.insert(.traitItalic) }`,
@@ -1586,12 +2208,14 @@ function renderGradientNode(
   const deep = indentation.repeat(level + 3);
   const gradient = node.gradient;
   const matrix = gradient.matrix;
-  const stops = gradient.stops.map((stop) => gradientStopLiteral(stop, node.paintOpacity)).join(", ");
+  const stops =
+    node.stopsExpression ??
+    `[${gradient.stops.map((stop) => gradientStopLiteral(stop, node.paintOpacity)).join(", ")}]`;
   const transform = runtimeTransform(matrix, node.coordinateSpace);
   const lines = [
     `${prefix}Canvas { context, size in`,
-    `${inner}let clipPath = ${node.helper}().path(in: CGRect(origin: .zero, size: size))`,
-    `${inner}let stops = [${stops}]`,
+    `${inner}let clipPath = ${shapeHelperCall(node.helper)}.path(in: CGRect(origin: .zero, size: size))`,
+    `${inner}let stops = ${stops}`,
     `${inner}if let gradient = svgGradient(stops: stops, spread: .${gradient.spreadMethod === "repeat" ? "repeating" : gradient.spreadMethod}, startT: ${formatNumber(gradient.startT)}, endT: ${formatNumber(gradient.endT)}, linearRGB: ${gradient.colorInterpolation === "linearRGB"}) {`,
     `${nested}context.withCGContext { graphics in`,
     `${deep}graphics.saveGState()`,
@@ -1649,11 +2273,13 @@ function renderGradientCommands(
   const nested = indentation.repeat(level + 2);
   const gradient = node.gradient;
   const transform = runtimeTransform(gradient.matrix, node.coordinateSpace);
-  const stops = gradient.stops.map((stop) => gradientStopLiteral(stop, node.paintOpacity)).join(", ");
+  const stops =
+    node.stopsExpression ??
+    `[${gradient.stops.map((stop) => gradientStopLiteral(stop, node.paintOpacity)).join(", ")}]`;
   const lines = [
     `${prefix}do {`,
-    `${inner}let clipPath = ${node.helper}().path(in: CGRect(origin: .zero, size: size))`,
-    `${inner}let stops = [${stops}]`,
+    `${inner}let clipPath = ${shapeHelperCall(node.helper)}.path(in: CGRect(origin: .zero, size: size))`,
+    `${inner}let stops = ${stops}`,
     `${inner}if let gradient = svgGradient(stops: stops, spread: .${gradient.spreadMethod === "repeat" ? "repeating" : gradient.spreadMethod}, startT: ${formatNumber(gradient.startT)}, endT: ${formatNumber(gradient.endT)}, linearRGB: ${gradient.colorInterpolation === "linearRGB"}) {`,
     `${nested}${graphicsName}.saveGState()`,
     `${nested}${graphicsName}.addPath(clipPath.cgPath)`,
@@ -1694,7 +2320,7 @@ function renderGeneratedCommands(
       lines.push(
         `${prefix}do {`,
         `${inner}${graphicsName}.saveGState()`,
-        `${inner}${graphicsName}.addPath(${node.helper}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+        `${inner}${graphicsName}.addPath(${shapeHelperCall(node.helper)}.path(in: CGRect(origin: .zero, size: size)).cgPath)`,
         `${inner}${graphicsName}.setFillColor(CGColor(colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!, components: [${formatNumber(color.red)}, ${formatNumber(color.green)}, ${formatNumber(color.blue)}, ${formatNumber(color.alpha)}])!)`,
         `${inner}${graphicsName}.fillPath()`,
         `${inner}${graphicsName}.restoreGState()`,
@@ -1720,13 +2346,15 @@ function renderGeneratedCommands(
     lines.push(`${prefix}do {`, `${inner}${graphicsName}.saveGState()`);
     if (node.viewportClip)
       lines.push(
-        `${inner}${graphicsName}.addPath(${node.viewportClip}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+        `${inner}${graphicsName}.addPath(${shapeHelperCall(node.viewportClip)}.path(in: CGRect(origin: .zero, size: size)).cgPath)`,
         `${inner}${graphicsName}.clip()`,
       );
     if (commandClipHelpers && commandClipHelpers.length > 0) {
       lines.push(`${inner}let clipUnion = CGMutablePath()`);
       for (const helper of commandClipHelpers)
-        lines.push(`${inner}clipUnion.addPath(${helper}().path(in: CGRect(origin: .zero, size: size)).cgPath)`);
+        lines.push(
+          `${inner}clipUnion.addPath(${shapeHelperCall(helper)}.path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+        );
       lines.push(`${inner}${graphicsName}.addPath(clipUnion)`, `${inner}${graphicsName}.clip()`);
     } else if (node.clipPath) {
       // Complex clip subtrees are rendered correctly by the SwiftUI view path.
@@ -1738,7 +2366,10 @@ function renderGeneratedCommands(
     if (node.blendMode !== "normal")
       lines.push(`${inner}${graphicsName}.setBlendMode(.${swiftBlendMode(node.blendMode)})`);
     if (node.isolated) {
-      if (node.opacity !== 1) lines.push(`${inner}${graphicsName}.setAlpha(${formatNumber(node.opacity)})`);
+      if (node.opacity !== 1)
+        lines.push(
+          `${inner}${graphicsName}.setAlpha(${typeof node.opacity === "number" ? formatNumber(node.opacity) : node.opacity})`,
+        );
       lines.push(`${inner}${graphicsName}.beginTransparencyLayer(auxiliaryInfo: nil)`);
     }
     lines.push(...renderGeneratedCommands(node.children, graphicsName, level + 1, indentation));
@@ -1828,7 +2459,7 @@ function renderBatchedPatternNode(
     `${nested}for column in (${runtime.minColumn})...(${runtime.maxColumn}) {`,
     `${deep}let offsetX${runtime.suffix} = (${runtime.originX} + CGFloat(column) * ${runtime.columnX} + CGFloat(row) * ${runtime.rowX}) * ${runtime.scaleX}`,
     `${deep}let offsetY${runtime.suffix} = (${runtime.originY} + CGFloat(column) * ${runtime.columnY} + CGFloat(row) * ${runtime.rowY}) * ${runtime.scaleY}`,
-    `${deep}repeatedPath.addPath(${node.helper}().path(in: CGRect(origin: .zero, size: size)).cgPath, transform: CGAffineTransform(translationX: offsetX${runtime.suffix}, y: offsetY${runtime.suffix}))`,
+    `${deep}repeatedPath.addPath(${shapeHelperCall(node.helper)}.path(in: CGRect(origin: .zero, size: size)).cgPath, transform: CGAffineTransform(translationX: offsetX${runtime.suffix}, y: offsetY${runtime.suffix}))`,
     `${nested}}`,
     `${inner}}`,
     `${inner}${graphicsName}.addPath(repeatedPath)`,
@@ -1859,7 +2490,7 @@ function renderUnbatchedPatternNode(
   ];
   if (runtime.tileClip)
     lines.push(
-      `${nested}${graphicsName}.addPath(${runtime.tileClip}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+      `${nested}${graphicsName}.addPath(${shapeHelperCall(runtime.tileClip)}.path(in: CGRect(origin: .zero, size: size)).cgPath)`,
       `${nested}${graphicsName}.clip()`,
     );
   lines.push(
@@ -1900,7 +2531,7 @@ function renderPatternCommands(
   const lines = [
     `${prefix}do {`,
     `${inner}${graphicsName}.saveGState()`,
-    `${inner}${graphicsName}.addPath(${node.helper}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+    `${inner}${graphicsName}.addPath(${shapeHelperCall(node.helper)}.path(in: CGRect(origin: .zero, size: size)).cgPath)`,
     `${inner}${graphicsName}.clip()`,
   ];
   if (node.paintOpacity !== 1) {
@@ -1954,9 +2585,26 @@ function appendAccessibilityModifiers(
 
 function renderViewNode(node: GeneratedViewNode, level: number, indentation: string): string[] {
   const prefix = indentation.repeat(level);
-  if (node.type === "text" || node.type === "image") return [`${prefix}${node.helper}()`];
+  if (node.type === "group" && node.presentationCondition) {
+    const { presentationCondition, ...visibleNode } = node;
+    return [
+      `${prefix}if ${presentationCondition} {`,
+      ...renderViewNode(visibleNode, level + 1, indentation),
+      `${prefix}}`,
+    ];
+  }
+  if (node.type === "group" && node.animationTransform) {
+    const { animationTransform, ...staticNode } = node;
+    return [
+      `${prefix}GeometryReader { proxy in`,
+      ...renderViewNode(staticNode, level + 1, indentation),
+      `${prefix}${indentation}.transformEffect(${animationTransform})`,
+      `${prefix}}`,
+    ];
+  }
+  if (node.type === "text" || node.type === "image") return [`${prefix}${shapeHelperCall(node.helper)}`];
   if (node.type === "paint") {
-    if (!node.clipUnions) return [`${prefix}${node.helper}().fill(${node.swiftColor})`];
+    if (!node.clipUnions) return [`${prefix}${shapeHelperCall(node.helper)}.fill(${node.swiftColor})`];
     const inner = `${prefix}${indentation}`;
     const deep = `${inner}${indentation}`;
     const lines = [
@@ -1967,12 +2615,14 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
     for (const [index, helpers] of node.clipUnions.entries()) {
       lines.push(`${deep}let clipUnion${index} = CGMutablePath()`);
       for (const helper of helpers)
-        lines.push(`${deep}clipUnion${index}.addPath(${helper}().path(in: CGRect(origin: .zero, size: size)).cgPath)`);
+        lines.push(
+          `${deep}clipUnion${index}.addPath(${shapeHelperCall(helper)}.path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+        );
       lines.push(`${deep}graphics.addPath(clipUnion${index})`, `${deep}graphics.clip()`);
     }
     lines.push(
-      `${deep}graphics.addPath(${node.helper}().path(in: CGRect(origin: .zero, size: size)).cgPath)`,
-      `${deep}graphics.setFillColor(CGColor(colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!, components: [${formatNumber(node.cgColor.red)}, ${formatNumber(node.cgColor.green)}, ${formatNumber(node.cgColor.blue)}, ${formatNumber(node.cgColor.alpha)}])!)`,
+      `${deep}graphics.addPath(${shapeHelperCall(node.helper)}.path(in: CGRect(origin: .zero, size: size)).cgPath)`,
+      `${deep}graphics.setFillColor(${node.cgColorExpression ?? `CGColor(colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!, components: [${formatNumber(node.cgColor.red)}, ${formatNumber(node.cgColor.green)}, ${formatNumber(node.cgColor.blue)}, ${formatNumber(node.cgColor.alpha)}])!`})`,
       `${deep}graphics.fillPath()`,
       `${deep}graphics.restoreGState()`,
       `${inner}}`,
@@ -2005,11 +2655,11 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
   // distributes masks and opacity across ZStack children, which changes
   // overlap colors and prevents nested clip-path intersections from composing.
   if (node.isolated) lines.push(`${prefix}.compositingGroup()`);
-  if (node.viewportClip) lines.push(`${prefix}.clipShape(${node.viewportClip}())`);
+  if (node.viewportClip) lines.push(`${prefix}.clipShape(${shapeHelperCall(node.viewportClip)})`);
   if (node.clipPath) {
     const simpleHelpers = simpleClipPathHelpers(node.clipPath);
     if (simpleHelpers?.length === 1) {
-      lines.push(`${prefix}.clipShape(${simpleHelpers[0]}())`);
+      lines.push(`${prefix}.clipShape(${shapeHelperCall(simpleHelpers[0]!)})`);
     } else {
       lines.push(
         `${prefix}.mask {`,
@@ -2053,7 +2703,7 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
       else for (const child of node.mask.children) lines.push(...renderViewNode(child, level + 4, indentation));
       lines.push(
         `${prefix}${indentation}${indentation}${indentation}}`,
-        `${prefix}${indentation}${indentation}${indentation}.clipShape(${node.mask.clip}())`,
+        `${prefix}${indentation}${indentation}${indentation}.clipShape(${shapeHelperCall(node.mask.clip)})`,
         `${prefix}${indentation}${indentation}${indentation}.frame(width: proxy.size.width, height: proxy.size.height)`,
         `${prefix}${indentation}${indentation}${indentation}.tag(0)`,
         `${prefix}${indentation}${indentation}}`,
@@ -2065,7 +2715,7 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
       else for (const child of node.mask.children) lines.push(...renderViewNode(child, level + 4, indentation));
       lines.push(
         `${prefix}${indentation}${indentation}${indentation}}`,
-        `${prefix}${indentation}${indentation}${indentation}.clipShape(${node.mask.clip}())`,
+        `${prefix}${indentation}${indentation}${indentation}.clipShape(${shapeHelperCall(node.mask.clip)})`,
         `${prefix}${indentation}${indentation}}`,
         `${prefix}${indentation}}`,
         `${prefix}}`,
@@ -2074,12 +2724,19 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
       lines.push(`${prefix}.mask {`, `${prefix}${indentation}ZStack {`);
       if (node.mask.children.length === 0) lines.push(`${prefix}${indentation}${indentation}Color.clear`);
       else for (const child of node.mask.children) lines.push(...renderViewNode(child, level + 2, indentation));
-      lines.push(`${prefix}${indentation}}`, `${prefix}${indentation}.clipShape(${node.mask.clip}())`, `${prefix}}`);
+      lines.push(
+        `${prefix}${indentation}}`,
+        `${prefix}${indentation}.clipShape(${shapeHelperCall(node.mask.clip)})`,
+        `${prefix}}`,
+      );
     }
   }
-  if (node.opacity !== 1) lines.push(`${prefix}.opacity(${swiftNumber(node.opacity)})`);
+  if (node.opacity !== 1)
+    lines.push(`${prefix}.opacity(${typeof node.opacity === "number" ? swiftNumber(node.opacity) : node.opacity})`);
   if (node.blendMode !== "normal") lines.push(`${prefix}.blendMode(.${swiftBlendMode(node.blendMode)})`);
   if (node.animationOffsetX) lines.push(`${prefix}.offset(x: ${node.animationOffsetX})`);
+  if (node.animationOffsetY) lines.push(`${prefix}.offset(y: ${node.animationOffsetY})`);
+  if (node.animationTransform) lines.push(`${prefix}.transformEffect(${node.animationTransform})`);
   appendAccessibilityModifiers(lines, node.accessibility, prefix);
   return lines;
 }
@@ -3475,7 +4132,7 @@ function createFilterImageHelper(helper: FilterImageHelper, indentationSize: num
   return body;
 }
 
-function gradientSupport(indentationSize: number): string[] {
+function gradientSupport(indentationSize: number, animated: boolean): string[] {
   const indentation = " ".repeat(indentationSize);
   return [
     "private struct SVGGradientStop {",
@@ -3485,6 +4142,27 @@ function gradientSupport(indentationSize: number): string[] {
     `${indentation}let blue: CGFloat`,
     `${indentation}let alpha: CGFloat`,
     "}",
+    ...(animated
+      ? [
+          "",
+          "private static func svgAnimatedGradientStop(offset: SVGAnimationRuntimeValue, color: SVGAnimationRuntimeValue, opacity: SVGAnimationRuntimeValue, paintOpacity: Double) -> SVGGradientStop {",
+          `${indentation}func encoded(_ component: Double) -> Double { component <= 0.0031308 ? component * 12.92 : 1.055 * pow(component, 1 / 2.4) - 0.055 }`,
+          `${indentation}let values = color.components + [0, 0, 0, 1]`,
+          `${indentation}let linear = color.signature == "linearRGB"`,
+          `${indentation}let alpha = values[3] * svgAnimationNumber(opacity) * paintOpacity`,
+          `${indentation}return SVGGradientStop(offset: CGFloat(min(1, max(0, svgAnimationNumber(offset)))), red: CGFloat(min(1, max(0, linear ? encoded(values[0]) : values[0]))), green: CGFloat(min(1, max(0, linear ? encoded(values[1]) : values[1]))), blue: CGFloat(min(1, max(0, linear ? encoded(values[2]) : values[2]))), alpha: CGFloat(min(1, max(0, alpha))))`,
+          "}",
+          "",
+          "private static func svgNormalizedGradientStops(_ stops: [SVGGradientStop]) -> [SVGGradientStop] {",
+          `${indentation}var previous: CGFloat = 0`,
+          `${indentation}return stops.map { stop in`,
+          `${indentation}${indentation}let offset = max(previous, min(1, max(0, stop.offset)))`,
+          `${indentation}${indentation}previous = offset`,
+          `${indentation}${indentation}return SVGGradientStop(offset: offset, red: stop.red, green: stop.green, blue: stop.blue, alpha: stop.alpha)`,
+          `${indentation}}`,
+          "}",
+        ]
+      : []),
     "",
     "private enum SVGGradientSpread {",
     `${indentation}case pad, reflect, repeating`,
@@ -3763,6 +4441,169 @@ function createView(
         `${indentation}return result`,
         "}",
         "",
+        "private static func svgAnimationNumber(_ value: SVGAnimationRuntimeValue) -> Double {",
+        `${indentation}value.components.first ?? 0`,
+        "}",
+        "",
+        "private static func svgAnimationSource(_ value: SVGAnimationRuntimeValue) -> String { value.source }",
+        "",
+        "private static func svgAnimationLengths(_ value: SVGAnimationRuntimeValue, scale: CGFloat) -> [CGFloat] {",
+        `${indentation}value.components.map { CGFloat($0) * scale }`,
+        "}",
+        "",
+        "private static func svgStrokeLineCap(_ value: String) -> CGLineCap {",
+        `${indentation}value == "round" ? .round : value == "square" ? .square : .butt`,
+        "}",
+        "",
+        "private static func svgStrokeLineJoin(_ value: String) -> CGLineJoin {",
+        `${indentation}value == "round" ? .round : value == "bevel" ? .bevel : .miter`,
+        "}",
+        "",
+        "private static func svgMultiplyTransform(_ left: CGAffineTransform, _ right: CGAffineTransform) -> CGAffineTransform {",
+        `${indentation}CGAffineTransform(a: left.a * right.a + left.c * right.b, b: left.b * right.a + left.d * right.b, c: left.a * right.c + left.c * right.d, d: left.b * right.c + left.d * right.d, tx: left.a * right.tx + left.c * right.ty + left.tx, ty: left.b * right.tx + left.d * right.ty + left.ty)`,
+        "}",
+        "",
+        "private static func svgViewBoxMatrix(_ value: SVGAnimationRuntimeValue, rect: CGRect, preserveAspectRatio: String) -> CGAffineTransform {",
+        `${indentation}let box = value.components + [0, 0, 1, 1]`,
+        `${indentation}let boxWidth = max(0.000000000001, box[2])`,
+        `${indentation}let boxHeight = max(0.000000000001, box[3])`,
+        `${indentation}var scaleX = Double(rect.width) / boxWidth`,
+        `${indentation}var scaleY = Double(rect.height) / boxHeight`,
+        `${indentation}let tokens = preserveAspectRatio.split(separator: " ").map(String.init)`,
+        `${indentation}let align = tokens.first(where: { $0 == "none" || $0.hasPrefix("x") }) ?? "xMidYMid"`,
+        `${indentation}if align != "none" {`,
+        `${indentation}${indentation}let scale = tokens.contains("slice") ? max(scaleX, scaleY) : min(scaleX, scaleY)`,
+        `${indentation}${indentation}scaleX = scale; scaleY = scale`,
+        `${indentation}}`,
+        `${indentation}let remainingX = Double(rect.width) - boxWidth * scaleX`,
+        `${indentation}let remainingY = Double(rect.height) - boxHeight * scaleY`,
+        `${indentation}let alignX = align.contains("xMid") ? remainingX / 2 : align.contains("xMax") ? remainingX : 0`,
+        `${indentation}let alignY = align.contains("YMid") ? remainingY / 2 : align.contains("YMax") ? remainingY : 0`,
+        `${indentation}return CGAffineTransform(a: scaleX, b: 0, c: 0, d: scaleY, tx: Double(rect.minX) + alignX - box[0] * scaleX, ty: Double(rect.minY) + alignY - box[1] * scaleY)`,
+        "}",
+        "",
+        "private static func svgOutputTransform(_ value: CGAffineTransform, size: CGSize, coordinateSpace: CGRect) -> CGAffineTransform {",
+        `${indentation}let width = max(0.000000000001, coordinateSpace.width)`,
+        `${indentation}let height = max(0.000000000001, coordinateSpace.height)`,
+        `${indentation}let outputWidth = max(0.000000000001, size.width)`,
+        `${indentation}let outputHeight = max(0.000000000001, size.height)`,
+        `${indentation}let tx = (value.a * coordinateSpace.minX + value.c * coordinateSpace.minY + value.tx - coordinateSpace.minX) / width * outputWidth`,
+        `${indentation}let ty = (value.b * coordinateSpace.minX + value.d * coordinateSpace.minY + value.ty - coordinateSpace.minY) / height * outputHeight`,
+        `${indentation}return CGAffineTransform(a: value.a, b: value.b * width / height * outputHeight / outputWidth, c: value.c * height / width * outputWidth / outputHeight, d: value.d, tx: tx, ty: ty)`,
+        "}",
+        "",
+        "private static func svgAnimatedViewBoxTransform(value: SVGAnimationRuntimeValue, base: SVGAnimationRuntimeValue, rect: CGRect, outer: CGAffineTransform, staticTransform: CGAffineTransform, outputSize: CGSize, coordinateSpace: CGRect, preserveAspectRatio: String) -> CGAffineTransform {",
+        `${indentation}let animatedUser = svgMultiplyTransform(outer, svgViewBoxMatrix(value, rect: rect, preserveAspectRatio: preserveAspectRatio))`,
+        `${indentation}let animatedOutput = svgOutputTransform(animatedUser, size: outputSize, coordinateSpace: coordinateSpace)`,
+        `${indentation}let staticOutput = svgOutputTransform(staticTransform, size: outputSize, coordinateSpace: coordinateSpace)`,
+        `${indentation}return svgMultiplyTransform(animatedOutput, staticOutput.inverted())`,
+        "}",
+        "",
+        "private static func svgAnimationColor(_ value: SVGAnimationRuntimeValue) -> Color {",
+        `${indentation}func encoded(_ component: Double) -> Double {`,
+        `${indentation}${indentation}component <= 0.0031308 ? component * 12.92 : 1.055 * pow(component, 1 / 2.4) - 0.055`,
+        `${indentation}}`,
+        `${indentation}let components = value.components + [0, 0, 0, 1]`,
+        `${indentation}let linear = value.signature == "linearRGB"`,
+        `${indentation}return Color(red: min(1, max(0, linear ? encoded(components[0]) : components[0])), green: min(1, max(0, linear ? encoded(components[1]) : components[1])), blue: min(1, max(0, linear ? encoded(components[2]) : components[2])), opacity: min(1, max(0, components[3])))`,
+        "}",
+        "",
+        "private static func svgAnimationCGColor(_ value: SVGAnimationRuntimeValue, opacity: Double) -> CGColor {",
+        `${indentation}func encoded(_ component: Double) -> Double { component <= 0.0031308 ? component * 12.92 : 1.055 * pow(component, 1 / 2.4) - 0.055 }`,
+        `${indentation}let values = value.components + [0, 0, 0, 0]`,
+        `${indentation}let linear = value.signature == "linearRGB"`,
+        `${indentation}let components: [CGFloat] = [CGFloat(min(1, max(0, linear ? encoded(values[0]) : values[0]))), CGFloat(min(1, max(0, linear ? encoded(values[1]) : values[1]))), CGFloat(min(1, max(0, linear ? encoded(values[2]) : values[2]))), CGFloat(min(1, max(0, values[3] * opacity)))]`,
+        `${indentation}return CGColor(colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!, components: components)!`,
+        "}",
+        "",
+        "private static func svgZeroValue(like value: SVGAnimationRuntimeValue) -> SVGAnimationRuntimeValue {",
+        `${indentation}SVGAnimationRuntimeValue(kind: value.kind, components: value.components.map { _ in 0 }, signature: value.signature, source: value.source)`,
+        "}",
+        "",
+        "private static func svgValuesCompatible(_ left: SVGAnimationRuntimeValue, _ right: SVGAnimationRuntimeValue) -> Bool {",
+        `${indentation}left.kind == right.kind && left.signature == right.signature && left.components.count == right.components.count && left.kind != .discrete`,
+        "}",
+        "",
+        "private static func svgInterpolateValue(_ left: SVGAnimationRuntimeValue, _ right: SVGAnimationRuntimeValue, _ progress: Double) -> SVGAnimationRuntimeValue {",
+        `${indentation}guard svgValuesCompatible(left, right) else { return progress >= 1 ? right : left }`,
+        `${indentation}let components = zip(left.components, right.components).map { $0 + ($1 - $0) * progress }`,
+        `${indentation}return SVGAnimationRuntimeValue(kind: left.kind, components: components, signature: left.signature, source: progress >= 1 ? right.source : left.source)`,
+        "}",
+        "",
+        "private static func svgValueDistance(_ left: SVGAnimationRuntimeValue, _ right: SVGAnimationRuntimeValue) -> Double? {",
+        `${indentation}guard svgValuesCompatible(left, right) else { return nil }`,
+        `${indentation}return sqrt(zip(left.components, right.components).reduce(0) { sum, pair in sum + (pair.1 - pair.0) * (pair.1 - pair.0) })`,
+        "}",
+        "",
+        "private static func svgAddValue(_ left: SVGAnimationRuntimeValue, _ right: SVGAnimationRuntimeValue) -> SVGAnimationRuntimeValue? {",
+        `${indentation}guard svgValuesCompatible(left, right) else { return nil }`,
+        `${indentation}return SVGAnimationRuntimeValue(kind: left.kind, components: zip(left.components, right.components).map { $0 + $1 }, signature: left.signature, source: right.source)`,
+        "}",
+        "",
+        "private static func svgClampValue(_ value: SVGAnimationRuntimeValue, _ clamp: SVGAnimationClamp) -> SVGAnimationRuntimeValue {",
+        `${indentation}var components = value.components`,
+        `${indentation}switch clamp {`,
+        `${indentation}case .none: break`,
+        `${indentation}case .unit: components = components.map { min(1, max(0, $0)) }`,
+        `${indentation}case .nonnegative: components = components.map { max(0, $0) }`,
+        `${indentation}case .integer: components = components.map { floor($0 + 0.5) }`,
+        `${indentation}}`,
+        `${indentation}return SVGAnimationRuntimeValue(kind: value.kind, components: components, signature: value.signature, source: value.source)`,
+        "}",
+        "",
+        "private static func svgAnimationTypedValueSample(progress: Double, values authoredValues: [SVGAnimationRuntimeValue], form: SVGAnimationForm, calcMode: SVGAnimationCalcMode, keyTimes: [Double], keySplines: [(x1: Double, y1: Double, x2: Double, y2: Double)], additive: Bool, accumulate: Bool, repeatIteration: Int, clamp: SVGAnimationClamp, underlying: SVGAnimationRuntimeValue) -> SVGAnimationRuntimeValue {",
+        `${indentation}var values = authoredValues`,
+        `${indentation}if form == .to {`,
+        `${indentation}${indentation}guard let target = authoredValues.first else { return underlying }`,
+        `${indentation}${indentation}values = [underlying, target]`,
+        `${indentation}} else if form == .by {`,
+        `${indentation}${indentation}guard let target = authoredValues.first else { return underlying }`,
+        `${indentation}${indentation}values = [svgZeroValue(like: target), target]`,
+        `${indentation}}`,
+        `${indentation}guard !values.isEmpty else { return underlying }`,
+        `${indentation}if values.count == 1 { return svgClampValue(values[0], clamp) }`,
+        `${indentation}var mode = calcMode`,
+        `${indentation}var times: [Double]`,
+        `${indentation}if mode == .paced {`,
+        `${indentation}${indentation}let measured = zip(values, values.dropFirst()).map { svgValueDistance($0, $1) }`,
+        `${indentation}${indentation}if measured.contains(where: { $0 == nil }) {`,
+        `${indentation}${indentation}${indentation}mode = values[0].kind == .discrete ? .discrete : .linear`,
+        `${indentation}${indentation}${indentation}times = values.indices.map { Double($0) / Double(values.count - 1) }`,
+        `${indentation}${indentation}} else {`,
+        `${indentation}${indentation}${indentation}let distances = measured.map { $0! }`,
+        `${indentation}${indentation}${indentation}let total = distances.reduce(0, +)`,
+        `${indentation}${indentation}${indentation}if total <= 0 { mode = .linear; times = values.indices.map { Double($0) / Double(values.count - 1) } }`,
+        `${indentation}${indentation}${indentation}else { var elapsed = 0.0; times = [0] + distances.map { distance in elapsed += distance; return elapsed / total } }`,
+        `${indentation}${indentation}}`,
+        `${indentation}} else { times = keyTimes.count == values.count ? keyTimes : values.indices.map { Double($0) / Double(values.count - 1) } }`,
+        `${indentation}let effect: SVGAnimationRuntimeValue`,
+        `${indentation}if mode == .discrete || values[0].kind == .discrete {`,
+        `${indentation}${indentation}let index = keyTimes.count == values.count ? (keyTimes.indices.last { progress + 0.000000000001 >= keyTimes[$0] } ?? 0) : min(values.count - 1, Int(floor(progress * Double(values.count) + 0.000000000001)))`,
+        `${indentation}${indentation}effect = values[index]`,
+        `${indentation}} else {`,
+        `${indentation}${indentation}var segment = progress >= 1 ? values.count - 2 : 0`,
+        `${indentation}${indentation}while segment + 1 < times.count - 1 && progress >= times[segment + 1] - 0.000000000001 { segment += 1 }`,
+        `${indentation}${indentation}let start = times[segment]`,
+        `${indentation}${indentation}let end = times[segment + 1]`,
+        `${indentation}${indentation}var local = progress >= 1 ? 1 : (end <= start ? 1 : min(1, max(0, (progress - start) / (end - start))))`,
+        `${indentation}${indentation}if mode == .spline && segment < keySplines.count { local = svgSplineProgress(local, keySplines[segment]) }`,
+        `${indentation}${indentation}effect = svgInterpolateValue(values[segment], values[segment + 1], local)`,
+        `${indentation}}`,
+        `${indentation}var accumulated = effect`,
+        `${indentation}if accumulate && repeatIteration > 0, let endpoint = values.last {`,
+        `${indentation}${indentation}for _ in 0..<repeatIteration { accumulated = svgAddValue(accumulated, endpoint) ?? accumulated }`,
+        `${indentation}}`,
+        `${indentation}let result = additive && form != .to ? (svgAddValue(underlying, accumulated) ?? accumulated) : accumulated`,
+        `${indentation}return svgClampValue(result, clamp)`,
+        "}",
+        "",
+        "private static func svgAnimatedValue(documentTime: Double, intervals: [(begin: Double, end: Double)], duration: Double, repeatingDuration: Double, values authoredValues: [SVGAnimationRuntimeValue], form: SVGAnimationForm, calcMode: SVGAnimationCalcMode, keyTimes: [Double], keySplines: [(x1: Double, y1: Double, x2: Double, y2: Double)], additive: Bool, accumulate: Bool, clamp: SVGAnimationClamp, underlying: SVGAnimationRuntimeValue, freeze: Bool) -> SVGAnimationRuntimeValue {",
+        `${indentation}let sample = svgTimingSample(documentTime: documentTime, intervals: intervals, duration: duration, repeatingDuration: repeatingDuration, freeze: freeze)`,
+        `${indentation}if sample.state == .inactive || sample.state == .completed { return underlying }`,
+        `${indentation}guard let progress = sample.simpleProgress else { return underlying }`,
+        `${indentation}return svgAnimationTypedValueSample(progress: progress, values: authoredValues, form: form, calcMode: calcMode, keyTimes: keyTimes, keySplines: keySplines, additive: additive, accumulate: accumulate, repeatIteration: sample.repeatIteration, clamp: clamp, underlying: underlying)`,
+        "}",
+        "",
         "private static func svgAnimatedNumber(documentTime: Double, intervals: [(begin: Double, end: Double)], duration: Double, repeatingDuration: Double, values authoredValues: [Double], form: SVGAnimationForm, calcMode: SVGAnimationCalcMode, keyTimes: [Double], keySplines: [(x1: Double, y1: Double, x2: Double, y2: Double)], additive: Bool, accumulate: Bool, clamp: SVGAnimationClamp, underlying: Double, freeze: Bool) -> Double {",
         `${indentation}let sample = svgTimingSample(documentTime: documentTime, intervals: intervals, duration: duration, repeatingDuration: repeatingDuration, freeze: freeze)`,
         `${indentation}if sample.state == .inactive || sample.state == .completed { return underlying }`,
@@ -3807,16 +4648,16 @@ function createView(
       name: helper.name,
       indent: indentationSize,
       returnType: "Shape",
-      body: pathFunction,
+      body: helper.animated ? ["let documentTime: Double", "", ...pathFunction] : pathFunction,
     });
     layerStruct[0] = `private ${layerStruct[0]}`;
     body.push("", ...layerStruct);
   }
   for (const helper of textHelpers)
-    body.push("", ...createTextHelper(helper, coordinateSpace, document, indentationSize));
+    body.push("", ...createTextHelper(helper, coordinateSpace, document, name, indentationSize));
   for (const helper of imageHelpers) body.push("", ...createImageHelper(helper, coordinateSpace, indentationSize));
   for (const helper of filterImageHelpers) body.push("", ...createFilterImageHelper(helper, indentationSize));
-  if (containsGradientNode(nodes)) body.push("", ...gradientSupport(indentationSize));
+  if (containsGradientNode(nodes)) body.push("", ...gradientSupport(indentationSize, animated));
   if (containsFilterNode(nodes)) body.push("", ...filterSupport(indentationSize));
   return createStructTemplate({
     name,

--- a/packages/svg-to-swiftui-core/src/renderTree/gradients.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/gradients.ts
@@ -131,6 +131,7 @@ function stopsFor(
   element: ElementNode,
   presentations: Map<ElementNode, Presentation>,
   diagnostics: RenderDiagnostic[],
+  animationTargetKey?: (element: ElementNode) => string | undefined,
 ): GradientStop[] {
   const result: GradientStop[] = [];
   let previous = 0;
@@ -152,6 +153,12 @@ function stopsFor(
       offset,
       color: { ...color, alpha: color.alpha * parseOpacity(opacitySource) },
       source: sourceLocation(stop),
+      ...(animationTargetKey?.(stop) ? { animationTargetKey: animationTargetKey(stop) } : {}),
+      animationBaseValues: {
+        offset: String(offset),
+        "stop-color": colorSource,
+        "stop-opacity": opacitySource,
+      },
     });
   }
   return result;
@@ -173,6 +180,7 @@ export function resolvePaintServers(
   styleResolver: SVGStyleResolver,
   rootPresentation: Presentation,
   diagnostics: RenderDiagnostic[],
+  animationTargetKey?: (element: ElementNode) => string | undefined,
 ): Map<string, PaintServer> {
   const presentations = new Map<ElementNode, Presentation>();
 
@@ -302,7 +310,7 @@ export function resolvePaintServers(
     }
 
     const stopOwner = chain.find((candidate) => children(candidate).some((child) => child.tagName === "stop"));
-    const stops = stopOwner ? stopsFor(stopOwner, presentations, diagnostics) : [];
+    const stops = stopOwner ? stopsFor(stopOwner, presentations, diagnostics, animationTargetKey) : [];
     const base = {
       id,
       units,

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -71,6 +71,8 @@ export interface GradientStop {
   offset: number;
   color: RGBAColor;
   source: SourceLocation;
+  animationTargetKey?: string;
+  animationBaseValues?: Readonly<Record<string, string>>;
 }
 
 interface GradientPaintBase {
@@ -659,6 +661,10 @@ export interface ComputedStyle {
   presentation: Readonly<Record<string, string | number>>;
   /** Winning CSS declaration context for inspectable cascade results. */
   provenance: Readonly<Record<string, CSSDiagnosticContext>>;
+  /** Properties whose computed presentation value is inherited from the parent. */
+  inheritedProperties: Readonly<Record<string, true>>;
+  /** Paint properties whose winning authored value uses currentColor. */
+  currentColorProperties: Readonly<Record<string, true>>;
 }
 
 export type Geometry =
@@ -672,7 +678,11 @@ export type Geometry =
 
 export interface RenderShape {
   type: "shape";
+  /** Stable source identity used to bind SMIL/CSS presentation values, including anonymous parent targets. */
+  animationTargetKey?: string;
   geometry: Geometry;
+  /** Authored geometry presence retained for SVG auto/default dependencies during animation. */
+  geometryAuthored?: Readonly<Record<string, string | number>>;
   style: ComputedStyle;
   transform: AffineTransform;
   source: SourceLocation;
@@ -699,6 +709,7 @@ export interface MarkerPlacement {
 
 export interface RenderGroup {
   type: "group";
+  animationTargetKey?: string;
   children: RenderNode[];
   style: ComputedStyle;
   transform: AffineTransform;
@@ -727,6 +738,7 @@ export interface RenderGroup {
 
 export interface RenderText {
   type: "text";
+  animationTargetKey?: string;
   text: string;
   chunks: RenderTextChunk[];
   attributes: Readonly<Record<string, string | number>>;
@@ -818,6 +830,7 @@ export interface RenderTextRun {
 
 export interface RenderImage {
   type: "image";
+  animationTargetKey?: string;
   href: string;
   viewport: ViewBoxData;
   preserveAspectRatio: PreserveAspectRatio;
@@ -836,6 +849,7 @@ export interface RenderImage {
 
 export interface RenderForeignObject {
   type: "foreignObject";
+  animationTargetKey?: string;
   /** Stable structural identity used to join the preflight snapshot to the final render tree. */
   key: string;
   viewport: ViewBoxData;

--- a/packages/svg-to-swiftui-core/src/styleCascade.ts
+++ b/packages/svg-to-swiftui-core/src/styleCascade.ts
@@ -17,6 +17,10 @@ export type Presentation = Record<string, string | number>;
 export interface StyleResolution {
   values: Presentation;
   provenance: Readonly<Record<string, CSSDiagnosticContext>>;
+  /** Properties whose computed value came from the parent presentation. */
+  inheritedProperties: Readonly<Record<string, true>>;
+  /** Paint properties whose winning authored value depends on `color`. */
+  currentColorProperties: Readonly<Record<string, true>>;
 }
 
 type StyleNode = ElementNode | TextNode | string;
@@ -581,6 +585,7 @@ export class SVGStyleResolver {
 
     const values: Presentation = {};
     const provenance: Record<string, CSSDiagnosticContext> = {};
+    const inheritedProperties: Record<string, true> = {};
     for (const name of new Set([
       ...Object.keys(inheritedCustom),
       ...[...winners.keys()].filter((property) => property.startsWith("--")),
@@ -596,6 +601,7 @@ export class SVGStyleResolver {
       let value: string | number;
       if (!winner) {
         const contextualOverflow = property === "overflow" && ["svg", "symbol"].includes(element.tagName ?? "");
+        if (definition.inherited && inherited[property] !== undefined) inheritedProperties[property] = true;
         value =
           definition.inherited && inherited[property] !== undefined
             ? inherited[property]!
@@ -612,13 +618,17 @@ export class SVGStyleResolver {
             winner.css,
           );
           value = definition.inherited && inherited[property] !== undefined ? inherited[property]! : definition.initial;
+          if (definition.inherited && inherited[property] !== undefined) inheritedProperties[property] = true;
         } else {
           const keyword = substituted.trim().toLowerCase();
-          if (keyword === "inherit") value = inherited[property] ?? definition.initial;
-          else if (keyword === "initial") value = definition.initial;
+          if (keyword === "inherit") {
+            value = inherited[property] ?? definition.initial;
+            if (inherited[property] !== undefined) inheritedProperties[property] = true;
+          } else if (keyword === "initial") value = definition.initial;
           else if (keyword === "unset" || keyword === "revert" || keyword === "revert-layer") {
             value =
               definition.inherited && inherited[property] !== undefined ? inherited[property]! : definition.initial;
+            if (definition.inherited && inherited[property] !== undefined) inheritedProperties[property] = true;
           } else value = substituted;
         }
         provenance[property] = winner.css;
@@ -626,6 +636,10 @@ export class SVGStyleResolver {
       values[property] = value;
     }
 
+    const currentColorProperties: Record<string, true> = {};
+    for (const property of ["fill", "stroke", "stop-color", "flood-color", "lighting-color", "solid-color"] as const) {
+      if (/\bcurrentcolor\b/i.test(String(values[property] ?? ""))) currentColorProperties[property] = true;
+    }
     const rawColor = values.color ?? STYLE_PROPERTY_DEFINITIONS.color.initial;
     const color =
       String(rawColor).trim().toLowerCase() === "currentcolor"
@@ -635,6 +649,6 @@ export class SVGStyleResolver {
     for (const property of ["fill", "stroke", "stop-color", "flood-color", "lighting-color", "solid-color"] as const) {
       values[property] = resolveCurrentColor(values[property]!, color);
     }
-    return { values, provenance };
+    return { values, provenance, inheritedProperties, currentColorProperties };
   }
 }

--- a/packages/svg-to-swiftui-core/src/tests/animation.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/animation.test.ts
@@ -144,8 +144,8 @@ describe("generated animation clock", () => {
     expect(swift).toContain("init(documentTime: Double? = nil, respectsReducedMotion: Bool = false)");
     expect(swift).toContain("TimelineView(.animation(paused:");
     expect(swift).toContain("content(at: Self.sanitizedDocumentTime(documentTime))");
-    expect(swift).toContain("svgAnimatedNumber(documentTime: documentTime");
-    expect(swift).toContain(".offset(x:");
+    expect(swift).toContain("svgAnimatedValue(documentTime: documentTime");
+    expect(swift).toContain("Layer0(documentTime: documentTime)");
     expect(swift.match(/TimelineView/g)).toHaveLength(1);
   });
 

--- a/packages/svg-to-swiftui-core/src/tests/animationTargets.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/animationTargets.test.ts
@@ -1,0 +1,244 @@
+import {
+  __testing,
+  ANIMATION_ATTRIBUTE_REGISTRY,
+  animationAttributeSpec,
+  convert,
+  convertWithDiagnostics,
+  parseAnimationValue,
+  sampleAnimatedPresentationValue,
+  serializeAnimationValue,
+} from "../index";
+
+describe("animation target registry", () => {
+  test("is machine-readable, unique, and declares invalidation for every supported property", () => {
+    const names = ANIMATION_ATTRIBUTE_REGISTRY.map((entry) => entry.canonicalName);
+    expect(new Set(names).size).toBe(names.length);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "display",
+        "visibility",
+        "fill",
+        "stroke",
+        "opacity",
+        "stroke-width",
+        "stroke-dasharray",
+        "x",
+        "cx",
+        "points",
+        "d",
+        "viewBox",
+        "preserveAspectRatio",
+        "textLength",
+        "flood-color",
+        "baseFrequency",
+      ]),
+    );
+    expect(ANIMATION_ATTRIBUTE_REGISTRY.every((entry) => entry.invalidates.length > 0)).toBe(true);
+    expect(animationAttributeSpec("d")).toMatchObject({ invalidates: expect.arrayContaining(["geometry", "bounds"]) });
+    expect(animationAttributeSpec("fill")).toMatchObject({ invalidates: expect.arrayContaining(["paint"]) });
+    expect(animationAttributeSpec("viewBox")).toMatchObject({ namespaces: ["XML"] });
+    expect(ANIMATION_ATTRIBUTE_REGISTRY.find((entry) => entry.canonicalName === "fill")?.runtimeBinding).toBe(
+      "render-node",
+    );
+    expect(ANIMATION_ATTRIBUTE_REGISTRY.find((entry) => entry.canonicalName === "stop-color")?.runtimeBinding).toBe(
+      "gradient-stop",
+    );
+    expect(ANIMATION_ATTRIBUTE_REGISTRY.find((entry) => entry.canonicalName === "baseFrequency")?.runtimeBinding).toBe(
+      "pending-resource",
+    );
+  });
+
+  test("uses the computed cascade and inherited presentation value as the immutable base", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 40 20">
+        <style>#box { x: 12px; opacity: .4 } g { fill: rgb(255, 0, 0) }</style>
+        <g><rect id="box" x="2" width="8" height="8">
+          <animate attributeName="x" to="20" dur="1s"/>
+          <animate attributeName="fill" to="blue" dur="1s"/>
+          <animate attributeName="opacity" to="1" dur="1s"/>
+        </rect></g>
+      </svg>`);
+    expect(document.animationProgram.animations[0]?.value).toMatchObject({ base: { family: "length", value: 12 } });
+    expect(document.animationProgram.animations[1]?.value).toMatchObject({
+      base: { family: "paint", value: { type: "color", color: { red: 1, green: 0, blue: 0 } } },
+    });
+    expect(document.animationProgram.animations[2]?.value).toMatchObject({ base: { family: "opacity", value: 0.4 } });
+  });
+
+  test("resolves anonymous parent, href, and xlink:href targets to the same stable source identity", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20">
+        <rect id="named" width="4" height="4"><animate attributeName="x" to="4" dur="1s"/></rect>
+        <animate href="#named" attributeName="y" to="4" dur="1s"/>
+        <animate xlink:href="#named" attributeName="opacity" to="0" dur="1s"/>
+        <circle cx="2" cy="2" r="2"><set attributeName="visibility" to="hidden" dur="1s"/></circle>
+      </svg>`);
+    expect(document.animationProgram.animations.slice(0, 3).map((item) => item.target?.key)).toEqual([
+      "id:named",
+      "id:named",
+      "id:named",
+    ]);
+    expect(document.animationProgram.animations[3]?.target?.key).toMatch(/^source:/);
+    expect(document.animationProgram.animations.every((item) => item.runtimeSupport === "typed")).toBe(true);
+  });
+
+  test("diagnoses namespace, applicability, resource, and non-rendered target errors with stable codes", () => {
+    const result = convertWithDiagnostics(`
+      <svg viewBox="0 0 20 20">
+        <animate attributeName="viewBox" attributeType="CSS" from="0 0 20 20" to="0 0 10 10" dur="1s"/>
+        <circle id="dot" r="2"><animate attributeName="x1" from="0" to="2" dur="1s"/></circle>
+        <rect id="paint" width="2" height="2"><animate attributeName="fill" to="url(#missing)" dur="1s"/></rect>
+        <defs><rect id="unused" width="2" height="2"><animate attributeName="x" to="2" dur="1s"/></rect></defs>
+      </svg>`);
+    expect(result.diagnostics.map((item) => item.code)).toEqual(
+      expect.arrayContaining([
+        "incompatible-animation-attribute-type",
+        "non-animatable-target-property",
+        "unresolved-animation-resource-reference",
+        "wrong-animation-target-type",
+      ]),
+    );
+    expect(() =>
+      convert(`<svg viewBox="0 0 10 10"><animate attributeName="viewBox" attributeType="CSS" to="0 0 5 5"/></svg>`, {
+        strict: true,
+      }),
+    ).toThrow(/incompatible-animation-attribute-type/);
+  });
+});
+
+describe("pure animate/set presentation sampling", () => {
+  const source = `
+    <svg viewBox="0 0 20 10">
+      <rect id="box" x="2" width="4" height="4" fill="red">
+        <animate attributeName="x" from="2" to="10" begin=".25s" dur="1s" fill="freeze"/>
+        <set attributeName="fill" to="blue" begin=".5s" dur=".25s"/>
+      </rect>
+    </svg>`;
+
+  test("set applies discretely at begin and removes exactly at end", () => {
+    const program = __testing.parseRenderDocument(source).animationProgram;
+    const fill = parseAnimationValue(animationAttributeSpec("fill")!, "red", {
+      length: {
+        viewport: { width: 20, height: 10 },
+        rootViewport: { width: 20, height: 10 },
+        fontMetrics: { fontSize: 16, rootFontSize: 16, xHeight: 8, zeroAdvance: 8 },
+        percentageBasis: "viewport-diagonal",
+        axis: "other",
+      },
+      colorSpace: "sRGB",
+    })!;
+    const sample = (time: number) =>
+      serializeAnimationValue(sampleAnimatedPresentationValue(program, "id:box", "fill", fill, time));
+    expect(sample(0.499999)).toContain("255 0 0");
+    expect(sample(0.5)).toContain("0 0 255");
+    expect(sample(0.749999)).toContain("0 0 255");
+    expect(sample(0.75)).toContain("255 0 0");
+  });
+
+  test("arbitrary timestamp order has no retained state", () => {
+    const program = __testing.parseRenderDocument(source).animationProgram;
+    const base = parseAnimationValue(animationAttributeSpec("x")!, "2", {
+      length: {
+        viewport: { width: 20, height: 10 },
+        rootViewport: { width: 20, height: 10 },
+        fontMetrics: { fontSize: 16, rootFontSize: 16, xHeight: 8, zeroAdvance: 8 },
+        percentageBasis: "viewport-diagonal",
+        axis: "horizontal",
+      },
+    })!;
+    const sample = (time: number) =>
+      serializeAnimationValue(sampleAnimatedPresentationValue(program, "id:box", "x", base, time));
+    const forward = [0, 0.25, 0.75, 1.25, 3].map(sample);
+    const shuffled = [3, 0.75, 0, 1.25, 0.25].map((time) => [time, sample(time)] as const);
+    expect(Object.fromEntries(shuffled)).toEqual(
+      Object.fromEntries([0, 0.25, 0.75, 1.25, 3].map((time, i) => [time, forward[i]])),
+    );
+  });
+
+  test("generated Swift wires geometry, path, points, stroke, paint, opacity, and set without mutable frame state", () => {
+    const swift = convert(
+      `
+      <svg viewBox="0 0 60 30">
+        <g opacity="1"><animate attributeName="opacity" to=".5" dur="1s"/>
+          <rect x="1" y="1" width="8" height="6" fill="red" stroke="white" stroke-width="1">
+            <animate attributeName="width" to="16" dur="1s"/><animate attributeName="fill" to="blue" dur="1s"/>
+            <animate attributeName="stroke-width" to="3" dur="1s"/><set attributeName="visibility" to="hidden" begin=".5s" dur=".1s"/>
+          </rect>
+          <polygon points="20,2 28,2 24,9"><animate attributeName="points" values="20,2 28,2 24,9;18,8 30,8 24,1" dur="1s"/></polygon>
+          <path d="M35 2 L45 2 L40 9 Z"><animate attributeName="d" values="M35 2 L45 2 L40 9 Z;M33 8 L47 8 L40 1 Z" dur="1s"/></path>
+        </g>
+      </svg>`,
+      { structName: "AnimatedProperties", strict: true },
+    );
+    expect(swift).toContain("svgAnimatedValue(documentTime: documentTime");
+    expect(swift).toContain("svgAnimationColor(");
+    expect(swift).toContain("strokedPath(StrokeStyle(lineWidth:");
+    expect(swift).toContain("switch svgGeometry.signature");
+    expect(swift).toContain("switch svgGeometry.components.count / 2");
+    expect(swift).toContain('!= "hidden"');
+    expect(swift).not.toContain("@State private var");
+  });
+
+  test("propagates group presentation animations through inheritance and currentColor", () => {
+    const swift = convert(
+      `
+      <svg viewBox="0 0 30 12">
+        <g fill="currentColor" color="red" stroke="black" stroke-width="1">
+          <animate attributeName="color" from="red" to="blue" dur="1s"/>
+          <animate attributeName="stroke-width" from="1" to="3" dur="1s"/>
+          <rect width="8" height="8"/>
+          <circle cx="15" cy="4" r="4" fill="green"/>
+        </g>
+      </svg>`,
+      { structName: "InheritedPresentation", strict: true },
+    );
+    expect(swift).toContain("kind: .paintColor, components: [1, 0, 0, 1]");
+    expect(swift).toContain("kind: .paintColor, components: [0, 0, 1, 1]");
+    expect(swift).toMatch(/svgAnimationColor\([\s\S]*svgAnimatedValue\(documentTime: documentTime/);
+    expect(swift).toMatch(/strokedPath\(StrokeStyle\(lineWidth:[\s\S]*svgAnimatedValue\(documentTime: documentTime/);
+  });
+
+  test("wires animated gradient stop offset, color, and opacity as resource presentation", () => {
+    const source = `
+      <svg viewBox="0 0 30 12">
+        <defs><linearGradient id="paint">
+          <stop id="animated-stop" offset="0" stop-color="red" stop-opacity="1">
+            <animate attributeName="offset" from="0" to=".7" dur="1s"/>
+            <animate attributeName="stop-color" from="red" to="blue" dur="1s"/>
+            <animate attributeName="stop-opacity" from="1" to=".4" dur="1s"/>
+          </stop>
+          <stop offset="1" stop-color="white"/>
+        </linearGradient></defs>
+        <rect width="30" height="12" fill="url(#paint)"/>
+      </svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(document.animationProgram.animations).toHaveLength(3);
+    expect(document.animationProgram.animations.every((item) => item.runtimeSupport === "typed")).toBe(true);
+    expect(document.animationProgram.animations[0]?.target).toMatchObject({
+      key: "id:animated-stop",
+      binding: "resource",
+    });
+    const swift = convert(source, { structName: "AnimatedGradient", strict: true });
+    expect(swift).toContain("svgAnimatedGradientStop(offset:");
+    expect(swift).toContain("svgNormalizedGradientStops");
+    expect(swift).toContain("kind: .color");
+    expect(swift).toContain("kind: .opacity");
+  });
+
+  test("recomputes nested viewport mapping from the sampled viewBox", () => {
+    const swift = convert(
+      `
+      <svg viewBox="0 0 40 20">
+        <svg id="nested" x="10" y="2" width="20" height="16" viewBox="0 0 20 16">
+          <rect width="8" height="8"/>
+        </svg>
+        <animate href="#nested" attributeName="viewBox" values="0 0 20 16;4 2 12 10" dur="1s"/>
+      </svg>`,
+      { structName: "AnimatedViewport", strict: true },
+    );
+    expect(swift).toContain("GeometryReader { proxy in");
+    expect(swift).toContain("svgAnimatedViewBoxTransform(value:");
+    expect(swift).toContain("outputSize: proxy.size");
+    expect(swift).toContain("staticTransform: CGAffineTransform");
+  });
+});

--- a/packages/svg-to-swiftui-core/src/tests/smilTiming.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/smilTiming.test.ts
@@ -294,7 +294,9 @@ describe("shared timing benchmark expectations", () => {
     expect(swift).toContain("private struct SVGTimingSample");
     expect(swift).toContain("intervals: [(begin: 0.2, end: 1.4)]");
     expect(swift).toContain("repeatingDuration: 1.2");
-    expect(swift).toContain("values: [16, 48, 80]");
+    expect(swift).toContain("components: [16]");
+    expect(swift).toContain("components: [48]");
+    expect(swift).toContain("components: [80]");
   });
 
   test("precompiles advanced offset and syncbase intervals into generated Swift", () => {
@@ -307,6 +309,6 @@ describe("shared timing benchmark expectations", () => {
     );
     expect(swift).toContain("intervals: [(begin: 0, end: 0.9), (begin: 1.2, end: 2.1)]");
     expect(swift).toContain("intervals: [(begin: 1, end: 1.5), (begin: 2.2, end: 2.7)]");
-    expect(swift.match(/Self\.svgAnimatedNumber\(documentTime:/g)).toHaveLength(2);
+    expect(swift.match(/AdvancedTiming\.svgAnimatedValue\(documentTime:/g)).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Closes #99.

## What changed

- resolves `<animate>` and `<set>` targets through parent, `href`, and `xlink:href` with stable source identities
- samples typed presentation values from computed cascade/inheritance bases in document order
- renders geometry, paint, stroke, visibility, opacity, text, nested/root viewport, and gradient-stop animation in pure SwiftUI `documentTime`
- preserves `currentColor` and inherited group presentation semantics
- adds explicit property namespaces, runtime bindings, and invalidation categories to the machine-readable registry
- adds generated animation conformance documentation and stable diagnostics for invalid or pending semantics
- adds benchmark 05 with exact `<set>` boundaries and progressively complex property/resource cases

## Validation

- `bun run test`: 378 passed
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- animation manifest: 15 fixtures / 171 deterministic frames
- full animation oracle: 9 reference probes passed; 92/92 SVG-vs-SwiftUI frames passed
- benchmark 05: 11/11 frames passed; worst outside-tolerance pixels 2.375%
