### PR TITLE
Implement animateMotion and mpath

### DIFF
--- a/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
@@ -316,6 +316,40 @@
         ]
       },
       "expectDistinctReferenceFrames": true
+    },
+    "benchmark-07-animate-motion": {
+      "mode": "comparison",
+      "referenceBackend": "webkit",
+      "width": 160,
+      "height": 120,
+      "expectedMode": "view",
+      "tags": [
+        "accumulate",
+        "additive",
+        "animate-motion",
+        "auto-reverse",
+        "auto-rotate",
+        "benchmark-07",
+        "closed-path",
+        "discrete",
+        "explicit-rotate",
+        "key-points",
+        "mpath",
+        "nested-transform",
+        "path-length",
+        "point-pairs",
+        "spline",
+        "transform-sandwich"
+      ],
+      "timeline": {
+        "durationMicroseconds": 2000000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [
+          0, 249999, 250000, 499999, 500000, 699999, 700000, 999999, 1000000, 1000001, 1249999, 1250000, 1499999,
+          1500000, 1749999, 1750000, 1999999, 2000000
+        ]
+      },
+      "expectDistinctReferenceFrames": true
     }
   }
 }

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-07-animate-motion.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-07-animate-motion.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 160 120">
+  <rect width="160" height="120" fill="#0f172a"/>
+  <defs>
+    <path id="curve" d="M10 24 C28 2 52 46 72 20" pathLength="100"/>
+    <path id="loop" d="M112 20 C138 4 151 28 137 45 C122 61 96 47 100 29 Z"/>
+    <filter id="glow" x="-60%" y="-60%" width="220%" height="220%">
+      <feGaussianBlur stdDeviation="1.2"/>
+    </filter>
+    <linearGradient id="ship-fill"><stop stop-color="#fbbf24"/><stop offset="1" stop-color="#fb7185"/></linearGradient>
+  </defs>
+
+  <path d="M10 24 C28 2 52 46 72 20" fill="none" stroke="#334155" stroke-width="1"/>
+  <g id="auto-ship">
+    <animateMotion dur="2s" rotate="auto" fill="freeze"><mpath href="#curve"/></animateMotion>
+    <path d="M-7 -4 L8 0 L-7 4 L-3 0 Z" fill="url(#ship-fill)" stroke="#fff7ed" stroke-width="1"/>
+  </g>
+
+  <path d="M112 20 C138 4 151 28 137 45 C122 61 96 47 100 29 Z" fill="none" stroke="#334155" stroke-width="1"/>
+  <g id="closed-loop">
+    <animateMotion dur="2s" rotate="auto-reverse" fill="freeze"><mpath xlink:href="#loop"/></animateMotion>
+    <path d="M-6 -3 L7 0 L-6 3 Z" fill="#38bdf8"/>
+  </g>
+
+  <g transform="translate(4 54) scale(.92)">
+    <g id="keypoints-target" transform="rotate(-4)">
+      <animateTransform attributeName="transform" type="rotate" values="-4;8;-4" additive="sum" dur="2s" fill="freeze"/>
+      <animateMotion path="M4 12 C36 -8 60 28 88 9" keyTimes="0;.35;1" keyPoints="0;.18;1" calcMode="spline" keySplines=".42 0 .58 1;.2 .8 .4 1" rotate="auto" dur="2s" fill="freeze"/>
+      <g filter="url(#glow)"><path d="M-6 -4 L8 0 L-6 4 Z" fill="#a78bfa"/></g>
+    </g>
+  </g>
+
+  <g id="point-pairs">
+    <animateMotion values="105,75;137,67;148,90" calcMode="linear" rotate="15" dur="2s" fill="freeze"/>
+    <rect x="-6" y="-4" width="12" height="8" rx="2" fill="#34d399" stroke="#ecfdf5"/>
+    <path d="M0 0 H7" stroke="#052e16" stroke-width="1.5"/>
+  </g>
+
+  <g id="discrete-motion">
+    <animateMotion values="104,56;124,56;146,56" calcMode="discrete" rotate="0" dur="2s" fill="freeze"/>
+    <path d="M-3 -3 H3 V3 H-3 Z" fill="#e879f9"/>
+  </g>
+
+  <g id="additive-motion">
+    <animateMotion from="12,104" to="77,104" dur="1s" repeatCount="2" accumulate="sum" fill="freeze"/>
+    <animateMotion values="0,0;0,-5;0,0" additive="sum" dur="1s" repeatCount="2" fill="freeze"/>
+    <path d="M-5 -5 H5 V5 H-5 Z M-2 0 H7" fill="#f97316" stroke="#fff7ed" stroke-width="1"/>
+  </g>
+
+  <path d="M10 48 H150 M10 96 H150" stroke="#1e293b" stroke-width="1" stroke-dasharray="2 3"/>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/manifest.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/manifest.ts
@@ -101,6 +101,24 @@ const REQUIRED_ANIMATE_TRANSFORM_BENCHMARK_TAGS = [
   "use",
 ] as const;
 
