### PR TITLE
Compile CSS keyframe animations

### DIFF
--- a/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
@@ -350,6 +350,39 @@
         ]
       },
       "expectDistinctReferenceFrames": true
+    },
+    "benchmark-08-css-keyframes": {
+      "mode": "comparison",
+      "referenceBackend": "webkit",
+      "width": 160,
+      "height": 120,
+      "expectedMode": "view",
+      "tags": [
+        "alternate",
+        "benchmark-08",
+        "css-keyframes",
+        "custom-properties",
+        "fill-mode",
+        "important",
+        "implicit-endpoints",
+        "keyframe-easing",
+        "list-matching",
+        "mixed-css-smil",
+        "multiple-names",
+        "negative-delay",
+        "reverse",
+        "steps",
+        "transform"
+      ],
+      "timeline": {
+        "durationMicroseconds": 2000000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [
+          0, 249999, 250000, 499999, 500000, 749999, 750000, 999999, 1000000, 1000001, 1249999, 1250000, 1499999,
+          1500000, 1749999, 1750000, 1999999, 2000000
+        ]
+      },
+      "expectDistinctReferenceFrames": true
     }
   }
 }

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-08-css-keyframes.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-08-css-keyframes.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120">
+  <rect width="160" height="120" fill="#0f172a"/>
+  <style>
+    :root { --travel: 68px; --hot: #fb7185; }
+    @keyframes slide {
+      from { x: 10px; }
+      45% { x: var(--travel); animation-timing-function: cubic-bezier(.2, .8, .4, 1); }
+      to { x: 126px; }
+    }
+    @keyframes tint {
+      from { fill: #38bdf8; }
+      50% { fill: var(--hot); }
+      to { fill: #fbbf24; }
+    }
+    @keyframes hop {
+      from { transform: translate(0px, 0px); }
+      50% { transform: translate(42px, -8px); }
+      to { transform: translate(84px, 0px); }
+    }
+    @keyframes blink { from { opacity: .2; } to { opacity: 1; } }
+    @keyframes middle-only { 50% { opacity: 1; } }
+    @keyframes first-paint { from { fill: #ef4444; } to { fill: #ef4444; } }
+    @keyframes final-paint { from { fill: #a78bfa; } to { fill: #34d399; } }
+
+    #slider { animation: slide 2s linear both; }
+    #tint { animation: tint 1s ease-in-out -250ms 2 alternate both; }
+    #hop { animation: hop 2s cubic-bezier(.42, 0, .58, 1) both; }
+    #steps { animation: blink 1s steps(4, jump-both) 2 reverse both; }
+    #implicit { animation: middle-only 2s linear both; }
+    #ordered { animation-name: first-paint, final-paint; animation-duration: 2s; animation-fill-mode: both; }
+    #protected { opacity: .65 !important; animation: blink 1s linear infinite; }
+    #mixed { animation: blink 2s linear both; }
+  </style>
+
+  <rect id="slider" x="10" y="12" width="24" height="12" rx="4" fill="#22d3ee"/>
+  <circle id="tint" cx="30" cy="43" r="10" fill="#38bdf8"/>
+  <g id="hop"><path d="M12 72 L24 64 L36 72 L24 80 Z" fill="#f97316"/></g>
+  <rect id="steps" x="105" y="36" width="34" height="14" rx="3" fill="#e2e8f0" opacity=".2"/>
+  <circle id="implicit" cx="117" cy="71" r="10" fill="#60a5fa" opacity=".2"/>
+  <rect id="ordered" x="10" y="92" width="34" height="14" rx="3" fill="#a78bfa"/>
+  <rect id="protected" x="55" y="92" width="34" height="14" rx="3" fill="#f8fafc"/>
+  <circle id="mixed" cx="118" cy="99" r="9" fill="#facc15" opacity=".2">
+    <animate attributeName="opacity" from="1" to=".2" dur="2s" fill="freeze"/>
+  </circle>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/manifest.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/manifest.ts
@@ -119,6 +119,23 @@ const REQUIRED_ANIMATE_MOTION_BENCHMARK_TAGS = [
   "transform-sandwich",
 ] as const;
 
+const REQUIRED_CSS_KEYFRAMES_BENCHMARK_TAGS = [
+  "alternate",
+  "css-keyframes",
+  "custom-properties",
+  "fill-mode",
+  "important",
+  "implicit-endpoints",
+  "keyframe-easing",
+  "list-matching",
+  "mixed-css-smil",
+  "multiple-names",
+  "negative-delay",
+  "reverse",
+  "steps",
+  "transform",
+] as const;
+
 function validateBackground(value: string | null): void {
   if (value !== null && !/^#([\da-f]{6}|[\da-f]{8})$/i.test(value))
     throw new Error(`Background must be null, #RRGGBB, or #RRGGBBAA: ${value}`);
@@ -373,6 +390,14 @@ export function validateAnimationManifest(): string[] {
   for (const tag of REQUIRED_ANIMATE_MOTION_BENCHMARK_TAGS)
     if (!animateMotionBenchmarkTags.has(tag))
       errors.push(`animateMotion comparison benchmark does not cover required tag: ${tag}`);
+  const cssKeyframesBenchmarkTags = new Set(
+    fixtures
+      .filter((fixture) => fixture.mode === "comparison" && fixture.tags.includes("benchmark-08"))
+      .flatMap((fixture) => fixture.tags),
+  );
+  for (const tag of REQUIRED_CSS_KEYFRAMES_BENCHMARK_TAGS)
+    if (!cssKeyframesBenchmarkTags.has(tag))
+      errors.push(`CSS keyframes comparison benchmark does not cover required tag: ${tag}`);
   if (valueGoldens.version !== 1) errors.push(`Unsupported animation value golden version: ${valueGoldens.version}`);
   if (!Number.isFinite(valueGoldens.tolerance) || valueGoldens.tolerance <= 0)
     errors.push("Animation value golden tolerance must be finite and positive");

--- a/packages/svg-to-swiftui-core/conformance/ANIMATION_REPORT.md
+++ b/packages/svg-to-swiftui-core/conformance/ANIMATION_REPORT.md
@@ -2,7 +2,7 @@
 
 Generated from `ANIMATION_ATTRIBUTE_REGISTRY`. Do not edit by hand.
 
-This report describes declarative animation wiring. Attribute rows cover `<animate>` and `<set>`; specialized animation elements are listed separately.
+This report describes declarative animation wiring. Attribute rows cover `<animate>`, `<set>`, and CSS `@keyframes`; specialized animation systems are listed separately.
 
 ## Summary
 
@@ -126,3 +126,4 @@ This report describes declarative animation wiring. Attribute rows cover `<anima
 | --- | --- | --- |
 | `<animateTransform>` | implemented | typed parser/sampler/composition tests; 18-frame `benchmark-06-animate-transform` |
 | `<animateMotion>` / `<mpath>` | implemented | metric/parser/composition tests; 18-frame `benchmark-07-animate-motion` |
+| CSS `@keyframes` | implemented | cascade/timing/value tests; 18-frame `benchmark-08-css-keyframes` |

--- a/packages/svg-to-swiftui-core/conformance/animation-report.ts
+++ b/packages/svg-to-swiftui-core/conformance/animation-report.ts
@@ -16,7 +16,7 @@ export function renderAnimationReport(): string {
     "",
     "Generated from `ANIMATION_ATTRIBUTE_REGISTRY`. Do not edit by hand.",
     "",
-    "This report describes declarative animation wiring. Attribute rows cover `<animate>` and `<set>`; specialized animation elements are listed separately.",
+    "This report describes declarative animation wiring. Attribute rows cover `<animate>`, `<set>`, and CSS `@keyframes`; specialized animation systems are listed separately.",
     "",
     "## Summary",
     "",
@@ -39,6 +39,7 @@ export function renderAnimationReport(): string {
     "| --- | --- | --- |",
     "| `<animateTransform>` | implemented | typed parser/sampler/composition tests; 18-frame `benchmark-06-animate-transform` |",
     "| `<animateMotion>` / `<mpath>` | implemented | metric/parser/composition tests; 18-frame `benchmark-07-animate-motion` |",
+    "| CSS `@keyframes` | implemented | cascade/timing/value tests; 18-frame `benchmark-08-css-keyframes` |",
     "",
   ];
   return lines.join("\n");

--- a/packages/svg-to-swiftui-core/docs/css-keyframe-animation.md
+++ b/packages/svg-to-swiftui-core/docs/css-keyframe-animation.md
@@ -1,0 +1,20 @@
+# CSS keyframe animation
+
+The compiler resolves static author CSS and emits a pure-time Swift runtime for SVG `@keyframes` animations. The same injected `documentTime` used by SMIL drives CSS effects, so tests can seek both engines to exact frames.
+
+## Supported syntax
+
+- `@keyframes` and `@-webkit-keyframes`, including `from`, `to`, percentage lists, duplicate offsets, and last-rule-wins names
+- `animation` shorthand plus all eight animation longhands and CSS list matching
+- durations, negative delays, finite/fractional/infinite iterations, all directions, fill modes, and play states
+- `linear`, easing keywords, `cubic-bezier()`, `step-start`, `step-end`, and all `steps()` positions
+- per-keyframe timing functions, implicit endpoints, multiple animation names, and target custom properties through `var()`
+- typed SVG geometry, paint, opacity, stroke, text, discrete, and transform values already present in the animation registry
+
+CSS animations replace the underlying presentation value. Later animation names win when effects target the same property. CSS effects are emitted after SMIL effects, while an author `!important` declaration remains above both animation systems. `!important` declarations inside keyframes are ignored with a diagnostic.
+
+Dynamic pseudo-classes, dynamic media queries, CSS transitions, script-created Web Animations, additive `animation-composition`, and animated custom-property registration are outside this compiler slice and remain explicit diagnostics or follow-up work.
+
+## Verification
+
+`benchmark-08-css-keyframes.svg` is rendered by WebKit and by generated SwiftUI at 18 exact timestamps. The lossless RGBA frames are compared directly; review videos are secondary artifacts. The benchmark covers negative delay, alternate/reverse directions, fill, steps and Bézier easing, custom properties, implicit endpoints, transform animation, list matching, multiple names, `!important`, and mixed CSS/SMIL composition.

--- a/packages/svg-to-swiftui-core/src/cssAnimations.ts
+++ b/packages/svg-to-swiftui-core/src/cssAnimations.ts
@@ -1,0 +1,255 @@
+export const CSS_ANIMATION_LONGHANDS = [
+  "animation-name",
+  "animation-duration",
+  "animation-timing-function",
+  "animation-delay",
+  "animation-iteration-count",
+  "animation-direction",
+  "animation-fill-mode",
+  "animation-play-state",
+] as const;
+
+export type CSSAnimationLonghand = (typeof CSS_ANIMATION_LONGHANDS)[number];
+
+export type CSSTimingFunction =
+  | { type: "linear" }
+  | { type: "cubic"; x1: number; y1: number; x2: number; y2: number }
+  | {
+      type: "steps";
+      count: number;
+      position: "jump-start" | "jump-end" | "jump-none" | "jump-both";
+    };
+
+export interface CSSAnimationInstance {
+  name: string;
+  duration: number;
+  delay: number;
+  timingFunction: CSSTimingFunction;
+  iterationCount: number;
+  direction: "normal" | "reverse" | "alternate" | "alternate-reverse";
+  fillMode: "none" | "forwards" | "backwards" | "both";
+  playState: "running" | "paused";
+  listIndex: number;
+}
+
+export const CSS_ANIMATION_INITIALS: Record<CSSAnimationLonghand, string> = {
+  "animation-name": "none",
+  "animation-duration": "0s",
+  "animation-timing-function": "ease",
+  "animation-delay": "0s",
+  "animation-iteration-count": "1",
+  "animation-direction": "normal",
+  "animation-fill-mode": "none",
+  "animation-play-state": "running",
+};
+
+/** Split a CSS comma-list without splitting functions or quoted names. */
+export function splitCSSList(source: string): string[] {
+  const result: string[] = [];
+  let start = 0;
+  let depth = 0;
+  let quote = "";
+  let escaped = false;
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = "";
+      continue;
+    }
+    if (character === '"' || character === "'") quote = character;
+    else if (character === "(") depth += 1;
+    else if (character === ")") depth = Math.max(0, depth - 1);
+    else if (character === "," && depth === 0) {
+      result.push(source.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  result.push(source.slice(start).trim());
+  return result;
+}
+
+function splitComponents(source: string): string[] {
+  const result: string[] = [];
+  let start = 0;
+  let depth = 0;
+  let quote = "";
+  let escaped = false;
+  const flush = (end: number) => {
+    const value = source.slice(start, end).trim();
+    if (value) result.push(value);
+  };
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = "";
+      continue;
+    }
+    if (character === '"' || character === "'") quote = character;
+    else if (character === "(") depth += 1;
+    else if (character === ")") depth = Math.max(0, depth - 1);
+    else if (/\s/.test(character) && depth === 0) {
+      flush(index);
+      start = index + 1;
+    }
+  }
+  flush(source.length);
+  return result;
+}
+
+function parseTime(source: string): number | undefined {
+  const match = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+))(ms|s)$/i.exec(source);
+  if (!match) return undefined;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value * (match[2]!.toLowerCase() === "ms" ? 0.001 : 1) : undefined;
+}
+
+export function parseCSSTimingFunction(source: string): CSSTimingFunction | undefined {
+  const value = source.trim().toLowerCase();
+  const presets: Record<string, CSSTimingFunction> = {
+    linear: { type: "linear" },
+    ease: { type: "cubic", x1: 0.25, y1: 0.1, x2: 0.25, y2: 1 },
+    "ease-in": { type: "cubic", x1: 0.42, y1: 0, x2: 1, y2: 1 },
+    "ease-out": { type: "cubic", x1: 0, y1: 0, x2: 0.58, y2: 1 },
+    "ease-in-out": { type: "cubic", x1: 0.42, y1: 0, x2: 0.58, y2: 1 },
+    "step-start": { type: "steps", count: 1, position: "jump-start" },
+    "step-end": { type: "steps", count: 1, position: "jump-end" },
+  };
+  if (presets[value]) return presets[value];
+  const cubic =
+    /^cubic-bezier\(\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*,\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*,\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*,\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*\)$/i.exec(
+      value,
+    );
+  if (cubic) {
+    const [x1, y1, x2, y2] = cubic.slice(1).map(Number) as [number, number, number, number];
+    return x1 >= 0 && x1 <= 1 && x2 >= 0 && x2 <= 1 ? { type: "cubic", x1, y1, x2, y2 } : undefined;
+  }
+  const steps = /^steps\(\s*(\d+)\s*(?:,\s*(start|end|jump-start|jump-end|jump-none|jump-both))?\s*\)$/i.exec(value);
+  if (steps) {
+    const count = Number(steps[1]);
+    const raw = steps[2]?.toLowerCase() ?? "end";
+    const position = raw === "start" ? "jump-start" : raw === "end" ? "jump-end" : raw;
+    if (count < 1 || (position === "jump-none" && count < 2)) return undefined;
+    return { type: "steps", count, position: position as Extract<CSSTimingFunction, { type: "steps" }>["position"] };
+  }
+  return undefined;
+}
+
+function unquote(source: string): string {
+  const trimmed = source.trim();
+  return (trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+    ? trimmed.slice(1, -1)
+    : trimmed;
+}
+
+export function parseAnimationShorthand(source: string): Record<CSSAnimationLonghand, string> | undefined {
+  const items = splitCSSList(source);
+  if (items.length === 0 || items.some((item) => !item)) return undefined;
+  const values = {} as Record<CSSAnimationLonghand, string[]>;
+  for (const property of CSS_ANIMATION_LONGHANDS) values[property] = [];
+  for (const item of items) {
+    let duration: string | undefined;
+    let delay: string | undefined;
+    let timing: string | undefined;
+    let iteration: string | undefined;
+    let direction: string | undefined;
+    let fill: string | undefined;
+    let play: string | undefined;
+    let name: string | undefined;
+    for (const token of splitComponents(item)) {
+      const lower = token.toLowerCase();
+      const time = parseTime(token);
+      if (time !== undefined && duration === undefined) duration = token;
+      else if (time !== undefined && delay === undefined) delay = token;
+      else if (timing === undefined && parseCSSTimingFunction(token)) timing = token;
+      else if (iteration === undefined && (lower === "infinite" || /^\d*(?:\.\d+)?$/.test(lower))) iteration = token;
+      else if (direction === undefined && ["normal", "reverse", "alternate", "alternate-reverse"].includes(lower))
+        direction = lower;
+      else if (fill === undefined && ["none", "forwards", "backwards", "both"].includes(lower)) fill = lower;
+      else if (play === undefined && ["running", "paused"].includes(lower)) play = lower;
+      else if (name === undefined) name = unquote(token);
+      else return undefined;
+    }
+    if (duration !== undefined && (parseTime(duration) ?? -1) < 0) return undefined;
+    values["animation-name"].push(name ?? "none");
+    values["animation-duration"].push(duration ?? "0s");
+    values["animation-timing-function"].push(timing ?? "ease");
+    values["animation-delay"].push(delay ?? "0s");
+    values["animation-iteration-count"].push(iteration ?? "1");
+    values["animation-direction"].push(direction ?? "normal");
+    values["animation-fill-mode"].push(fill ?? "none");
+    values["animation-play-state"].push(play ?? "running");
+  }
+  return Object.fromEntries(
+    CSS_ANIMATION_LONGHANDS.map((property) => [property, values[property].join(", ")]),
+  ) as Record<CSSAnimationLonghand, string>;
+}
+
+function listItem(source: string, index: number): string | undefined {
+  const values = splitCSSList(source);
+  return values.length === 0 || values.some((value) => value === "") ? undefined : values[index % values.length];
+}
+
+export function parseCSSAnimationInstances(values: Readonly<Record<string, string | number>>): {
+  instances: CSSAnimationInstance[];
+  errors: string[];
+} {
+  const errors: string[] = [];
+  const names = splitCSSList(String(values["animation-name"] ?? "none"));
+  if (names.some((name) => !name)) return { instances: [], errors: ["animation-name contains an empty list item"] };
+  const instances: CSSAnimationInstance[] = [];
+  for (let index = 0; index < names.length; index++) {
+    const name = unquote(names[index]!);
+    if (name.toLowerCase() === "none") continue;
+    const durationRaw = listItem(String(values["animation-duration"] ?? "0s"), index);
+    const delayRaw = listItem(String(values["animation-delay"] ?? "0s"), index);
+    const timingRaw = listItem(String(values["animation-timing-function"] ?? "ease"), index);
+    const iterationRaw = listItem(String(values["animation-iteration-count"] ?? "1"), index);
+    const directionRaw = listItem(String(values["animation-direction"] ?? "normal"), index)?.toLowerCase();
+    const fillRaw = listItem(String(values["animation-fill-mode"] ?? "none"), index)?.toLowerCase();
+    const playRaw = listItem(String(values["animation-play-state"] ?? "running"), index)?.toLowerCase();
+    const duration = durationRaw === undefined ? undefined : parseTime(durationRaw);
+    const delay = delayRaw === undefined ? undefined : parseTime(delayRaw);
+    const timingFunction = timingRaw === undefined ? undefined : parseCSSTimingFunction(timingRaw);
+    const iterationCount = iterationRaw?.toLowerCase() === "infinite" ? Number.POSITIVE_INFINITY : Number(iterationRaw);
+    if (duration === undefined || duration < 0) errors.push(`${name}: invalid animation-duration '${durationRaw}'`);
+    if (delay === undefined) errors.push(`${name}: invalid animation-delay '${delayRaw}'`);
+    if (!timingFunction) errors.push(`${name}: invalid animation-timing-function '${timingRaw}'`);
+    if ((!Number.isFinite(iterationCount) && iterationRaw?.toLowerCase() !== "infinite") || iterationCount < 0)
+      errors.push(`${name}: invalid animation-iteration-count '${iterationRaw}'`);
+    if (!directionRaw || !["normal", "reverse", "alternate", "alternate-reverse"].includes(directionRaw))
+      errors.push(`${name}: invalid animation-direction '${directionRaw}'`);
+    if (!fillRaw || !["none", "forwards", "backwards", "both"].includes(fillRaw))
+      errors.push(`${name}: invalid animation-fill-mode '${fillRaw}'`);
+    if (!playRaw || !["running", "paused"].includes(playRaw))
+      errors.push(`${name}: invalid animation-play-state '${playRaw}'`);
+    if (errors.some((error) => error.startsWith(`${name}:`))) continue;
+    instances.push({
+      name,
+      duration: duration!,
+      delay: delay!,
+      timingFunction: timingFunction!,
+      iterationCount,
+      direction: directionRaw as CSSAnimationInstance["direction"],
+      fillMode: fillRaw as CSSAnimationInstance["fillMode"],
+      playState: playRaw as CSSAnimationInstance["playState"],
+      listIndex: index,
+    });
+  }
+  return { instances, errors };
+}

--- a/packages/svg-to-swiftui-core/src/renderTree/animation.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/animation.ts
@@ -1,5 +1,12 @@
 import type { ElementNode } from "svg-parser";
+import {
+  type CSSAnimationInstance,
+  type CSSTimingFunction,
+  parseCSSAnimationInstances,
+  parseCSSTimingFunction,
+} from "../cssAnimations";
 import { defaultFontMetrics } from "../lengths";
+import { type CSSKeyframesRule, substituteVariables } from "../styleCascade";
 import { parseViewBox } from "../viewports";
 import {
   type AnimateTransformType,
@@ -8,6 +15,7 @@ import {
   type AnimationValueSet,
   animationAttributeSpec,
   parseAnimateTransformValueSet,
+  parseAnimationValue,
   parseAnimationValueSet,
   parseKeySplines,
   parseKeyTimes,
@@ -19,7 +27,7 @@ import { type MotionDefinition, parseMotionDefinition } from "./motion";
 import { type DeterministicTimingEvent, sampleSMILProgram, sampleSMILTiming } from "./smilTiming";
 import type { RenderDiagnostic, SourceLocation } from "./types";
 
-export type AnimationKind = "animate" | "set" | "animateTransform" | "animateMotion" | "discard";
+export type AnimationKind = "animate" | "set" | "animateTransform" | "animateMotion" | "discard" | "cssAnimation";
 
 export type AnimationTime =
   | { type: "offset"; seconds: number }
@@ -77,6 +85,18 @@ export interface AnimationTargetSnapshot {
   context: AnimationValueContext;
   /** Computed static presentation/geometry values, after cascade and inheritance. */
   baseValues: Readonly<Record<string, string>>;
+  importantProperties?: Readonly<Record<string, true>>;
+}
+
+export interface CSSAnimationRuntime {
+  name: string;
+  duration: number;
+  delay: number;
+  iterationCount: number;
+  direction: CSSAnimationInstance["direction"];
+  fillMode: CSSAnimationInstance["fillMode"];
+  playState: CSSAnimationInstance["playState"];
+  segmentTimingFunctions: readonly CSSTimingFunction[];
 }
 
 export interface AnimationDefinition {
@@ -87,6 +107,7 @@ export interface AnimationDefinition {
   kind: AnimationKind;
   transformType?: AnimateTransformType;
   motion?: MotionDefinition;
+  cssAnimation?: CSSAnimationRuntime;
   authoredAttributeName?: string;
   attributeName?: string;
   attributeType: "auto" | "XML" | "CSS";
@@ -313,7 +334,11 @@ function parseValue(
 }
 
 function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSupport">): boolean {
-  if (!(["animate", "set", "animateTransform", "animateMotion"] as AnimationKind[]).includes(definition.kind))
+  if (
+    !(["animate", "set", "animateTransform", "animateMotion", "cssAnimation"] as AnimationKind[]).includes(
+      definition.kind,
+    )
+  )
     return false;
   const attribute = definition.attributeName ? resolveAnimationAttribute(definition.attributeName) : undefined;
   const resourceSupported =
@@ -329,7 +354,7 @@ function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSuppor
     !definition.target?.renderable ||
     (!renderNodeSupported && !resourceSupported) ||
     !definition.attributeName ||
-    (definition.attributeName === "transform" && definition.kind !== "animateTransform") ||
+    (definition.attributeName === "transform" && !["animateTransform", "cssAnimation"].includes(definition.kind)) ||
     !propertyAppliesToTarget(definition.attributeName, definition.target.tagName)
   )
     return false;
@@ -373,6 +398,7 @@ export function buildAnimationProgram(
   root: ElementNode,
   diagnostics: RenderDiagnostic[],
   targetSnapshots: ReadonlyMap<string, AnimationTargetSnapshot> = new Map(),
+  cssKeyframes: ReadonlyMap<string, CSSKeyframesRule> = new Map(),
 ): AnimationProgram {
   let parsedRootViewBox: ReturnType<typeof parseViewBox>;
   try {
@@ -944,6 +970,155 @@ export function buildAnimationProgram(
         "unsupported-animation-semantics",
         `Animation <${element.tagName}> is parsed by the value engine but target wiring is delivered by a later ticket.`,
       );
+  }
+
+  for (const targetElement of order.keys()) {
+    const targetKey = property(targetElement, "id")
+      ? `id:${property(targetElement, "id")}`
+      : `source:${order.get(targetElement)}`;
+    const targetSnapshot = targetSnapshots.get(targetKey);
+    if (!targetSnapshot) continue;
+    const parsed = parseCSSAnimationInstances(targetSnapshot.baseValues);
+    for (const message of parsed.errors)
+      diagnostic(diagnostics, targetElement, "invalid-css-animation", message, "animation");
+    for (const instance of parsed.instances) {
+      const rule = cssKeyframes.get(instance.name);
+      if (!rule) {
+        diagnostic(
+          diagnostics,
+          targetElement,
+          "missing-css-keyframes",
+          `animation-name '${instance.name}' does not match an @keyframes rule.`,
+          "animation-name",
+        );
+        continue;
+      }
+      const properties = new Set(rule.blocks.flatMap((block) => block.declarations.map((item) => item.property)));
+      for (const attributeName of properties) {
+        if (attributeName.startsWith("--")) continue;
+        if (targetSnapshot.importantProperties?.[attributeName]) continue;
+        const attribute = resolveAnimationAttribute(attributeName, "CSS");
+        if (!attribute || !attribute.animatable || !propertyAppliesToTarget(attributeName, targetSnapshot.tagName)) {
+          diagnostic(
+            diagnostics,
+            targetElement,
+            "non-animatable-css-property",
+            `CSS keyframes cannot animate '${attributeName}' on <${targetSnapshot.tagName}>.`,
+            attributeName,
+          );
+          continue;
+        }
+        const baseRaw = targetSnapshot.baseValues[attributeName];
+        if (baseRaw === undefined) continue;
+        const base = parseAnimationValue(attribute, baseRaw, targetSnapshot.context);
+        if (!base) {
+          diagnostic(
+            diagnostics,
+            targetElement,
+            "invalid-css-animation-base-value",
+            `The computed '${attributeName}' value '${baseRaw}' cannot be animated.`,
+            attributeName,
+          );
+          continue;
+        }
+        const entries: Array<{ offset: number; value: typeof base; timingFunction: CSSTimingFunction }> = [];
+        for (const block of rule.blocks) {
+          const declaration = [...block.declarations].reverse().find((item) => item.property === attributeName);
+          if (!declaration) continue;
+          const resolved = substituteVariables(declaration.value, (name) => {
+            const value = targetSnapshot.baseValues[name];
+            return value === undefined ? undefined : String(value);
+          });
+          const value = resolved ? parseAnimationValue(attribute, resolved, targetSnapshot.context) : undefined;
+          const timingFunction = block.timingFunction
+            ? parseCSSTimingFunction(block.timingFunction)
+            : instance.timingFunction;
+          if (!value || !timingFunction) {
+            diagnostic(
+              diagnostics,
+              targetElement,
+              "invalid-css-keyframe-value",
+              `The ${Math.round(block.offset * 100)}% '${attributeName}' keyframe is invalid and is ignored.`,
+              attributeName,
+            );
+            continue;
+          }
+          entries.push({ offset: block.offset, value, timingFunction });
+        }
+        if (!entries.some((entry) => entry.offset === 0))
+          entries.unshift({ offset: 0, value: base, timingFunction: instance.timingFunction });
+        if (!entries.some((entry) => entry.offset === 1))
+          entries.push({ offset: 1, value: base, timingFunction: instance.timingFunction });
+        entries.sort((left, right) => left.offset - right.offset);
+        if (entries.length < 2) continue;
+        const sourceLocation = source(targetElement);
+        const target: AnimationTarget = {
+          key: targetKey,
+          source: sourceLocation,
+          reference: { type: "parent" },
+          renderable: true,
+          tagName: targetSnapshot.tagName,
+          binding: targetSnapshot.binding ?? "render-node",
+          referenceChain: (() => {
+            const chain: SourceLocation[] = [];
+            let current: ElementNode | undefined = targetElement;
+            while (current) {
+              chain.push(source(current));
+              current = parents.get(current);
+            }
+            return chain;
+          })(),
+        };
+        const documentOrder = nextOrder++;
+        const value: AnimationValueSet = {
+          family: attribute.family,
+          attribute,
+          base,
+          values: entries.map((entry) => entry.value),
+          form: "values",
+        };
+        const definition: AnimationDefinition = {
+          stableId: `css-animation-${String(documentOrder).padStart(6, "0")}`,
+          source: sourceLocation,
+          target,
+          kind: "cssAnimation",
+          cssAnimation: {
+            name: instance.name,
+            duration: instance.duration,
+            delay: instance.delay,
+            iterationCount: instance.iterationCount,
+            direction: instance.direction,
+            fillMode: instance.fillMode,
+            playState: instance.playState,
+            segmentTimingFunctions: entries.slice(0, -1).map((entry) => entry.timingFunction),
+          },
+          authoredAttributeName: attributeName,
+          attributeName,
+          attributeType: "CSS",
+          timing: {
+            begin: [{ type: "offset", seconds: instance.delay }],
+            duration: { type: "seconds", seconds: instance.duration },
+            end: [],
+            repeatCount: Number.isFinite(instance.iterationCount)
+              ? { type: "count", value: instance.iterationCount }
+              : { type: "indefinite" },
+            restart: "always",
+            fill: instance.fillMode === "forwards" || instance.fillMode === "both" ? "freeze" : "remove",
+          },
+          value,
+          composition: {
+            calcMode: attribute.family === "discrete" ? "discrete" : "linear",
+            keyTimes: entries.map((entry) => entry.offset),
+            additive: "replace",
+            accumulate: "none",
+          },
+          documentOrder,
+          dependencies: [],
+          runtimeSupport: "typed",
+        };
+        animations.push(definition);
+      }
+    }
   }
 
   const compositions = new Map<string, AnimationDefinition[]>();

--- a/packages/svg-to-swiftui-core/src/renderTree/animationValues.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/animationValues.ts
@@ -516,20 +516,70 @@ function parsePath(source: string): AnimationPathCommand[] | undefined {
   }
 }
 
-function parseTransforms(source: string): AnimationTransformComponent[] | undefined {
+function parseTransforms(source: string, context?: AnimationValueContext): AnimationTransformComponent[] | undefined {
+  if (source.trim().toLowerCase() === "none") return [];
   const pattern = /([a-zA-Z]+)\s*\(([^)]*)\)/g;
   const components: AnimationTransformComponent[] = [];
   let last = 0;
+  let svgSyntax = true;
   try {
     parseSVGTransform(source);
   } catch {
-    return undefined;
+    svgSyntax = false;
   }
   for (const match of source.matchAll(pattern)) {
     if (!/^[\s,]*$/.test(source.slice(last, match.index))) return undefined;
     const rawKind = match[1]!.toLowerCase();
-    const kind = rawKind === "skewx" ? "skewX" : rawKind === "skewy" ? "skewY" : rawKind;
-    components.push({ kind: kind as AnimationTransformComponent["kind"], values: numbers(match[2]!) ?? [] });
+    if (svgSyntax) {
+      const kind = rawKind === "skewx" ? "skewX" : rawKind === "skewy" ? "skewY" : rawKind;
+      components.push({ kind: kind as AnimationTransformComponent["kind"], values: numbers(match[2]!) ?? [] });
+    } else {
+      if (!context) return undefined;
+      const tokens = match[2]!
+        .trim()
+        .split(/[\s,]+/)
+        .filter(Boolean);
+      const lengths = (axes: LengthAxis[]) =>
+        tokens.map((token, index) => parseLength(token, context, axes[Math.min(index, axes.length - 1)]));
+      const plain = tokens.map((token) => {
+        try {
+          return parsePlainNumber(token, "CSS transform number");
+        } catch {
+          return undefined;
+        }
+      });
+      if (rawKind === "translate" || rawKind === "translatex" || rawKind === "translatey") {
+        const parsed = lengths(rawKind === "translatey" ? ["vertical"] : ["horizontal", "vertical"]);
+        if (parsed.some((value) => value === undefined) || parsed.length < 1 || parsed.length > 2) return undefined;
+        components.push({
+          kind: "translate",
+          values:
+            rawKind === "translatex"
+              ? [parsed[0]!, 0]
+              : rawKind === "translatey"
+                ? [0, parsed[0]!]
+                : (parsed as number[]),
+        });
+      } else if (["scale", "scalex", "scaley"].includes(rawKind)) {
+        if (plain.some((value) => value === undefined) || plain.length < 1 || plain.length > 2) return undefined;
+        const first = plain[0]!;
+        components.push({
+          kind: "scale",
+          values: rawKind === "scalex" ? [first, 1] : rawKind === "scaley" ? [1, first] : [first, plain[1] ?? first],
+        });
+      } else if (rawKind === "rotate") {
+        const angle = tokens.length === 1 ? parseAngle(tokens[0]!) : undefined;
+        if (angle === undefined) return undefined;
+        components.push({ kind: "rotate", values: [angle] });
+      } else if (rawKind === "skewx" || rawKind === "skewy") {
+        const angle = tokens.length === 1 ? parseAngle(tokens[0]!) : undefined;
+        if (angle === undefined) return undefined;
+        components.push({ kind: rawKind === "skewx" ? "skewX" : "skewY", values: [angle] });
+      } else if (rawKind === "matrix") {
+        if (plain.length !== 6 || plain.some((value) => value === undefined)) return undefined;
+        components.push({ kind: "matrix", values: plain as number[] });
+      } else return undefined;
+    }
     last = (match.index ?? 0) + match[0].length;
   }
   return components.length > 0 && /^[\s,]*$/.test(source.slice(last)) ? components : undefined;
@@ -723,7 +773,7 @@ export function parseAnimationValue(
       }
     }
     case "transform": {
-      const components = parseTransforms(raw);
+      const components = parseTransforms(raw, context);
       return components ? { family: "transform", components } : undefined;
     }
     case "discrete":

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -488,6 +488,7 @@ function computeStyle(
   isLine = false,
   inheritedProperties: StyleResolution["inheritedProperties"] = {},
   currentColorProperties: StyleResolution["currentColorProperties"] = {},
+  importantProperties: StyleResolution["importantProperties"] = {},
 ): ComputedStyle {
   effective["font-size"] = fontMetrics.fontSize;
   const styleCoordinate = { ...coordinate, fontMetrics };
@@ -627,6 +628,7 @@ function computeStyle(
     provenance,
     inheritedProperties,
     currentColorProperties,
+    importantProperties,
   };
 }
 
@@ -667,6 +669,7 @@ function resolvedPresentation(
       element.tagName === "line",
       resolution.inheritedProperties,
       resolution.currentColorProperties,
+      resolution.importantProperties,
     ),
     provenance: resolution.provenance,
   };
@@ -3268,6 +3271,7 @@ export function buildRenderDocument(
                 : "sRGB",
           },
           baseValues: animationBaseValues(node),
+          importantProperties: node.style.importantProperties,
         });
       if (node.type === "group") collectAnimationTargetSnapshots(node.children);
     }
@@ -3292,10 +3296,16 @@ export function buildRenderDocument(
           colorSpace: paint.colorInterpolation,
         },
         baseValues: stop.animationBaseValues ?? {},
+        importantProperties: {},
       });
     }
   }
-  const animationProgram = buildAnimationProgram(svg, diagnostics, animationTargetSnapshots);
+  const animationProgram = buildAnimationProgram(
+    svg,
+    diagnostics,
+    animationTargetSnapshots,
+    styleResolver.animationKeyframes(),
+  );
 
   return {
     viewport: {

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -6,6 +6,7 @@ import { createFunctionTemplate, createStructTemplate } from "../templates";
 import { IDENTITY_TRANSFORM, multiplyTransforms, wrapWithTransform } from "../transformUtils";
 import type { SVGElementProperties, SwiftUIGeneratorConfig, TranspilerOptions, ViewBoxData } from "../types";
 import { viewBoxTransform } from "../viewports";
+import type { AnimationDefinition } from "./animation";
 import {
   addAnimationValues,
   animationAttributeSpec,
@@ -427,6 +428,21 @@ function buildViewNodes(
         : ("sRGB" as const),
   });
 
+  const cssTimingLiteral = (
+    timing: NonNullable<AnimationDefinition["cssAnimation"]>["segmentTimingFunctions"][number],
+  ) => {
+    if (timing.type === "linear") return `${context.rootName}.SVGCSSTimingFunction(kind: .linear)`;
+    if (timing.type === "cubic")
+      return `${context.rootName}.SVGCSSTimingFunction(kind: .cubic, x1: ${formatNumber(timing.x1)}, y1: ${formatNumber(timing.y1)}, x2: ${formatNumber(timing.x2)}, y2: ${formatNumber(timing.y2)})`;
+    const position = {
+      "jump-start": "jumpStart",
+      "jump-end": "jumpEnd",
+      "jump-none": "jumpNone",
+      "jump-both": "jumpBoth",
+    }[timing.position];
+    return `${context.rootName}.SVGCSSTimingFunction(kind: .steps, count: ${timing.count}, position: .${position})`;
+  };
+
   const animatedValueExpressionFromAnimations = (
     animations: ReturnType<typeof directAnimationsFor>,
     base: TypedAnimationValue,
@@ -455,6 +471,21 @@ function buildViewNodes(
         authoredValues = authoredValues.map((value) =>
           value.family === "color" ? { family: "paint", value: { type: "color", color: value.value } } : value,
         );
+      const clampMode =
+        set.family === "integer"
+          ? "integer"
+          : set.attribute.clamp === "unit"
+            ? "unit"
+            : set.attribute.clamp === "nonnegative"
+              ? "nonnegative"
+              : "none";
+      if (animation.kind === "cssAnimation" && animation.cssAnimation) {
+        const css = animation.cssAnimation;
+        const keyTimes = animation.composition.keyTimes?.map((value) => formatNumber(value)).join(", ") ?? "";
+        const iterationCount = Number.isFinite(css.iterationCount) ? formatNumber(css.iterationCount) : ".infinity";
+        expression = `${context.rootName}.svgCSSAnimatedValue(documentTime: documentTime, duration: ${swiftDuration(css.duration)}, delay: ${swiftDuration(css.delay)}, iterationCount: ${iterationCount}, direction: .${css.direction.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase())}, fillMode: .${css.fillMode}, playState: .${css.playState}, values: [${authoredValues.map((value) => swiftAnimationValueLiteral(value, context.precision, `${context.rootName}.`)).join(", ")}], keyTimes: [${keyTimes}], timingFunctions: [${css.segmentTimingFunctions.map(cssTimingLiteral).join(", ")}], clamp: .${clampMode}, underlying: ${expression})`;
+        continue;
+      }
       const intervals = context.animationIntervals.get(animation.stableId) ?? [];
       const intervalLiteral = intervals
         .map((interval) => `(begin: ${swiftDuration(interval.begin)}, end: ${swiftDuration(interval.end)})`)
@@ -470,14 +501,6 @@ function buildViewNodes(
               `(x1: ${formatNumber(spline.x1)}, y1: ${formatNumber(spline.y1)}, x2: ${formatNumber(spline.x2)}, y2: ${formatNumber(spline.y2)})`,
           )
           .join(", ") ?? "";
-      const clampMode =
-        set.family === "integer"
-          ? "integer"
-          : set.attribute.clamp === "unit"
-            ? "unit"
-            : set.attribute.clamp === "nonnegative"
-              ? "nonnegative"
-              : "none";
       expression = `${context.rootName}.svgAnimatedValue(documentTime: documentTime, intervals: [${intervalLiteral}], duration: ${swiftDuration(duration)}, repeatingDuration: ${swiftDuration(repeatingDuration)}, values: [${authoredValues.map((value) => swiftAnimationValueLiteral(value, context.precision, `${context.rootName}.`)).join(", ")}], form: .${form.replace(/-/g, "")}, calcMode: .${animation.kind === "set" ? "discrete" : animation.composition.calcMode}, keyTimes: [${keyTimes}], keySplines: [${keySplines}], additive: ${animation.composition.additive === "sum" || set.form === "by" ? "true" : "false"}, accumulate: ${animation.composition.accumulate === "sum" ? "true" : "false"}, clamp: .${clampMode}, underlying: ${expression}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"})`;
     }
     return expression;
@@ -4422,6 +4445,12 @@ function createView(
         "enum SVGAnimationForm { case values, fromto, fromby, by, to }",
         "enum SVGAnimationCalcMode { case discrete, linear, paced, spline }",
         "enum SVGAnimationClamp { case none, unit, nonnegative, integer }",
+        "enum SVGCSSAnimationDirection { case normal, reverse, alternate, alternateReverse }",
+        "enum SVGCSSAnimationFillMode { case none, forwards, backwards, both }",
+        "enum SVGCSSAnimationPlayState { case running, paused }",
+        "enum SVGCSSTimingKind { case linear, cubic, steps }",
+        "enum SVGSStepPosition { case jumpStart, jumpEnd, jumpNone, jumpBoth }",
+        "struct SVGCSSTimingFunction { let kind: SVGCSSTimingKind; var x1 = 0.0; var y1 = 0.0; var x2 = 1.0; var y2 = 1.0; var count = 1; var position = SVGSStepPosition.jumpEnd }",
         "enum SVGAnimationMotionRotate { case auto, autoReverse, angle }",
         "struct SVGAnimationMotionPoint { let x: Double; let y: Double; let distance: Double; let move: Bool }",
         "enum SVGAnimationRuntimeValueKind { case number, integer, opacity, length, angle, color, numberList, lengthList, points, paintColor, path, viewBox, transform, discrete }",
@@ -4764,6 +4793,65 @@ function createView(
         `${indentation}if sample.state == .inactive || sample.state == .completed { return underlying }`,
         `${indentation}guard let progress = sample.simpleProgress else { return underlying }`,
         `${indentation}return svgAnimationTypedValueSample(progress: progress, values: authoredValues, form: form, calcMode: calcMode, keyTimes: keyTimes, keySplines: keySplines, additive: additive, accumulate: accumulate, repeatIteration: sample.repeatIteration, clamp: clamp, underlying: underlying)`,
+        "}",
+        "",
+        "private static func svgCSSTimingProgress(_ progress: Double, _ timing: SVGCSSTimingFunction) -> Double {",
+        `${indentation}let value = min(1, max(0, progress))`,
+        `${indentation}switch timing.kind {`,
+        `${indentation}case .linear: return value`,
+        `${indentation}case .cubic: return svgSplineProgress(value, (timing.x1, timing.y1, timing.x2, timing.y2))`,
+        `${indentation}case .steps:`,
+        `${indentation}${indentation}let count = max(1, timing.count)`,
+        `${indentation}${indentation}switch timing.position {`,
+        `${indentation}${indentation}case .jumpStart: return min(1, Double(Int(floor(value * Double(count))) + 1) / Double(count))`,
+        `${indentation}${indentation}case .jumpEnd: return value >= 1 ? 1 : Double(Int(floor(value * Double(count)))) / Double(count)`,
+        `${indentation}${indentation}case .jumpNone: return min(1, max(0, Double(Int(floor(value * Double(count)))) / Double(max(1, count - 1))))`,
+        `${indentation}${indentation}case .jumpBoth: return min(1, Double(Int(floor(value * Double(count))) + 1) / Double(count + 1))`,
+        `${indentation}${indentation}}`,
+        `${indentation}}`,
+        "}",
+        "",
+        "private static func svgCSSAnimatedValue(documentTime: Double, duration: Double, delay: Double, iterationCount: Double, direction: SVGCSSAnimationDirection, fillMode: SVGCSSAnimationFillMode, playState: SVGCSSAnimationPlayState, values: [SVGAnimationRuntimeValue], keyTimes: [Double], timingFunctions: [SVGCSSTimingFunction], clamp: SVGAnimationClamp, underlying: SVGAnimationRuntimeValue) -> SVGAnimationRuntimeValue {",
+        `${indentation}guard values.count >= 2 else { return values.first.map { svgClampValue($0, clamp) } ?? underlying }`,
+        `${indentation}let localTime = (playState == .paused ? 0 : documentTime) - delay`,
+        `${indentation}let activeDuration = iterationCount.isFinite ? max(0, duration * iterationCount) : Double.infinity`,
+        `${indentation}var progress: Double`,
+        `${indentation}var iteration = 0`,
+        `${indentation}var preserveEndpoint = false`,
+        `${indentation}if localTime < 0 {`,
+        `${indentation}${indentation}guard fillMode == .backwards || fillMode == .both else { return underlying }`,
+        `${indentation}${indentation}progress = 0`,
+        `${indentation}} else if duration <= 0 || iterationCount <= 0 || localTime >= activeDuration {`,
+        `${indentation}${indentation}guard fillMode == .forwards || fillMode == .both else { return underlying }`,
+        `${indentation}${indentation}preserveEndpoint = true`,
+        `${indentation}${indentation}let whole = floor(iterationCount)`,
+        `${indentation}${indentation}let fraction = iterationCount.isFinite ? iterationCount - whole : 0`,
+        `${indentation}${indentation}if fraction > 0.000000000001 { iteration = max(0, Int(whole)); progress = fraction }`,
+        `${indentation}${indentation}else { iteration = max(0, Int(max(0, whole - 1))); progress = 1 }`,
+        `${indentation}} else {`,
+        `${indentation}${indentation}let quotient = localTime / duration`,
+        `${indentation}${indentation}iteration = max(0, Int(floor(quotient)))`,
+        `${indentation}${indentation}progress = min(1, max(0, quotient - Double(iteration)))`,
+        `${indentation}}`,
+        `${indentation}let reversed: Bool`,
+        `${indentation}switch direction {`,
+        `${indentation}case .normal: reversed = false`,
+        `${indentation}case .reverse: reversed = true`,
+        `${indentation}case .alternate: reversed = iteration % 2 == 1`,
+        `${indentation}case .alternateReverse: reversed = iteration % 2 == 0`,
+        `${indentation}}`,
+        `${indentation}if reversed { progress = 1 - progress }`,
+        `${indentation}let times = keyTimes.count == values.count ? keyTimes : values.indices.map { Double($0) / Double(values.count - 1) }`,
+        `${indentation}if values[0].kind == .discrete {`,
+        `${indentation}${indentation}let index = times.indices.last { progress + 0.000000000001 >= times[$0] } ?? 0`,
+        `${indentation}${indentation}return svgClampValue(values[min(index, values.count - 1)], clamp)`,
+        `${indentation}}`,
+        `${indentation}var segment = progress >= 1 ? values.count - 2 : 0`,
+        `${indentation}while segment + 1 < times.count - 1 && progress >= times[segment + 1] - 0.000000000001 { segment += 1 }`,
+        `${indentation}let start = times[segment]; let end = times[segment + 1]`,
+        `${indentation}var segmentProgress = progress >= 1 ? 1 : (end <= start ? 1 : min(1, max(0, (progress - start) / (end - start))))`,
+        `${indentation}if !preserveEndpoint && segment < timingFunctions.count { segmentProgress = svgCSSTimingProgress(segmentProgress, timingFunctions[segment]) }`,
+        `${indentation}return svgClampValue(svgInterpolateValue(values[segment], values[segment + 1], segmentProgress), clamp)`,
         "}",
         "",
         "private static func svgAnimatedNumber(documentTime: Double, intervals: [(begin: Double, end: Double)], duration: Double, repeatingDuration: Double, values authoredValues: [Double], form: SVGAnimationForm, calcMode: SVGAnimationCalcMode, keyTimes: [Double], keySplines: [(x1: Double, y1: Double, x2: Double, y2: Double)], additive: Bool, accumulate: Bool, clamp: SVGAnimationClamp, underlying: Double, freeze: Bool) -> Double {",

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -665,6 +665,8 @@ export interface ComputedStyle {
   inheritedProperties: Readonly<Record<string, true>>;
   /** Paint properties whose winning authored value uses currentColor. */
   currentColorProperties: Readonly<Record<string, true>>;
+  /** Properties whose winning declaration is author !important. */
+  importantProperties: Readonly<Record<string, true>>;
 }
 
 export type Geometry =

--- a/packages/svg-to-swiftui-core/src/styleCascade.ts
+++ b/packages/svg-to-swiftui-core/src/styleCascade.ts
@@ -1,9 +1,10 @@
 import { compile, type Options as SelectorOptions } from "css-select";
-import postcss, { type Container, type Declaration, type Rule } from "postcss";
+import postcss, { type AtRule, type Container, type Declaration, type Rule } from "postcss";
 import safeParse from "postcss-safe-parser";
 import selectorParser, { type Selector, type Node as SelectorNode } from "postcss-selector-parser";
 import valueParser, { type Node as ValueNode } from "postcss-value-parser";
 import type { ElementNode, TextNode } from "svg-parser";
+import { CSS_ANIMATION_LONGHANDS, type CSSAnimationLonghand, parseAnimationShorthand } from "./cssAnimations";
 import type { CSSDiagnosticContext, RenderDiagnostic, SourceLocation } from "./renderTree/types";
 import {
   canonicalPropertyName,
@@ -21,6 +22,25 @@ export interface StyleResolution {
   inheritedProperties: Readonly<Record<string, true>>;
   /** Paint properties whose winning authored value depends on `color`. */
   currentColorProperties: Readonly<Record<string, true>>;
+  /** Properties protected from animation by an author !important declaration. */
+  importantProperties: Readonly<Record<string, true>>;
+}
+
+export interface CSSKeyframeDeclaration {
+  property: string;
+  value: string;
+  css: CSSDiagnosticContext;
+}
+
+export interface CSSKeyframeBlock {
+  offset: number;
+  declarations: readonly CSSKeyframeDeclaration[];
+  timingFunction?: string;
+}
+
+export interface CSSKeyframesRule {
+  name: string;
+  blocks: readonly CSSKeyframeBlock[];
 }
 
 type StyleNode = ElementNode | TextNode | string;
@@ -32,6 +52,7 @@ interface CascadedDeclaration {
   specificity: Specificity;
   order: number;
   css: CSSDiagnosticContext;
+  animationShorthand?: true;
 }
 
 interface Specificity {
@@ -141,7 +162,10 @@ function replaceNodeWithWord(node: ValueNode, value: string): void {
   if ("nodes" in node) delete (node as ValueNode & { nodes?: ValueNode[] }).nodes;
 }
 
-function substituteVariables(raw: string, resolveCustom: (name: string) => string | undefined): string | undefined {
+export function substituteVariables(
+  raw: string,
+  resolveCustom: (name: string) => string | undefined,
+): string | undefined {
   const parsed = valueParser(raw);
   let valid = true;
 
@@ -193,6 +217,7 @@ function declarationNodes(container: Container): Declaration[] {
  */
 export class SVGStyleResolver {
   private readonly rules: CompiledRule[] = [];
+  private readonly keyframes = new Map<string, CSSKeyframesRule>();
   private readonly elements: ElementNode[] = [];
   private readonly parent = new WeakMap<object, ElementNode | null>();
   private readonly ownDeclarations = new WeakMap<
@@ -344,6 +369,10 @@ export class SVGStyleResolver {
   private collectContainerRules(container: Container, styleElement: ElementNode): void {
     for (const node of container.nodes ?? []) {
       if (node.type === "atrule") {
+        if (["keyframes", "-webkit-keyframes"].includes(node.name.toLowerCase())) {
+          this.collectKeyframes(node, styleElement);
+          continue;
+        }
         const code = node.name.toLowerCase() === "media" ? "unsupported-dynamic-media" : "unsupported-css-at-rule";
         this.diagnostic(styleElement, code, `Static style resolution does not support @${node.name} ${node.params}.`, {
           source: "embedded-style",
@@ -355,6 +384,92 @@ export class SVGStyleResolver {
       }
       if (node.type === "rule") this.compileRule(node, styleElement);
     }
+  }
+
+  private collectKeyframes(rule: AtRule, styleElement: ElementNode): void {
+    const name = rule.params.trim().replace(/^(?:"([\s\S]*)"|'([\s\S]*)')$/, "$1$2");
+    if (!name || name.toLowerCase() === "none") {
+      this.diagnostic(styleElement, "invalid-css-keyframes-name", `@${rule.name} requires a valid name.`, {
+        source: "embedded-style",
+        selector: `@${rule.name} ${rule.params}`.trim(),
+      });
+      return;
+    }
+    const byOffset = new Map<number, CSSKeyframeDeclaration[]>();
+    const timingByOffset = new Map<number, string>();
+    for (const node of rule.nodes ?? []) {
+      if (node.type !== "rule") continue;
+      const offsets: number[] = [];
+      let valid = true;
+      for (const selector of node.selector.split(",")) {
+        const value = selector.trim().toLowerCase();
+        const offset =
+          value === "from"
+            ? 0
+            : value === "to"
+              ? 1
+              : /^\d+(?:\.\d+)?%$/.test(value)
+                ? Number(value.slice(0, -1)) / 100
+                : Number.NaN;
+        if (!Number.isFinite(offset) || offset < 0 || offset > 1) {
+          valid = false;
+          this.diagnostic(
+            styleElement,
+            "invalid-css-keyframe-selector",
+            `Invalid keyframe selector '${selector.trim()}'.`,
+            {
+              source: "embedded-style",
+              selector: node.selector,
+            },
+          );
+        } else offsets.push(offset);
+      }
+      if (!valid) continue;
+      for (const offset of offsets) if (!byOffset.has(offset)) byOffset.set(offset, []);
+      for (const declaration of declarationNodes(node)) {
+        const property = canonicalPropertyName(declaration.prop);
+        const css: CSSDiagnosticContext = {
+          source: "embedded-style",
+          selector: node.selector,
+          property,
+          ...(declaration.source?.start?.line === undefined ? {} : { line: declaration.source.start.line }),
+          ...(declaration.source?.start?.column === undefined ? {} : { column: declaration.source.start.column }),
+        };
+        if (declaration.important) {
+          this.diagnostic(
+            styleElement,
+            "ignored-keyframe-important",
+            `!important is ignored inside @keyframes for '${property}'.`,
+            css,
+          );
+          continue;
+        }
+        if (property === "animation-timing-function") {
+          for (const offset of offsets) timingByOffset.set(offset, declaration.value.trim());
+          continue;
+        }
+        if (property === "animation" || CSS_ANIMATION_LONGHANDS.includes(property as CSSAnimationLonghand)) continue;
+        for (const offset of offsets) {
+          const declarations = byOffset.get(offset) ?? [];
+          declarations.push({ property, value: declaration.value.trim(), css });
+          byOffset.set(offset, declarations);
+        }
+      }
+    }
+    this.keyframes.set(name, {
+      name,
+      blocks: [...byOffset.entries()]
+        .sort(([left], [right]) => left - right)
+        .map(([offset, declarations]) => ({
+          offset,
+          declarations,
+          ...(timingByOffset.get(offset) ? { timingFunction: timingByOffset.get(offset) } : {}),
+        })),
+    });
+  }
+
+  animationKeyframes(): ReadonlyMap<string, CSSKeyframesRule> {
+    return this.keyframes;
   }
 
   private compileRule(rule: Rule, styleElement: ElementNode): void {
@@ -427,7 +542,12 @@ export class SVGStyleResolver {
         ...(declaration.source?.start?.line === undefined ? {} : { line: declaration.source.start.line }),
         ...(declaration.source?.start?.column === undefined ? {} : { column: declaration.source.start.column }),
       };
-      if (!property.startsWith("--") && !isStyleProperty(property) && property !== "marker") {
+      if (
+        !property.startsWith("--") &&
+        !isStyleProperty(property) &&
+        property !== "marker" &&
+        property !== "animation"
+      ) {
         if (allowForeignObjectCSS) continue;
         this.diagnostic(
           sourceElement,
@@ -441,7 +561,12 @@ export class SVGStyleResolver {
         this.diagnostic(sourceElement, "invalid-css-declaration", `Property '${property}' has an empty value.`, css);
         continue;
       }
-      const targets = property === "marker" ? ["marker-start", "marker-mid", "marker-end"] : [property];
+      const targets =
+        property === "marker"
+          ? ["marker-start", "marker-mid", "marker-end"]
+          : property === "animation"
+            ? [...CSS_ANIMATION_LONGHANDS]
+            : [property];
       for (const target of targets) {
         result.push({
           property: target,
@@ -449,6 +574,7 @@ export class SVGStyleResolver {
           important: Boolean(declaration.important),
           order: this.order++,
           css: { ...css, property: target },
+          ...(property === "animation" ? { animationShorthand: true as const } : {}),
         });
       }
     }
@@ -480,6 +606,7 @@ export class SVGStyleResolver {
     for (const [rawName, rawValue] of Object.entries(element.properties ?? {})) {
       const property = canonicalPropertyName(rawName);
       if (!StylePropertiesSet.has(property) && property !== "marker") continue;
+      if (CSS_ANIMATION_LONGHANDS.includes(property as CSSAnimationLonghand)) continue;
       const value = String(rawValue).trim();
       const css: CSSDiagnosticContext = { source: "presentation-attribute", property };
       if (/!\s*important\s*$/i.test(value)) {
@@ -586,6 +713,7 @@ export class SVGStyleResolver {
     const values: Presentation = {};
     const provenance: Record<string, CSSDiagnosticContext> = {};
     const inheritedProperties: Record<string, true> = {};
+    const importantProperties: Record<string, true> = {};
     for (const name of new Set([
       ...Object.keys(inheritedCustom),
       ...[...winners.keys()].filter((property) => property.startsWith("--")),
@@ -609,12 +737,18 @@ export class SVGStyleResolver {
               ? "hidden"
               : definition.initial;
       } else {
-        const substituted = substituteVariables(winner.value, resolveCustom);
+        const substitutedRaw = substituteVariables(winner.value, resolveCustom);
+        const substituted =
+          winner.animationShorthand && substitutedRaw !== undefined
+            ? parseAnimationShorthand(substitutedRaw)?.[property as CSSAnimationLonghand]
+            : substitutedRaw;
         if (substituted === undefined) {
           this.diagnostic(
             element,
-            "invalid-css-variable",
-            `Property '${property}' is invalid after var() substitution.`,
+            substitutedRaw === undefined ? "invalid-css-variable" : "invalid-css-animation-shorthand",
+            substitutedRaw === undefined
+              ? `Property '${property}' is invalid after var() substitution.`
+              : `The animation shorthand '${substitutedRaw}' is invalid.`,
             winner.css,
           );
           value = definition.inherited && inherited[property] !== undefined ? inherited[property]! : definition.initial;
@@ -632,6 +766,7 @@ export class SVGStyleResolver {
           } else value = substituted;
         }
         provenance[property] = winner.css;
+        if (winner.important) importantProperties[property] = true;
       }
       values[property] = value;
     }
@@ -649,6 +784,6 @@ export class SVGStyleResolver {
     for (const property of ["fill", "stroke", "stop-color", "flood-color", "lighting-color", "solid-color"] as const) {
       values[property] = resolveCurrentColor(values[property]!, color);
     }
-    return { values, provenance, inheritedProperties, currentColorProperties };
+    return { values, provenance, inheritedProperties, currentColorProperties, importantProperties };
   }
 }

--- a/packages/svg-to-swiftui-core/src/styleProperties.ts
+++ b/packages/svg-to-swiftui-core/src/styleProperties.ts
@@ -10,6 +10,14 @@ export interface StylePropertyDefinition {
  */
 export const STYLE_PROPERTY_DEFINITIONS = {
   "alignment-baseline": { initial: "auto", inherited: false },
+  "animation-delay": { initial: "0s", inherited: false },
+  "animation-direction": { initial: "normal", inherited: false },
+  "animation-duration": { initial: "0s", inherited: false },
+  "animation-fill-mode": { initial: "none", inherited: false },
+  "animation-iteration-count": { initial: "1", inherited: false },
+  "animation-name": { initial: "none", inherited: false },
+  "animation-play-state": { initial: "running", inherited: false },
+  "animation-timing-function": { initial: "ease", inherited: false },
   "baseline-shift": { initial: "baseline", inherited: false },
   clip: { initial: "auto", inherited: false },
   "clip-path": { initial: "none", inherited: false },

--- a/packages/svg-to-swiftui-core/src/tests/cssAnimations.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/cssAnimations.test.ts
@@ -1,0 +1,122 @@
+import { parseAnimationShorthand, parseCSSAnimationInstances, parseCSSTimingFunction } from "../cssAnimations";
+import { __testing, convert, convertWithDiagnostics } from "../index";
+
+describe("CSS animation syntax", () => {
+  test("expands shorthand lists and applies CSS list matching", () => {
+    const shorthand = parseAnimationShorthand(
+      "slide 2s ease-in -250ms 2.5 alternate both paused, pulse 500ms steps(4, jump-both)",
+    );
+    expect(shorthand).toMatchObject({
+      "animation-name": "slide, pulse",
+      "animation-duration": "2s, 500ms",
+      "animation-delay": "-250ms, 0s",
+      "animation-iteration-count": "2.5, 1",
+      "animation-direction": "alternate, normal",
+      "animation-fill-mode": "both, none",
+      "animation-play-state": "paused, running",
+    });
+    const parsed = parseCSSAnimationInstances({
+      ...shorthand!,
+      "animation-duration": "1s",
+      "animation-delay": "0s, -500ms",
+    });
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.instances).toMatchObject([
+      { name: "slide", duration: 1, delay: 0, iterationCount: 2.5, direction: "alternate" },
+      { name: "pulse", duration: 1, delay: -0.5, timingFunction: { type: "steps", count: 4 } },
+    ]);
+  });
+
+  test("validates cubic and step timing functions", () => {
+    expect(parseCSSTimingFunction("cubic-bezier(.2, -1, .8, 2)")).toEqual({
+      type: "cubic",
+      x1: 0.2,
+      y1: -1,
+      x2: 0.8,
+      y2: 2,
+    });
+    expect(parseCSSTimingFunction("steps(1, jump-none)")).toBeUndefined();
+    expect(parseCSSTimingFunction("cubic-bezier(-.1, 0, 1, 1)")).toBeUndefined();
+  });
+});
+
+describe("compiled CSS keyframes", () => {
+  const source = `
+    <svg viewBox="0 0 100 40"><style>
+      :root { --end-x: 80; }
+      @keyframes move { from { cx: 10; fill: red; } 50% { cx: var(--end-x); animation-timing-function: steps(2, end); } to { cx: 20; fill: blue; } }
+      @keyframes move { from { cx: 12; fill: #ff0000; } 50% { cx: var(--end-x); animation-timing-function: steps(2, end); } to { cx: 24; fill: #0000ff; } }
+      #dot { animation: move 2s cubic-bezier(.2, 0, .8, 1) -250ms 2 alternate both; }
+    </style><circle id="dot" cx="8" cy="20" r="6"/>
+    </svg>`;
+
+  test("uses the last keyframes rule, resolves variables, and builds typed property effects", () => {
+    const document = __testing.parseRenderDocument(source);
+    const animations = document.animationProgram.animations.filter((item) => item.kind === "cssAnimation");
+    expect(animations).toHaveLength(2);
+    expect(animations.map((item) => item.attributeName).sort()).toEqual(["cx", "fill"]);
+    const cx = animations.find((item) => item.attributeName === "cx")!;
+    expect(cx).toMatchObject({
+      target: { key: "id:dot" },
+      value: {
+        family: "length",
+        values: [{ value: 12 }, { value: 80 }, { value: 24 }],
+      },
+      composition: { keyTimes: [0, 0.5, 1] },
+      cssAnimation: {
+        duration: 2,
+        delay: -0.25,
+        iterationCount: 2,
+        direction: "alternate",
+        fillMode: "both",
+        segmentTimingFunctions: [{ type: "cubic" }, { type: "steps", count: 2 }],
+      },
+      runtimeSupport: "typed",
+    });
+  });
+
+  test("lets important declarations beat animations and diagnoses malformed rules", () => {
+    const importantSource = `
+      <svg viewBox="0 0 20 20"><style>
+        @keyframes bad { 120% { opacity: .5 } from { opacity: .2 !important } }
+        #box { opacity: 0.75 !important; animation: bad 1s; }
+      </style><rect id="box" width="20" height="20"/></svg>`;
+    const result = convertWithDiagnostics(importantSource);
+    expect(result.diagnostics.map((item) => item.code)).toEqual(
+      expect.arrayContaining(["invalid-css-keyframe-selector", "ignored-keyframe-important"]),
+    );
+    expect(__testing.parseRenderDocument(importantSource).animationProgram.animations).toHaveLength(0);
+  });
+
+  test("emits the native CSS timing runtime", () => {
+    const swift = convert(source, { structName: "CSSKeyframes", strict: true });
+    expect(swift).toContain("svgCSSAnimatedValue(documentTime: documentTime");
+    expect(swift).toContain("direction: .alternate");
+    expect(swift).toContain("SVGCSSTimingFunction(kind: .steps, count: 2, position: .jumpEnd)");
+    expect(swift).toContain("private static func svgCSSTimingProgress");
+  });
+
+  test("cascades stylesheet longhands against inline shorthand and preserves paused state", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20"><style>
+        @keyframes fade { from { opacity: 0 } to { opacity: 1 } }
+        #box { animation-name: fade; animation-duration: 8s; animation-play-state: running; }
+      </style><rect id="box" width="20" height="20" style="animation: fade 3s linear -1s infinite reverse both paused"/></svg>`);
+    expect(document.animationProgram.animations).toHaveLength(1);
+    expect(document.animationProgram.animations[0]?.cssAnimation).toMatchObject({
+      duration: 3,
+      delay: -1,
+      iterationCount: Number.POSITIVE_INFINITY,
+      direction: "reverse",
+      fillMode: "both",
+      playState: "paused",
+    });
+  });
+
+  test("reports invalid shorthand without compiling a guessed effect", () => {
+    const result = convertWithDiagnostics(`
+      <svg viewBox="0 0 20 20"><style>@keyframes fade { to { opacity: 0 } }</style>
+      <rect id="box" width="20" height="20" style="animation: fade 1s 2s 3s"/></svg>`);
+    expect(result.diagnostics.map((item) => item.code)).toContain("invalid-css-animation-shorthand");
+  });
+});


### PR DESCRIPTION
Closes #102

## What changed
- parse and cascade CSS @keyframes, animation shorthand, all animation longhands, variables, duplicate keyframes, and !important precedence
- emit native SwiftUI timing for delays, iterations, directions, fill/play states, Bézier easing, steps, implicit endpoints, multiple names, transforms, and mixed CSS/SMIL effects
- add benchmark 8 with exact WebKit-vs-Swift frame comparison and document the supported profile

## Validation
- 394 unit tests passed
- benchmark 8: 18/18 frames passed; worst outside tolerance 0.664%
- full temporal suite: 9 reference probes and 146 comparison frames passed
- build, core typecheck, core lint, manifest, animation report, conformance inventory, and fast-path benchmark passed