+const REQUIRED_ANIMATE_MOTION_BENCHMARK_TAGS = [
+  "accumulate",
+  "additive",
+  "animate-motion",
+  "auto-reverse",
+  "auto-rotate",
+  "closed-path",
+  "discrete",
+  "explicit-rotate",
+  "key-points",
+  "mpath",
+  "nested-transform",
+  "path-length",
+  "point-pairs",
+  "spline",
+  "transform-sandwich",
+] as const;
+
 function validateBackground(value: string | null): void {
   if (value !== null && !/^#([\da-f]{6}|[\da-f]{8})$/i.test(value))
     throw new Error(`Background must be null, #RRGGBB, or #RRGGBBAA: ${value}`);
@@ -347,6 +365,14 @@ export function validateAnimationManifest(): string[] {
   for (const tag of REQUIRED_ANIMATE_TRANSFORM_BENCHMARK_TAGS)
     if (!animateTransformBenchmarkTags.has(tag))
       errors.push(`animateTransform comparison benchmark does not cover required tag: ${tag}`);
+  const animateMotionBenchmarkTags = new Set(
+    fixtures
+      .filter((fixture) => fixture.mode === "comparison" && fixture.tags.includes("benchmark-07"))
+      .flatMap((fixture) => fixture.tags),
+  );
+  for (const tag of REQUIRED_ANIMATE_MOTION_BENCHMARK_TAGS)
+    if (!animateMotionBenchmarkTags.has(tag))
+      errors.push(`animateMotion comparison benchmark does not cover required tag: ${tag}`);
   if (valueGoldens.version !== 1) errors.push(`Unsupported animation value golden version: ${valueGoldens.version}`);
   if (!Number.isFinite(valueGoldens.tolerance) || valueGoldens.tolerance <= 0)
     errors.push("Animation value golden tolerance must be finite and positive");

--- a/packages/svg-to-swiftui-core/conformance/ANIMATION_REPORT.md
+++ b/packages/svg-to-swiftui-core/conformance/ANIMATION_REPORT.md
@@ -125,4 +125,4 @@ This report describes declarative animation wiring. Attribute rows cover `<anima
 | Element | Status | Evidence |
 | --- | --- | --- |
 | `<animateTransform>` | implemented | typed parser/sampler/composition tests; 18-frame `benchmark-06-animate-transform` |
-| `<animateMotion>` | pending roadmap ticket | not yet wired to SwiftUI |
+| `<animateMotion>` / `<mpath>` | implemented | metric/parser/composition tests; 18-frame `benchmark-07-animate-motion` |

--- a/packages/svg-to-swiftui-core/conformance/animation-report.ts
+++ b/packages/svg-to-swiftui-core/conformance/animation-report.ts
@@ -38,7 +38,7 @@ export function renderAnimationReport(): string {
     "| Element | Status | Evidence |",
     "| --- | --- | --- |",
     "| `<animateTransform>` | implemented | typed parser/sampler/composition tests; 18-frame `benchmark-06-animate-transform` |",
-    "| `<animateMotion>` | pending roadmap ticket | not yet wired to SwiftUI |",
+    "| `<animateMotion>` / `<mpath>` | implemented | metric/parser/composition tests; 18-frame `benchmark-07-animate-motion` |",
     "",
   ];
   return lines.join("\n");

--- a/packages/svg-to-swiftui-core/docs/animate-motion.md
+++ b/packages/svg-to-swiftui-core/docs/animate-motion.md
@@ -1,0 +1,13 @@
+# `<animateMotion>` and `<mpath>` contract
+
+The compiler implements SVG motion as a deterministic supplemental transform sampled from `documentTime`. Motion sources follow SVG precedence: a child `<mpath>` overrides `path`, which overrides `values`, which overrides `from`/`to`/`by`. Local `href` and `xlink:href` references can target paths and SVG basic shapes. Missing, external, duplicate, wrong-type, empty, invalid, and cyclic references produce stable diagnostics with the complete reference chain.
+
+Paths are converted to bounded, adaptive, immutable distance metrics. Lines, quadratic/cubic curves, arcs, closed paths, multiple subpaths, discontinuities, coincident points, and degenerate segments have stable random-access sampling. `pathLength` calibration is retained. The implementation caps subdivision depth and flattened point count, so adversarial paths cannot create unbounded work.
+
+The default `calcMode` is paced. Discrete, linear, paced, and spline timing are supported, including validated `keyPoints`/`keyTimes` and `keySplines`. Point-pair sources accept SVG length units and resolve percentages in the target viewport. `rotate="auto"`, `auto-reverse`, and explicit angles (`deg`, `rad`, `grad`, and `turn`) are supported. A zero-length tangent neighborhood searches forward and then backward; a fully degenerate path has no effect.
+
+Motion is supplemental to the target's static transform and all `<animateTransform>` effects. The compiler applies translation followed by motion rotation, then preserves structural transforms used by `<use>` and nested viewports. Multiple motion animations use the SMIL replace/additive sandwich in document order; cumulative repeats concatenate the endpoint effect. The correction wraps the complete rendered subtree, so clips, masks, filters, gradients, patterns, markers, text, and descendants move with their target.
+
+SVG defines only `origin="default"`, which has no effect. Other host/CSS interpretations emit `unsupported-animation-motion-origin` and are ignored. Invalid motion keeps the static target in permissive mode and fails strict conversion through the normal diagnostic policy.
+
+Evidence includes path-metric golden tests, parser/reference/rotation/composition tests, generated Swift inspection, and the 18-frame `benchmark-07-animate-motion` WebKit-versus-SwiftUI comparison. The benchmark covers mpath, pathLength, auto orientation, auto-reverse, explicit rotation, keyPoints spline timing, nested/static/animated transforms, additive motion, accumulation, point pairs, and a full closed loop.

--- a/packages/svg-to-swiftui-core/docs/animate-set-properties.md
+++ b/packages/svg-to-swiftui-core/docs/animate-set-properties.md
@@ -8,7 +8,7 @@ The cascade is resolved before animation parsing. CSS winners, inheritance, expl
 
 `ANIMATION_ATTRIBUTE_REGISTRY` is the source of truth for exact names, XML/CSS namespaces, typed value families, target kinds, invalidation categories, and runtime binding. The generated [animation report](../conformance/ANIMATION_REPORT.md) exposes implemented and pending entries without guessing support.
 
-Resource values that require rebuilding a filter, marker, mask, clip, or paint-server graph remain explicitly `pending-resource` and emit `unsupported-animation-semantics`. `<animateTransform>` is documented separately in [its implemented contract](./animate-transform.md); motion paths and CSS keyframes remain roadmap work.
+Resource values that require rebuilding a filter, marker, mask, clip, or paint-server graph remain explicitly `pending-resource` and emit `unsupported-animation-semantics`. `<animateTransform>` and [`<animateMotion>`](./animate-motion.md) are documented separately; CSS keyframes remain roadmap work.
 
 Diagnostics use stable codes for missing/wrong targets, incompatible `attributeType`, non-applicable properties, malformed values/calculation metadata, unresolved resource URLs, and parsed-but-unwired semantics. Permissive mode keeps the immutable base; strict mode rejects warnings.
 

--- a/packages/svg-to-swiftui-core/src/renderTree/animation.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/animation.ts
@@ -15,6 +15,7 @@ import {
   sampleAnimationValue,
   validateAnimationCalculation,
 } from "./animationValues";
+import { type MotionDefinition, parseMotionDefinition } from "./motion";
 import { type DeterministicTimingEvent, sampleSMILProgram, sampleSMILTiming } from "./smilTiming";
 import type { RenderDiagnostic, SourceLocation } from "./types";
 
@@ -85,6 +86,7 @@ export interface AnimationDefinition {
   target?: AnimationTarget;
   kind: AnimationKind;
   transformType?: AnimateTransformType;
+  motion?: MotionDefinition;
   authoredAttributeName?: string;
   attributeName?: string;
   attributeType: "auto" | "XML" | "CSS";
@@ -311,7 +313,8 @@ function parseValue(
 }
 
 function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSupport">): boolean {
-  if (!(["animate", "set", "animateTransform"] as AnimationKind[]).includes(definition.kind)) return false;
+  if (!(["animate", "set", "animateTransform", "animateMotion"] as AnimationKind[]).includes(definition.kind))
+    return false;
   const attribute = definition.attributeName ? resolveAnimationAttribute(definition.attributeName) : undefined;
   const resourceSupported =
     definition.target?.binding === "resource" &&
@@ -320,7 +323,8 @@ function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSuppor
   const renderNodeSupported =
     definition.target?.binding === "render-node" &&
     (attribute?.runtimeBinding === "render-node" ||
-      (definition.kind === "animateTransform" && definition.attributeName === "transform"));
+      (definition.kind === "animateTransform" && definition.attributeName === "transform") ||
+      (definition.kind === "animateMotion" && definition.attributeName === "motion"));
   if (
     !definition.target?.renderable ||
     (!renderNodeSupported && !resourceSupported) ||
@@ -344,6 +348,20 @@ function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSuppor
     (!Number.isFinite(definition.timing.repeatCount.value) || definition.timing.repeatCount.value <= 0)
   )
     return false;
+  if (definition.kind === "animateMotion") {
+    if (!definition.motion) return false;
+    const keyPoints = definition.composition.keyPoints;
+    const keyTimes = definition.composition.keyTimes;
+    if (keyPoints && (!keyTimes || keyPoints.length !== keyTimes.length || keyPoints.length < 2)) return false;
+    const motionPointCount = keyPoints?.length ?? definition.motion.keyDistances.length;
+    if (keyTimes && keyTimes.length !== motionPointCount) return false;
+    if (
+      definition.composition.calcMode === "spline" &&
+      definition.composition.keySplines?.length !== motionPointCount - 1
+    )
+      return false;
+    return true;
+  }
   if (definition.value.family === "unsupported" || definition.value.form === "invalid") return false;
   if (definition.kind === "set" && !definition.value.to && !definition.value.values?.length) return false;
   const count = definition.value.values?.length ?? 2;
@@ -518,11 +536,15 @@ export function buildAnimationProgram(
     const attributeType: AnimationDefinition["attributeType"] =
       attributeTypeSource === "XML" || attributeTypeSource === "CSS" ? attributeTypeSource : "auto";
     const effectiveAttributeName =
-      kind === "animateTransform" ? (authoredAttributeName ?? "transform") : authoredAttributeName;
+      kind === "animateTransform"
+        ? (authoredAttributeName ?? "transform")
+        : kind === "animateMotion"
+          ? "motion"
+          : authoredAttributeName;
     const attributeSpec = effectiveAttributeName
       ? resolveAnimationAttribute(effectiveAttributeName, attributeType)
       : undefined;
-    const attributeName = attributeSpec?.canonicalName;
+    const attributeName = kind === "animateMotion" ? "motion" : attributeSpec?.canonicalName;
     if ((kind === "animate" || kind === "set" || kind === "animateTransform") && !authoredAttributeName)
       diagnostic(
         diagnostics,
@@ -631,6 +653,11 @@ export function buildAnimationProgram(
       ...(keySplinesSource === undefined ? {} : { keySplines: parseKeySplines(keySplinesSource) ?? [] }),
       ...(keyPointsSource === undefined ? {} : { keyPoints: parseKeyTimes(keyPointsSource) ?? [] }),
     };
+    const parsedMotion =
+      kind === "animateMotion"
+        ? parseMotionDefinition(element, definitions, duplicateIds, targetSnapshot?.context ?? animationValueContext)
+        : undefined;
+    if (parsedMotion) diagnostics.push(...parsedMotion.diagnostics);
     const dependencies = [...timing.begin, ...timing.end]
       .filter(
         (time): time is Extract<AnimationTime, { type: "syncbase" | "repeat" }> =>
@@ -644,6 +671,7 @@ export function buildAnimationProgram(
       ...(target ? { target } : {}),
       kind,
       ...(kind === "animateTransform" && transformType ? { transformType } : {}),
+      ...(parsedMotion?.motion ? { motion: parsedMotion.motion } : {}),
       ...(authoredAttributeName ? { authoredAttributeName } : {}),
       ...(attributeName ? { attributeName } : {}),
       attributeType,
@@ -813,7 +841,7 @@ export function buildAnimationProgram(
         );
       }
     }
-    if (value.family === "unsupported")
+    if (value.family === "unsupported" && kind !== "animateMotion")
       diagnostic(
         diagnostics,
         element,
@@ -831,7 +859,7 @@ export function buildAnimationProgram(
         `One or more ${transformType} values have invalid syntax or arity.`,
         property(element, "values") === undefined ? "from" : "values",
       );
-    if (value.family !== "unsupported") {
+    if (value.family !== "unsupported" && kind !== "animateMotion") {
       if (value.form === "invalid")
         diagnostic(
           diagnostics,
@@ -872,7 +900,44 @@ export function buildAnimationProgram(
           composition.additive === "sum" ? "additive" : "accumulate",
         );
     }
-    if (runtimeSupport === "pending" && value.family !== "unsupported")
+    if (kind === "animateMotion" && composition.keyPoints) {
+      if (!composition.keyTimes || composition.keyPoints.length !== composition.keyTimes.length)
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-animation-motion-key-points",
+          "animateMotion keyPoints requires a matching keyTimes entry for every point.",
+          "keyPoints",
+        );
+      if (composition.calcMode === "spline" && composition.keySplines?.length !== composition.keyPoints.length - 1)
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-animation-motion-key-splines",
+          "Spline motion requires one keySpline per keyPoints interval.",
+          "keySplines",
+        );
+    }
+    if (kind === "animateMotion" && parsedMotion?.motion && !composition.keyPoints) {
+      const pointCount = parsedMotion.motion.keyDistances.length;
+      if (composition.keyTimes && composition.keyTimes.length !== pointCount)
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-animation-motion-key-times",
+          `Motion path has ${pointCount} authored points, so keyTimes must contain ${pointCount} entries.`,
+          "keyTimes",
+        );
+      if (composition.calcMode === "spline" && composition.keySplines?.length !== pointCount - 1)
+        diagnostic(
+          diagnostics,
+          element,
+          "invalid-animation-motion-key-splines",
+          `Motion path has ${pointCount - 1} intervals, so keySplines must contain ${pointCount - 1} entries.`,
+          "keySplines",
+        );
+    }
+    if (runtimeSupport === "pending" && (value.family !== "unsupported" || kind === "animateMotion"))
       diagnostic(
         diagnostics,
         element,

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -489,6 +489,45 @@ function buildViewNodes(
     base: TypedAnimationValue,
   ): string | undefined => animatedValueExpressionFromAnimations(animationsFor(node, attributeName), base);
 
+  const animatedMotionExpression = (node: RenderNode): string | undefined => {
+    const animations = directAnimationsFor(node, "motion");
+    if (animations.length === 0) return undefined;
+    let expression = "CGAffineTransform.identity";
+    for (const animation of animations) {
+      const motion = animation.motion;
+      if (!motion) continue;
+      const intervals = context.animationIntervals.get(animation.stableId) ?? [];
+      const intervalLiteral = intervals
+        .map((interval) => `(begin: ${swiftDuration(interval.begin)}, end: ${swiftDuration(interval.end)})`)
+        .join(", ");
+      const duration =
+        animation.timing.duration.type === "seconds" ? animation.timing.duration.seconds : Number.POSITIVE_INFINITY;
+      const repeatingDuration = computeSMILRepeatingDuration(animation.timing);
+      const points = motion.points
+        .map(
+          (point) =>
+            `${context.rootName}.SVGAnimationMotionPoint(x: ${formatNumber(point.x)}, y: ${formatNumber(point.y)}, distance: ${formatNumber(point.distance)}, move: ${point.move})`,
+        )
+        .join(", ");
+      const keyTimes = animation.composition.keyTimes?.map((value) => formatNumber(value)).join(", ") ?? "";
+      const keyPoints = animation.composition.keyPoints?.map((value) => formatNumber(value)).join(", ") ?? "";
+      const pathPoints = motion.keyDistances
+        .map((distance) => formatNumber(motion.length <= 1e-12 ? 0 : distance / motion.length))
+        .join(", ");
+      const keySplines =
+        animation.composition.keySplines
+          ?.map(
+            (spline) =>
+              `(x1: ${formatNumber(spline.x1)}, y1: ${formatNumber(spline.y1)}, x2: ${formatNumber(spline.x2)}, y2: ${formatNumber(spline.y2)})`,
+          )
+          .join(", ") ?? "";
+      const rotateMode = motion.rotate.type === "auto" ? (motion.rotate.reverse ? "autoReverse" : "auto") : "angle";
+      const angle = motion.rotate.type === "angle" ? motion.rotate.degrees : 0;
+      expression = `${context.rootName}.svgAnimatedMotion(documentTime: documentTime, intervals: [${intervalLiteral}], duration: ${swiftDuration(duration)}, repeatingDuration: ${swiftDuration(repeatingDuration)}, points: [${points}], length: ${formatNumber(motion.length)}, pathPoints: [${pathPoints}], rotate: .${rotateMode}, angle: ${formatNumber(angle)}, calcMode: .${animation.composition.calcMode}, keyTimes: [${keyTimes}], keyPoints: [${keyPoints}], keySplines: [${keySplines}], additive: ${animation.composition.additive === "sum" ? "true" : "false"}, accumulate: ${animation.composition.accumulate === "sum" ? "true" : "false"}, underlying: ${expression}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"})`;
+    }
+    return expression === "CGAffineTransform.identity" ? undefined : expression;
+  };
+
   const transformCorrectionExpression = (
     node: RenderNode,
     transforms: RenderNode["transform"][],
@@ -512,10 +551,11 @@ function buildViewNodes(
       ],
     };
     const animatedBase = animatedValueExpression(node, "transform", baseValue);
-    if (!animatedBase && !animatedSuffix) return undefined;
+    const animatedMotion = animatedMotionExpression(node);
+    if (!animatedBase && !animatedSuffix && !animatedMotion) return undefined;
     const ancestors = transforms.reduce(multiplyTransforms, IDENTITY_TRANSFORM);
     const staticTransform = multiplyTransforms(ancestors, node.transform);
-    return `${context.rootName}.svgAnimatedTransformCorrection(animatedBase: ${animatedBase ? `${context.rootName}.svgAnimationTransform(${animatedBase})` : swiftTransform(metadata.base)}, animatedSuffix: ${animatedSuffix ?? swiftTransform(metadata.suffix)}, ancestors: ${swiftTransform(ancestors)}, staticTransform: ${swiftTransform(staticTransform)}, outputSize: proxy.size, coordinateSpace: CGRect(x: ${formatNumber(context.options.viewBox.x)}, y: ${formatNumber(context.options.viewBox.y)}, width: ${formatNumber(context.options.viewBox.width)}, height: ${formatNumber(context.options.viewBox.height)}))`;
+    return `${context.rootName}.svgAnimatedTransformCorrection(animatedBase: ${animatedBase ? `${context.rootName}.svgAnimationTransform(${animatedBase})` : swiftTransform(metadata.base)}, animatedMotion: ${animatedMotion ?? "CGAffineTransform.identity"}, animatedSuffix: ${animatedSuffix ?? swiftTransform(metadata.suffix)}, ancestors: ${swiftTransform(ancestors)}, staticTransform: ${swiftTransform(staticTransform)}, outputSize: proxy.size, coordinateSpace: CGRect(x: ${formatNumber(context.options.viewBox.x)}, y: ${formatNumber(context.options.viewBox.y)}, width: ${formatNumber(context.options.viewBox.width)}, height: ${formatNumber(context.options.viewBox.height)}))`;
   };
 
   const numericBase = (
@@ -4382,6 +4422,8 @@ function createView(
         "enum SVGAnimationForm { case values, fromto, fromby, by, to }",
         "enum SVGAnimationCalcMode { case discrete, linear, paced, spline }",
         "enum SVGAnimationClamp { case none, unit, nonnegative, integer }",
+        "enum SVGAnimationMotionRotate { case auto, autoReverse, angle }",
+        "struct SVGAnimationMotionPoint { let x: Double; let y: Double; let distance: Double; let move: Bool }",
         "enum SVGAnimationRuntimeValueKind { case number, integer, opacity, length, angle, color, numberList, lengthList, points, paintColor, path, viewBox, transform, discrete }",
         "struct SVGAnimationRuntimeValue {",
         `${indentation}let kind: SVGAnimationRuntimeValueKind`,
@@ -4565,11 +4607,50 @@ function createView(
         `${indentation}return svgMultiplyTransform(animatedOutput, staticOutput.inverted())`,
         "}",
         "",
-        "private static func svgAnimatedTransformCorrection(animatedBase: CGAffineTransform, animatedSuffix: CGAffineTransform, ancestors: CGAffineTransform, staticTransform: CGAffineTransform, outputSize: CGSize, coordinateSpace: CGRect) -> CGAffineTransform {",
-        `${indentation}let animatedUser = svgMultiplyTransform(ancestors, svgMultiplyTransform(animatedBase, animatedSuffix))`,
+        "private static func svgAnimatedTransformCorrection(animatedBase: CGAffineTransform, animatedMotion: CGAffineTransform, animatedSuffix: CGAffineTransform, ancestors: CGAffineTransform, staticTransform: CGAffineTransform, outputSize: CGSize, coordinateSpace: CGRect) -> CGAffineTransform {",
+        `${indentation}let target = svgMultiplyTransform(animatedBase, svgMultiplyTransform(animatedMotion, animatedSuffix))`,
+        `${indentation}let animatedUser = svgMultiplyTransform(ancestors, target)`,
         `${indentation}let animatedOutput = svgOutputTransform(animatedUser, size: outputSize, coordinateSpace: coordinateSpace)`,
         `${indentation}let staticOutput = svgOutputTransform(staticTransform, size: outputSize, coordinateSpace: coordinateSpace)`,
         `${indentation}return svgMultiplyTransform(animatedOutput, staticOutput.inverted())`,
+        "}",
+        "",
+        "private static func svgMotionSample(points: [SVGAnimationMotionPoint], length: Double, fraction: Double) -> (x: Double, y: Double, angle: Double) {",
+        `${indentation}guard let first = points.first else { return (0, 0, 0) }`,
+        `${indentation}let distance = min(max(0, fraction), 1) * max(0, length)`,
+        `${indentation}var low = 0; var high = points.count - 1`,
+        `${indentation}while low < high { let middle = (low + high) / 2; if points[middle].distance < distance - 0.000000000001 { low = middle + 1 } else { high = middle } }`,
+        `${indentation}var upper = low`,
+        `${indentation}while upper + 1 < points.count && points[upper + 1].distance <= distance + 0.000000000001 { upper += 1 }`,
+        `${indentation}func usable(_ index: Int) -> Bool { index > 0 && index < points.count && !points[index].move && hypot(points[index].x - points[index - 1].x, points[index].y - points[index - 1].y) > 0.000000000001 }`,
+        `${indentation}var segment: Int?`,
+        `${indentation}var forward = max(1, points[upper].distance <= distance + 0.000000000001 ? upper + 1 : upper)`,
+        `${indentation}while forward < points.count { if usable(forward) { segment = forward; break }; forward += 1 }`,
+        `${indentation}if segment == nil { var backward = min(points.count - 1, low); while backward >= 1 { if usable(backward) { segment = backward; break }; backward -= 1 } }`,
+        `${indentation}guard let segment else { return (points[upper].x, points[upper].y, 0) }`,
+        `${indentation}let start = points[segment - 1]; let end = points[segment]`,
+        `${indentation}let span = end.distance - start.distance`,
+        `${indentation}let progress = span <= 0.000000000001 ? 0 : min(1, max(0, (distance - start.distance) / span))`,
+        `${indentation}return (start.x + (end.x - start.x) * progress, start.y + (end.y - start.y) * progress, atan2(end.y - start.y, end.x - start.x))`,
+        "}",
+        "",
+        "private static func svgMotionTransform(points: [SVGAnimationMotionPoint], length: Double, fraction: Double, rotate: SVGAnimationMotionRotate, angle: Double) -> CGAffineTransform {",
+        `${indentation}let sample = svgMotionSample(points: points, length: length, fraction: fraction)`,
+        `${indentation}let radians: Double`,
+        `${indentation}switch rotate { case .auto: radians = sample.angle; case .autoReverse: radians = sample.angle + .pi; case .angle: radians = angle * .pi / 180 }`,
+        `${indentation}let translation = CGAffineTransform(translationX: sample.x, y: sample.y)`,
+        `${indentation}return svgMultiplyTransform(translation, CGAffineTransform(rotationAngle: radians))`,
+        "}",
+        "",
+        "private static func svgAnimatedMotion(documentTime: Double, intervals: [(begin: Double, end: Double)], duration: Double, repeatingDuration: Double, points: [SVGAnimationMotionPoint], length: Double, pathPoints: [Double], rotate: SVGAnimationMotionRotate, angle: Double, calcMode: SVGAnimationCalcMode, keyTimes: [Double], keyPoints: [Double], keySplines: [(x1: Double, y1: Double, x2: Double, y2: Double)], additive: Bool, accumulate: Bool, underlying: CGAffineTransform, freeze: Bool) -> CGAffineTransform {",
+        `${indentation}let timing = svgTimingSample(documentTime: documentTime, intervals: intervals, duration: duration, repeatingDuration: repeatingDuration, freeze: freeze)`,
+        `${indentation}if timing.state == .inactive || timing.state == .completed { return underlying }`,
+        `${indentation}guard let progress = timing.simpleProgress else { return underlying }`,
+        `${indentation}let controlPoints = keyPoints.count >= 2 ? keyPoints : pathPoints`,
+        `${indentation}let fraction = calcMode == .paced && keyPoints.isEmpty ? progress : svgAnimationValueSample(progress: progress, values: controlPoints, form: .values, calcMode: calcMode, keyTimes: keyTimes, keySplines: keySplines, additive: false, accumulate: false, repeatIteration: 0, clamp: .unit, underlying: 0)`,
+        `${indentation}var effect = svgMotionTransform(points: points, length: length, fraction: fraction, rotate: rotate, angle: angle)`,
+        `${indentation}if accumulate && timing.repeatIteration > 0 { let endpoint = svgMotionTransform(points: points, length: length, fraction: 1, rotate: rotate, angle: angle); for _ in 0..<timing.repeatIteration { effect = svgMultiplyTransform(effect, endpoint) } }`,
+        `${indentation}return additive ? svgMultiplyTransform(underlying, effect) : effect`,
         "}",
         "",
         "private static func svgAnimationColor(_ value: SVGAnimationRuntimeValue) -> Color {",

--- a/packages/svg-to-swiftui-core/src/renderTree/motion.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/motion.ts
@@ -1,0 +1,361 @@
+import type { ElementNode } from "svg-parser";
+import { parseSVGLength, resolveSVGLength } from "../lengths";
+import type { AnimationValueContext } from "./animationValues";
+import { measureGeometryPath } from "./pathMetrics";
+import type { Geometry, RenderDiagnostic, RenderTextPathPoint, SourceLocation } from "./types";
+
+export type MotionRotate = { type: "auto"; reverse: boolean } | { type: "angle"; degrees: number };
+
+export interface MotionDefinition {
+  points: readonly RenderTextPathPoint[];
+  keyDistances: readonly number[];
+  length: number;
+  authoredLength?: number;
+  rotate: MotionRotate;
+  source: "mpath" | "path" | "points";
+  referenceChain?: readonly string[];
+}
+
+const GEOMETRY_TAGS = new Set(["path", "circle", "ellipse", "rect", "line", "polyline", "polygon"]);
+
+function property(element: ElementNode, name: string): string | undefined {
+  const value = element.properties?.[name];
+  return value === undefined || value === null ? undefined : String(value).trim();
+}
+
+function source(element: ElementNode): SourceLocation {
+  const id = property(element, "id");
+  return { element: element.tagName ?? "unknown", ...(id ? { id } : {}) };
+}
+
+function warning(
+  element: ElementNode,
+  code: string,
+  message: string,
+  attribute?: string,
+  chain?: readonly string[],
+): RenderDiagnostic {
+  return {
+    code,
+    message,
+    severity: "warning",
+    source: source(element),
+    ...(attribute ? { attribute } : {}),
+    ...(chain ? { referenceChain: chain } : {}),
+  };
+}
+
+function coordinate(raw: string, axis: "horizontal" | "vertical", context: AnimationValueContext): number | undefined {
+  try {
+    const value = parseSVGLength(raw);
+    const resolved = resolveSVGLength(value, {
+      ...context.length,
+      axis,
+      percentageBasis: axis === "horizontal" ? "viewport-width" : "viewport-height",
+    });
+    return typeof resolved === "number" && Number.isFinite(resolved) ? resolved : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function pair(raw: string, context: AnimationValueContext): { x: number; y: number } | undefined {
+  const normalized = raw
+    .trim()
+    .replace(/^\(\s*/, "")
+    .replace(/\s*\)$/, "");
+  const tokens = normalized.split(/(?:\s*,\s*|\s+)/).filter(Boolean);
+  if (tokens.length !== 2) return undefined;
+  const x = coordinate(tokens[0]!, "horizontal", context);
+  const y = coordinate(tokens[1]!, "vertical", context);
+  return x === undefined || y === undefined ? undefined : { x, y };
+}
+
+function rawLength(
+  element: ElementNode,
+  name: string,
+  axis: "horizontal" | "vertical",
+  context: AnimationValueContext,
+  fallback = 0,
+): number | undefined {
+  const value = property(element, name);
+  return value === undefined ? fallback : coordinate(value, axis, context);
+}
+
+function geometryFor(element: ElementNode, context: AnimationValueContext): Geometry | undefined {
+  const pathLength = property(element, "pathLength");
+  const calibrated = pathLength === undefined ? {} : { pathLength };
+  switch ((element.tagName ?? "").toLowerCase()) {
+    case "path":
+      return { type: "path", d: property(element, "d") ?? "", ...calibrated };
+    case "line": {
+      const x1 = rawLength(element, "x1", "horizontal", context);
+      const y1 = rawLength(element, "y1", "vertical", context);
+      const x2 = rawLength(element, "x2", "horizontal", context);
+      const y2 = rawLength(element, "y2", "vertical", context);
+      return x1 === undefined || y1 === undefined || x2 === undefined || y2 === undefined
+        ? undefined
+        : { type: "line", x1, y1, x2, y2, ...calibrated };
+    }
+    case "circle": {
+      const cx = rawLength(element, "cx", "horizontal", context);
+      const cy = rawLength(element, "cy", "vertical", context);
+      const r = rawLength(element, "r", "horizontal", context);
+      return cx === undefined || cy === undefined || r === undefined || r < 0
+        ? undefined
+        : { type: "circle", cx, cy, r, ...calibrated };
+    }
+    case "ellipse": {
+      const cx = rawLength(element, "cx", "horizontal", context);
+      const cy = rawLength(element, "cy", "vertical", context);
+      const rx = rawLength(element, "rx", "horizontal", context);
+      const ry = rawLength(element, "ry", "vertical", context);
+      return cx === undefined || cy === undefined || rx === undefined || ry === undefined || rx < 0 || ry < 0
+        ? undefined
+        : { type: "ellipse", cx, cy, rx, ry, ...calibrated };
+    }
+    case "rect": {
+      const x = rawLength(element, "x", "horizontal", context);
+      const y = rawLength(element, "y", "vertical", context);
+      const width = rawLength(element, "width", "horizontal", context);
+      const height = rawLength(element, "height", "vertical", context);
+      const rx = property(element, "rx") === undefined ? undefined : rawLength(element, "rx", "horizontal", context);
+      const ry = property(element, "ry") === undefined ? undefined : rawLength(element, "ry", "vertical", context);
+      return x === undefined ||
+        y === undefined ||
+        width === undefined ||
+        height === undefined ||
+        width < 0 ||
+        height < 0
+        ? undefined
+        : {
+            type: "rect",
+            x,
+            y,
+            width,
+            height,
+            ...(rx === undefined ? {} : { rx }),
+            ...(ry === undefined ? {} : { ry }),
+            ...calibrated,
+          };
+    }
+    case "polyline":
+    case "polygon":
+      return {
+        type: element.tagName!.toLowerCase() as "polyline" | "polygon",
+        points: property(element, "points") ?? "",
+        ...calibrated,
+      };
+    default:
+      return undefined;
+  }
+}
+
+function parseRotate(raw: string | undefined): MotionRotate | undefined {
+  if (raw === undefined || raw === "") return { type: "angle", degrees: 0 };
+  if (raw === "auto") return { type: "auto", reverse: false };
+  if (raw === "auto-reverse") return { type: "auto", reverse: true };
+  const match = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?)(deg|rad|grad|turn)?$/i.exec(raw);
+  if (!match) return undefined;
+  const value = Number(match[1]);
+  const degrees =
+    match[2]?.toLowerCase() === "rad"
+      ? (value * 180) / Math.PI
+      : match[2]?.toLowerCase() === "grad"
+        ? value * 0.9
+        : match[2]?.toLowerCase() === "turn"
+          ? value * 360
+          : value;
+  return Number.isFinite(degrees) ? { type: "angle", degrees } : undefined;
+}
+
+function pointsGeometry(element: ElementNode, context: AnimationValueContext): Geometry | undefined {
+  const values = property(element, "values")
+    ?.split(";")
+    .map((item) => pair(item, context));
+  let points: Array<{ x: number; y: number }> | undefined;
+  if (values) {
+    if (values.some((item) => item === undefined)) return undefined;
+    points = values as Array<{ x: number; y: number }>;
+  } else {
+    const from = property(element, "from") === undefined ? undefined : pair(property(element, "from")!, context);
+    const to = property(element, "to") === undefined ? undefined : pair(property(element, "to")!, context);
+    const by = property(element, "by") === undefined ? undefined : pair(property(element, "by")!, context);
+    if (
+      (property(element, "from") !== undefined && !from) ||
+      (property(element, "to") !== undefined && !to) ||
+      (property(element, "by") !== undefined && !by)
+    )
+      return undefined;
+    if (from && to) points = [from, to];
+    else if (from && by) points = [from, { x: from.x + by.x, y: from.y + by.y }];
+    else if (to) points = [{ x: 0, y: 0 }, to];
+    else if (by) points = [{ x: 0, y: 0 }, by];
+  }
+  if (!points || points.length === 0) return undefined;
+  return { type: "polyline", points: points.map(({ x, y }) => `${x},${y}`).join(" ") };
+}
+
+export function parseMotionDefinition(
+  element: ElementNode,
+  definitions: ReadonlyMap<string, ElementNode>,
+  duplicateIds: ReadonlySet<string>,
+  context: AnimationValueContext,
+): { motion?: MotionDefinition; diagnostics: RenderDiagnostic[] } {
+  const diagnostics: RenderDiagnostic[] = [];
+  const rotate = parseRotate(property(element, "rotate"));
+  if (!rotate)
+    diagnostics.push(
+      warning(
+        element,
+        "invalid-animation-motion-rotate",
+        `Invalid animateMotion rotate value '${property(element, "rotate")}'.`,
+        "rotate",
+      ),
+    );
+  const origin = property(element, "origin");
+  if (origin !== undefined && origin !== "default")
+    diagnostics.push(
+      warning(
+        element,
+        "unsupported-animation-motion-origin",
+        `SVG only defines origin="default"; '${origin}' is a host/CSS interpretation and is ignored.`,
+        "origin",
+      ),
+    );
+
+  let geometry: Geometry | undefined;
+  let motionSource: MotionDefinition["source"] = "points";
+  let referenceChain: string[] | undefined;
+  const mpath = element.children.find(
+    (child): child is ElementNode =>
+      typeof child !== "string" && child.type === "element" && child.tagName?.toLowerCase() === "mpath",
+  );
+  if (mpath) {
+    motionSource = "mpath";
+    const visited = new Set<string>();
+    referenceChain = [];
+    let cursor: ElementNode | undefined = mpath;
+    while (cursor?.tagName?.toLowerCase() === "mpath") {
+      const href = property(cursor, "href") ?? property(cursor, "xlink:href");
+      const match = href ? /^#([^\s]+)$/.exec(href) : undefined;
+      if (!href || !match) {
+        diagnostics.push(
+          warning(
+            element,
+            href ? "external-animation-motion-path" : "missing-animation-motion-path-reference",
+            href ? `mpath reference '${href}' must be a local #id.` : "mpath requires href or xlink:href.",
+            "href",
+            referenceChain,
+          ),
+        );
+        cursor = undefined;
+        break;
+      }
+      const id = match[1]!;
+      referenceChain.push(`#${id}`);
+      if (visited.has(id)) {
+        diagnostics.push(
+          warning(
+            element,
+            "cyclic-animation-motion-path-reference",
+            `Cyclic mpath reference: ${referenceChain.join(" -> ")}.`,
+            "href",
+            referenceChain,
+          ),
+        );
+        cursor = undefined;
+        break;
+      }
+      visited.add(id);
+      if (duplicateIds.has(id)) {
+        diagnostics.push(
+          warning(
+            element,
+            "duplicate-animation-motion-path-id",
+            `mpath reference #${id} is ambiguous.`,
+            "href",
+            referenceChain,
+          ),
+        );
+        cursor = undefined;
+        break;
+      }
+      cursor = definitions.get(id);
+      if (!cursor) {
+        diagnostics.push(
+          warning(
+            element,
+            "missing-animation-motion-path-target",
+            `mpath references missing element #${id}.`,
+            "href",
+            referenceChain,
+          ),
+        );
+        break;
+      }
+    }
+    if (cursor && !GEOMETRY_TAGS.has(cursor.tagName?.toLowerCase() ?? ""))
+      diagnostics.push(
+        warning(
+          element,
+          "invalid-animation-motion-path-target",
+          `mpath target <${cursor.tagName}> is not a geometry element.`,
+          "href",
+          referenceChain,
+        ),
+      );
+    else if (cursor) geometry = geometryFor(cursor, context);
+  } else if (property(element, "path") !== undefined) {
+    motionSource = "path";
+    geometry = { type: "path", d: property(element, "path")! };
+  } else geometry = pointsGeometry(element, context);
+
+  if (!geometry) {
+    if (diagnostics.length === 0)
+      diagnostics.push(
+        warning(
+          element,
+          "missing-animation-motion-values",
+          "animateMotion requires mpath, path, values, from/to, from/by, to, or by.",
+        ),
+      );
+    return { diagnostics };
+  }
+  try {
+    const metrics = measureGeometryPath(geometry);
+    if (metrics.points.length === 0 || metrics.length <= 1e-12) {
+      diagnostics.push(
+        warning(
+          element,
+          "empty-animation-motion-path",
+          "The resolved motion path has zero length; the animation has no effect.",
+        ),
+      );
+      return { diagnostics };
+    }
+    return {
+      motion: {
+        points: metrics.points,
+        keyDistances: metrics.keyDistances,
+        length: metrics.length,
+        ...(metrics.authoredLength ? { authoredLength: metrics.authoredLength } : {}),
+        rotate: rotate ?? { type: "angle", degrees: 0 },
+        source: motionSource,
+        ...(referenceChain ? { referenceChain } : {}),
+      },
+      diagnostics,
+    };
+  } catch (error) {
+    diagnostics.push(
+      warning(
+        element,
+        "invalid-animation-motion-path",
+        `Invalid motion path: ${error instanceof Error ? error.message : String(error)}.`,
+        motionSource === "path" ? "path" : "href",
+        referenceChain,
+      ),
+    );
+    return { diagnostics };
+  }
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/pathMetrics.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/pathMetrics.ts
@@ -10,10 +10,23 @@ interface Point {
 
 export interface PathMetrics {
   points: RenderTextPathPoint[];
+  /** Distances at authored segment endpoints; internal move commands are excluded. */
+  keyDistances: number[];
   length: number;
   closed: boolean;
   authoredLength?: number;
 }
+
+export interface PathMetricSample {
+  point: Point;
+  /** Directional tangent in radians in the path's user coordinate system. */
+  angle: number;
+  /** Index of the flattened segment used for the sample. */
+  segment: number;
+}
+
+export const PATH_METRIC_MAX_DEPTH = 18;
+export const PATH_METRIC_MAX_POINTS = 131_072;
 
 const IDENTITY: AffineTransform = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
 
@@ -47,7 +60,7 @@ function flattenQuadratic(
   output: Point[],
   depth = 0,
 ): void {
-  if (depth >= 18 || pointLineDistance(control, start, end) <= tolerance) {
+  if (depth >= PATH_METRIC_MAX_DEPTH || pointLineDistance(control, start, end) <= tolerance) {
     output.push(end);
     return;
   }
@@ -68,7 +81,7 @@ function flattenCubic(
   depth = 0,
 ): void {
   const flatness = Math.max(pointLineDistance(control1, start, end), pointLineDistance(control2, start, end));
-  if (depth >= 18 || flatness <= tolerance) {
+  if (depth >= PATH_METRIC_MAX_DEPTH || flatness <= tolerance) {
     output.push(end);
     return;
   }
@@ -120,6 +133,7 @@ export function measureGeometryPath(
   const commands = new SVGPathData(pathData(geometry)).toAbs().normalizeHVZ(false, true, true).normalizeST().aToC()
     .commands as SVGCommand[];
   const sampled: Array<{ point: Point; move: boolean }> = [];
+  const authoredPointIndexes: number[] = [];
   let current: Point = { x: 0, y: 0 };
   let subpathStart: Point = current;
   let subpaths = 0;
@@ -132,10 +146,15 @@ export function measureGeometryPath(
     currentClosed = false;
     current = point;
     subpathStart = point;
+    if (sampled.length >= PATH_METRIC_MAX_POINTS) throw new Error("SVG path metric point limit exceeded.");
     sampled.push({ point, move: true });
+    if (subpaths === 1) authoredPointIndexes.push(sampled.length - 1);
   };
   const append = (points: Point[]) => {
-    for (const point of points) sampled.push({ point, move: false });
+    for (const point of points) {
+      if (sampled.length >= PATH_METRIC_MAX_POINTS) throw new Error("SVG path metric point limit exceeded.");
+      sampled.push({ point, move: false });
+    }
     if (points.length > 0) current = points[points.length - 1]!;
   };
 
@@ -146,6 +165,7 @@ export function measureGeometryPath(
         break;
       case SVGPathData.LINE_TO:
         append([transformed({ x: command.x, y: command.y }, matrix)]);
+        authoredPointIndexes.push(sampled.length - 1);
         break;
       case SVGPathData.QUAD_TO: {
         const points: Point[] = [];
@@ -157,6 +177,7 @@ export function measureGeometryPath(
           points,
         );
         append(points);
+        authoredPointIndexes.push(sampled.length - 1);
         break;
       }
       case SVGPathData.CURVE_TO: {
@@ -170,10 +191,12 @@ export function measureGeometryPath(
           points,
         );
         append(points);
+        authoredPointIndexes.push(sampled.length - 1);
         break;
       }
       case SVGPathData.CLOSE_PATH:
         if (Math.hypot(current.x - subpathStart.x, current.y - subpathStart.y) > 1e-12) append([subpathStart]);
+        if (sampled.length > 0) authoredPointIndexes.push(sampled.length - 1);
         currentClosed = true;
         break;
     }
@@ -190,8 +213,54 @@ export function measureGeometryPath(
   const authored = Number(geometry.pathLength);
   return {
     points,
+    keyDistances: authoredPointIndexes.map((index) => points[index]?.distance ?? 0),
     length,
     closed: subpaths === 1 && allClosed,
     ...(Number.isFinite(authored) && authored > 0 ? { authoredLength: authored } : {}),
+  };
+}
+
+function nonZeroSegment(points: readonly RenderTextPathPoint[], start: number, direction: -1 | 1): number | undefined {
+  let index = start;
+  while (index >= 1 && index < points.length) {
+    const current = points[index]!;
+    const previous = points[index - 1]!;
+    if (!current.move && Math.hypot(current.x - previous.x, current.y - previous.y) > 1e-12) return index;
+    index += direction;
+  }
+  return undefined;
+}
+
+/**
+ * Sample flattened metrics without mutable cursors, so random-access frame
+ * rendering is bit-for-bit stable. At discontinuities the outgoing subpath is
+ * selected; a zero-length neighborhood searches forward, then backward.
+ */
+export function samplePathMetrics(metrics: PathMetrics, authoredDistance: number): PathMetricSample | undefined {
+  const { points } = metrics;
+  if (points.length === 0) return undefined;
+  const scale = metrics.authoredLength ? metrics.length / metrics.authoredLength : 1;
+  const distance = Math.min(metrics.length, Math.max(0, authoredDistance * scale));
+  let low = 0;
+  let high = points.length - 1;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (points[middle]!.distance < distance - 1e-12) low = middle + 1;
+    else high = middle;
+  }
+  let upper = low;
+  while (upper + 1 < points.length && points[upper + 1]!.distance <= distance + 1e-12) upper += 1;
+  const forwardStart = points[upper]!.distance <= distance + 1e-12 ? upper + 1 : upper;
+  let segment = nonZeroSegment(points, Math.max(1, forwardStart), 1);
+  if (segment === undefined) segment = nonZeroSegment(points, Math.min(points.length - 1, low), -1);
+  if (segment === undefined) return { point: { x: points[upper]!.x, y: points[upper]!.y }, angle: 0, segment: upper };
+  const end = points[segment]!;
+  const start = points[segment - 1]!;
+  const span = end.distance - start.distance;
+  const progress = span <= 1e-12 ? 0 : Math.min(1, Math.max(0, (distance - start.distance) / span));
+  return {
+    point: { x: start.x + (end.x - start.x) * progress, y: start.y + (end.y - start.y) * progress },
+    angle: Math.atan2(end.y - start.y, end.x - start.x),
+    segment,
   };
 }

--- a/packages/svg-to-swiftui-core/src/tests/animation.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/animation.test.ts
@@ -162,6 +162,64 @@ describe("typed SVG animation program", () => {
       ]),
     );
   });
+
+  test("parses animateMotion paths, point pairs, mpath shapes, rotation, and keyPoints", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 100 60">
+        <defs><path id="curve" d="M0 0 C20 0 20 30 50 30" pathLength="10"/><circle id="ring" cx="30" cy="30" r="12"/></defs>
+        <g id="path-target"><animateMotion path="M0 0 L20 0 L20 20" rotate="auto" keyTimes="0;.4;1" keyPoints="0;.25;1" calcMode="spline" keySplines=".4 0 .6 1;.4 0 .6 1" dur="2s"/></g>
+        <rect id="mpath-target"><animateMotion rotate="auto-reverse" dur="2s"><mpath href="#curve"/></animateMotion></rect>
+        <g id="shape-target"><animateMotion rotate="1.57079632679rad" dur="2s"><mpath href="#ring"/></animateMotion></g>
+        <g id="points-target"><animateMotion from="10%, 1em" by="20, 10" dur="2s"/></g>
+      </svg>`);
+    expect(document.animationProgram.animations).toHaveLength(4);
+    expect(document.animationProgram.animations[0]).toMatchObject({
+      kind: "animateMotion",
+      attributeName: "motion",
+      runtimeSupport: "typed",
+      motion: { source: "path", rotate: { type: "auto", reverse: false } },
+    });
+    expect(document.animationProgram.animations[1]).toMatchObject({
+      runtimeSupport: "typed",
+      motion: {
+        source: "mpath",
+        authoredLength: 10,
+        rotate: { type: "auto", reverse: true },
+        referenceChain: ["#curve"],
+      },
+    });
+    expect(document.animationProgram.animations[2]?.motion?.rotate.type).toBe("angle");
+    expect((document.animationProgram.animations[2]?.motion?.rotate as { degrees: number }).degrees).toBeCloseTo(90);
+    expect(document.animationProgram.animations[3]?.motion?.points[0]).toMatchObject({ x: 10, y: 16 });
+  });
+
+  test("diagnoses invalid, missing, external, wrong-type, empty, cyclic, rotate, origin, and keyPoint motion", () => {
+    const result = convertWithDiagnostics(`
+      <svg viewBox="0 0 20 20">
+        <defs><g id="wrong"/><path id="empty" d="M0 0"/><mpath id="a" href="#b"/><mpath id="b" href="#a"/></defs>
+        <g><animateMotion dur="1s"><mpath/></animateMotion></g>
+        <g><animateMotion dur="1s"><mpath href="https://example.com/path"/></animateMotion></g>
+        <g><animateMotion dur="1s"><mpath href="#missing"/></animateMotion></g>
+        <g><animateMotion dur="1s"><mpath href="#wrong"/></animateMotion></g>
+        <g><animateMotion dur="1s"><mpath href="#empty"/></animateMotion></g>
+        <g><animateMotion dur="1s"><mpath href="#a"/></animateMotion></g>
+        <g><animateMotion path="bad" rotate="sideways" origin="layout" keyTimes="0;1" keyPoints="0;.5;1" dur="1s"/></g>
+      </svg>`);
+    expect(result.diagnostics.map((item) => item.code)).toEqual(
+      expect.arrayContaining([
+        "missing-animation-motion-path-reference",
+        "external-animation-motion-path",
+        "missing-animation-motion-path-target",
+        "invalid-animation-motion-path-target",
+        "empty-animation-motion-path",
+        "cyclic-animation-motion-path-reference",
+        "invalid-animation-motion-path",
+        "invalid-animation-motion-rotate",
+        "unsupported-animation-motion-origin",
+        "invalid-animation-motion-key-points",
+      ]),
+    );
+  });
 });
 
 describe("generated animation clock", () => {
@@ -211,5 +269,21 @@ describe("generated animation clock", () => {
     expect(swift).toContain(".transformEffect(AnimatedTransform.svgAnimatedTransformCorrection");
     expect(swift.match(/svgAnimatedValue\(documentTime: documentTime/g)?.length).toBeGreaterThanOrEqual(2);
     expect(swift).not.toContain("@State private var");
+  });
+
+  test("generates deterministic motion metrics and composes motion after animated transforms", () => {
+    const swift = convert(
+      `<svg viewBox="0 0 100 60"><g transform="scale(1.2)">
+        <animateTransform attributeName="transform" type="rotate" from="0" to="30" dur="2s"/>
+        <animateMotion path="M0 0 C20 0 30 30 60 20" rotate="auto" dur="2s" fill="freeze"/>
+        <path d="M-5 -3 L8 0 L-5 3 Z" fill="orange"/>
+      </g></svg>`,
+      { structName: "AnimatedMotion", strict: true },
+    );
+    expect(swift).toContain("svgAnimatedMotion(documentTime: documentTime");
+    expect(swift).toContain("SVGAnimationMotionPoint(");
+    expect(swift).toContain("animatedMotion: AnimatedMotion.svgAnimatedMotion");
+    expect(swift).toContain("svgMultiplyTransform(animatedBase, svgMultiplyTransform(animatedMotion, animatedSuffix))");
+    expect(swift).toContain(".transformEffect(AnimatedMotion.svgAnimatedTransformCorrection");
   });
 });

--- a/packages/svg-to-swiftui-core/src/tests/pathMetrics.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/pathMetrics.test.ts
@@ -1,4 +1,4 @@
-import { measureGeometryPath } from "../renderTree/pathMetrics";
+import { measureGeometryPath, samplePathMetrics } from "../renderTree/pathMetrics";
 
 describe("text path metrics", () => {
   test("measures lines exactly and keeps disconnected subpaths discontinuous", () => {
@@ -7,6 +7,7 @@ describe("text path metrics", () => {
     expect(metrics.closed).toBe(false);
     expect(metrics.points.filter((point) => point.move)).toHaveLength(2);
     expect(metrics.points[metrics.points.length - 1]?.distance).toBeCloseTo(55);
+    expect(metrics.keyDistances).toEqual([0, 50, 55]);
   });
 
   test("adaptively subdivides curves after transforms and retains pathLength calibration", () => {
@@ -17,6 +18,7 @@ describe("text path metrics", () => {
     expect(metrics.points.length).toBeGreaterThan(20);
     expect(metrics.length).toBeGreaterThan(200);
     expect(metrics.authoredLength).toBe(50);
+    expect(metrics.keyDistances).toHaveLength(2);
   });
 
   test("converts basic shapes, rounded rectangles, and closed paths", () => {
@@ -26,5 +28,20 @@ describe("text path metrics", () => {
     expect(circle.length).toBeCloseTo(2 * Math.PI * 10, 1);
     expect(rounded.closed).toBe(true);
     expect(rounded.points.length).toBeGreaterThan(10);
+  });
+
+  test("samples joins, discontinuities, endpoints, and degenerate neighborhoods deterministically", () => {
+    const metrics = measureGeometryPath({ type: "path", d: "M0 0L10 0L10 10M30 30L30 30L40 30" });
+    expect(samplePathMetrics(metrics, 0)).toMatchObject({ point: { x: 0, y: 0 }, angle: 0 });
+    expect(samplePathMetrics(metrics, 15)?.point).toEqual({ x: 10, y: 5 });
+    expect(samplePathMetrics(metrics, 10)?.angle).toBeCloseTo(Math.PI / 2);
+    expect(samplePathMetrics(metrics, 20)).toMatchObject({ point: { x: 30, y: 30 }, angle: 0 });
+    expect(samplePathMetrics(metrics, 30)?.point).toEqual({ x: 40, y: 30 });
+    expect(samplePathMetrics(metrics, 15)).toEqual(samplePathMetrics(metrics, 15));
+  });
+
+  test("calibrates authored pathLength distances", () => {
+    const metrics = measureGeometryPath({ type: "line", x1: 0, y1: 0, x2: 100, y2: 0, pathLength: "10" });
+    expect(samplePathMetrics(metrics, 2.5)?.point.x).toBeCloseTo(25);
   });
 });


### PR DESCRIPTION
## Summary

- implement typed `<animateMotion>` compilation for `path`, `<mpath>`, `values`, `from`, `to`, and `by`
- resolve local path/basic-shape references with stable missing, external, duplicate, wrong-type, empty, invalid, and cyclic diagnostics
- add bounded adaptive path metrics with authored endpoint distances, `pathLength` calibration, discontinuity handling, and deterministic position/tangent sampling
- support discrete, linear, paced, and spline timing; `keyPoints`; `keyTimes`; auto, auto-reverse, and explicit rotation; additive and cumulative motion
- compose the supplemental motion transform after target/animated transforms and before structural suffix transforms
- add benchmark 7 plus implementation documentation and conformance reporting

## Why

SVG motion animation was parsed but left pending, so generated SwiftUI stayed static. This completes roadmap issue #101 and makes motion paths part of the same exact-time compiler/runtime model as `<animate>`, `<set>`, and `<animateTransform>`.

## Validation

- 387 core tests passed across 32 suites
- core TypeScript typecheck passed
- scoped Biome checks passed
- monorepo production build passed
- animation manifest: 17 fixtures / 207 exact times
- full animation suite: 9 reference probes and 128/128 SwiftUI comparison frames passed
- benchmark 7: 18/18 frames passed; worst outside-tolerance pixels 1.370%
- animation conformance report verified current

Closes #101
