### PR TITLE
Add animated resource and filter rendering

### DIFF
--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -254,6 +254,8 @@ Typed interpolation, paced/spline sampling, additive composition, and repeat acc
 
 `<animate>` and `<set>` now drive native geometry, presentation, text, viewport, inheritance, and gradient-stop rendering. See the [property contract](docs/animate-set-properties.md) and generated [animation attribute report](conformance/ANIMATION_REPORT.md) for exact implemented and pending properties.
 
+Animated gradients, patterns, clips, masks, markers, filters, text positioning, images, and nested SVG timelines use consumer-specific, pure-time evaluation. See the [animated resource contract](docs/animated-resources.md) and its lossless `benchmark-09` reference comparison.
+
 Optional MP4 files are review artifacts only. They are encoded after the lossless comparisons and never decide whether a test passes. Animation compiler support is being implemented in dependency order under the [Animated SVG roadmap](https://github.com/bring-shrubbery/SVG-to-SwiftUI/issues/94).
 
 ## Migration from 0.4

--- a/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
@@ -383,6 +383,40 @@
         ]
       },
       "expectDistinctReferenceFrames": true
+    },
+    "benchmark-09-animated-resources": {
+      "mode": "comparison",
+      "referenceBackend": "webkit",
+      "width": 160,
+      "height": 120,
+      "expectedMode": "view",
+      "tags": [
+        "animated-bounds",
+        "benchmark-09",
+        "clip-content",
+        "clip-transform",
+        "filter-parameters",
+        "filter-regions",
+        "gradient-coordinates",
+        "image",
+        "marker-content",
+        "marker-orientation",
+        "marker-units",
+        "mask-content",
+        "mask-region",
+        "pattern-content",
+        "pattern-transform",
+        "preserve-aspect-ratio",
+        "resource-consumers",
+        "text",
+        "text-character-position"
+      ],
+      "timeline": {
+        "durationMicroseconds": 2000000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [0, 250000, 500000, 750000, 1000000, 1250000, 1500000, 1750000, 2000000]
+      },
+      "expectDistinctReferenceFrames": true
     }
   }
 }

--- a/packages/svg-to-swiftui-core/animation-tests/assets/benchmark-09-nested-image.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/assets/benchmark-09-nested-image.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="10" viewBox="0 0 20 10">
+  <rect width="20" height="10" rx="2" fill="#1e293b"/>
+  <rect x="1" y="1" width="4" height="8" rx="1" fill="#facc15"/>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-09-animated-resources.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/benchmark-09-animated-resources.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120">
+  <rect width="160" height="120" fill="#0f172a"/>
+  <defs>
+    <linearGradient id="moving-gradient" gradientUnits="userSpaceOnUse" x1="8" y1="0" x2="50" y2="0">
+      <animate attributeName="x2" values="50;82" dur="2s" fill="freeze"/>
+      <stop offset="0" stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#f97316"/>
+    </linearGradient>
+    <pattern id="moving-pattern" width="12" height="12" patternUnits="userSpaceOnUse">
+      <animate attributeName="width" values="12;8" dur="2s" fill="freeze"/>
+      <animate attributeName="patternTransform" values="translate(0 0);translate(1 0)" dur="2s" fill="freeze"/>
+      <rect width="4" height="12" fill="#34d399">
+        <animate attributeName="width" values="4;10" dur="2s" fill="freeze"/>
+      </rect>
+    </pattern>
+    <clipPath id="growing-clip" transform="translate(0 0)">
+      <animateTransform attributeName="transform" type="translate" values="0 0;1 0" dur="2s" fill="freeze"/>
+      <circle cx="40" cy="79" r="8">
+        <animate attributeName="r" values="8;24" dur="2s" fill="freeze"/>
+      </circle>
+    </clipPath>
+    <mask id="sliding-mask" maskUnits="userSpaceOnUse" x="82" y="58" width="70" height="42">
+      <animate attributeName="x" values="82;78" dur="2s" fill="freeze"/>
+      <animate attributeName="width" values="70;74" dur="2s" fill="freeze"/>
+      <rect x="82" y="58" width="34" height="42" fill="white">
+        <animate attributeName="x" values="82;116" dur="2s" fill="freeze"/>
+      </rect>
+    </mask>
+    <marker id="animated-arrow" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="0" markerUnits="userSpaceOnUse" overflow="visible">
+      <animate attributeName="orient" values="0;24" dur="2s" fill="freeze"/>
+      <animate attributeName="markerUnits" values="userSpaceOnUse;strokeWidth" dur="2s" calcMode="discrete" fill="freeze"/>
+      <path d="M0 0L9 4.5L0 9Z" fill="#fb7185">
+        <animate attributeName="fill" values="#fb7185;#facc15" dur="2s" fill="freeze"/>
+      </path>
+    </marker>
+    <filter id="moving-filter" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse" x="92" y="3" width="64" height="50">
+      <animate attributeName="x" values="92;88" dur="2s" fill="freeze"/>
+      <animate attributeName="width" values="64;72" dur="2s" fill="freeze"/>
+      <feGaussianBlur stdDeviation="0" result="blur">
+        <animate attributeName="stdDeviation" values="0;2" dur="2s" fill="freeze"/>
+      </feGaussianBlur>
+      <feOffset in="blur" x="92" y="3" width="64" height="50" dx="0" dy="0">
+        <animate attributeName="x" values="92;88" dur="2s" fill="freeze"/>
+        <animate attributeName="width" values="64;72" dur="2s" fill="freeze"/>
+        <animate attributeName="dx" values="0;7" dur="2s" fill="freeze"/>
+        <animate attributeName="dy" values="0;3" dur="2s" fill="freeze"/>
+      </feOffset>
+    </filter>
+  </defs>
+
+  <rect x="8" y="8" width="74" height="38" rx="7" fill="url(#moving-gradient)"/>
+  <rect x="92" y="8" width="58" height="38" rx="7" fill="#a78bfa" filter="url(#moving-filter)"/>
+  <rect x="8" y="58" width="64" height="42" fill="url(#moving-pattern)" clip-path="url(#growing-clip)"/>
+  <rect x="82" y="58" width="70" height="42" fill="#60a5fa" mask="url(#sliding-mask)"/>
+  <path d="M12 110H72" fill="none" stroke="#e2e8f0" stroke-width="3" marker-end="url(#animated-arrow)"/>
+  <image href="../assets/benchmark-09-nested-image.svg" x="72" y="103" width="18" height="12" preserveAspectRatio="xMidYMid meet">
+    <animate attributeName="preserveAspectRatio" values="xMidYMid meet;none" dur="2s" calcMode="discrete" fill="freeze"/>
+  </image>
+  <text x="92" y="113" fill="#f8fafc" font-family="sans-serif" font-size="11"><tspan dx="0 0 0">SVG
+    <animate attributeName="dx" values="0 0 0;0 1 0" dur="2s" fill="freeze"/>
+  </tspan>
+    <animate attributeName="x" values="92;118" dur="2s" fill="freeze"/>
+  </text>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/manifest.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/manifest.ts
@@ -136,6 +136,27 @@ const REQUIRED_CSS_KEYFRAMES_BENCHMARK_TAGS = [
   "transform",
 ] as const;
 
+const REQUIRED_ANIMATED_RESOURCES_BENCHMARK_TAGS = [
+  "animated-bounds",
+  "clip-content",
+  "clip-transform",
+  "filter-parameters",
+  "filter-regions",
+  "gradient-coordinates",
+  "image",
+  "marker-content",
+  "marker-orientation",
+  "marker-units",
+  "mask-content",
+  "mask-region",
+  "pattern-content",
+  "pattern-transform",
+  "preserve-aspect-ratio",
+  "resource-consumers",
+  "text",
+  "text-character-position",
+] as const;
+
 function validateBackground(value: string | null): void {
   if (value !== null && !/^#([\da-f]{6}|[\da-f]{8})$/i.test(value))
     throw new Error(`Background must be null, #RRGGBB, or #RRGGBBAA: ${value}`);
@@ -398,6 +419,14 @@ export function validateAnimationManifest(): string[] {
   for (const tag of REQUIRED_CSS_KEYFRAMES_BENCHMARK_TAGS)
     if (!cssKeyframesBenchmarkTags.has(tag))
       errors.push(`CSS keyframes comparison benchmark does not cover required tag: ${tag}`);
+  const animatedResourcesBenchmarkTags = new Set(
+    fixtures
+      .filter((fixture) => fixture.mode === "comparison" && fixture.tags.includes("benchmark-09"))
+      .flatMap((fixture) => fixture.tags),
+  );
+  for (const tag of REQUIRED_ANIMATED_RESOURCES_BENCHMARK_TAGS)
+    if (!animatedResourcesBenchmarkTags.has(tag))
+      errors.push(`Animated resources comparison benchmark does not cover required tag: ${tag}`);
   if (valueGoldens.version !== 1) errors.push(`Unsupported animation value golden version: ${valueGoldens.version}`);
   if (!Number.isFinite(valueGoldens.tolerance) || valueGoldens.tolerance <= 0)
     errors.push("Animation value golden tolerance must be finite and positive");

--- a/packages/svg-to-swiftui-core/conformance/ANIMATION_REPORT.md
+++ b/packages/svg-to-swiftui-core/conformance/ANIMATION_REPORT.md
@@ -8,88 +8,123 @@ This report describes declarative animation wiring. Attribute rows cover `<anima
 
 | Status | Attributes |
 | --- | ---: |
-| pending follow-up | 29 |
-| pending resource wiring | 35 |
-| implemented | 39 |
+| pending follow-up | 50 |
+| implemented | 86 |
+| pending resource wiring | 6 |
 
 ## Registry
 
 | Attribute | Value family | Namespace | Invalidation | Target | Runtime |
 | --- | --- | --- | --- | --- | --- |
 | `alignment-baseline` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
-| `amplitude` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `azimuth` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `baseFrequency` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `bias` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `amplitude` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `azimuth` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `baseFrequency` | number-list | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `bias` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `clip-path` | discrete | XML, CSS | resource | any | pending resource wiring |
 | `clip-rule` | discrete | XML, CSS | paint | any | pending follow-up |
+| `clipPathUnits` | discrete | XML, CSS | paint | any | pending follow-up |
 | `color` | color | XML, CSS | paint | any | implemented |
-| `color-interpolation` | discrete | XML, CSS | paint | any | pending follow-up |
+| `color-interpolation` | discrete | XML, CSS | paint | any | implemented |
 | `color-interpolation-filters` | discrete | XML, CSS | paint | any | pending follow-up |
 | `cx` | length | XML, CSS | geometry, bounds | any | implemented |
 | `cy` | length | XML, CSS | geometry, bounds | any | implemented |
 | `d` | path | XML, CSS | geometry, bounds | any | implemented |
-| `diffuseConstant` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `diffuseConstant` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `display` | discrete | XML, CSS | visibility | any | implemented |
-| `divisor` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `divisor` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `dominant-baseline` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
 | `dx` | length | XML, CSS | text-layout, bounds | any | implemented |
 | `dy` | length | XML, CSS | text-layout, bounds | any | implemented |
-| `elevation` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `exponent` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `edgeMode` | discrete | XML, CSS | paint | any | pending follow-up |
+| `elevation` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `exponent` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `fill` | paint | XML, CSS | paint | any | implemented |
 | `fill-opacity` | opacity | XML, CSS | paint | any | implemented |
 | `fill-rule` | discrete | XML, CSS | paint | any | pending follow-up |
 | `filter` | discrete | XML, CSS | resource, filter-buffer | any | pending resource wiring |
-| `flood-color` | color | XML, CSS | paint, filter-buffer | filter-primitives | pending resource wiring |
-| `flood-opacity` | opacity | XML, CSS | paint, filter-buffer | filter-primitives | pending resource wiring |
+| `filterUnits` | discrete | XML, CSS | paint | any | pending follow-up |
+| `flood-color` | color | XML, CSS | paint, filter-buffer | filter-primitives | implemented |
+| `flood-opacity` | opacity | XML, CSS | paint, filter-buffer | filter-primitives | implemented |
 | `font-family` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
 | `font-size` | length | XML, CSS | text-layout, bounds | any | implemented |
 | `font-style` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
 | `font-weight` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
-| `fx` | length | XML, CSS | paint | any | pending follow-up |
-| `fy` | length | XML, CSS | paint | any | pending follow-up |
+| `fr` | length | XML, CSS | paint | any | implemented |
+| `fx` | length | XML, CSS | paint | any | implemented |
+| `fy` | length | XML, CSS | paint | any | implemented |
 | `glyph-orientation-horizontal` | angle | XML, CSS | text-layout, bounds | any | pending follow-up |
 | `glyph-orientation-vertical` | angle | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `gradientTransform` | transform | XML, CSS | paint | any | implemented |
+| `gradientUnits` | discrete | XML, CSS | paint | any | implemented |
 | `height` | length | XML, CSS | geometry, bounds | any | implemented |
-| `intercept` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `k` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `k1` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `k2` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `k3` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `k4` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `href` | discrete | XML, CSS | paint | any | pending follow-up |
+| `in` | discrete | XML, CSS | paint | any | pending follow-up |
+| `in2` | discrete | XML, CSS | paint | any | pending follow-up |
+| `intercept` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `k` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `k1` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `k2` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `k3` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `k4` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `kernelMatrix` | number-list | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `kernelUnitLength` | number-list | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `keyPoints` | number-list | XML, CSS | paint | any | pending follow-up |
+| `lengthAdjust` | discrete | XML, CSS | paint | any | pending follow-up |
 | `letter-spacing` | length | XML, CSS | text-layout, bounds | any | implemented |
-| `lighting-color` | color | XML, CSS | paint, filter-buffer | filter-primitives | pending resource wiring |
-| `limitingConeAngle` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `lighting-color` | color | XML, CSS | paint, filter-buffer | filter-primitives | implemented |
+| `limitingConeAngle` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `marker-end` | discrete | XML, CSS | resource | any | pending resource wiring |
 | `marker-mid` | discrete | XML, CSS | resource | any | pending resource wiring |
 | `marker-start` | discrete | XML, CSS | resource | any | pending resource wiring |
 | `markerHeight` | length | XML, CSS | paint | any | pending follow-up |
+| `markerUnits` | discrete | XML, CSS | paint | any | pending follow-up |
 | `markerWidth` | length | XML, CSS | paint | any | pending follow-up |
 | `mask` | discrete | XML, CSS | resource | any | pending resource wiring |
-| `numOctaves` | integer | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `mask-type` | discrete | XML, CSS | paint | any | pending follow-up |
+| `maskContentUnits` | discrete | XML, CSS | paint | any | pending follow-up |
+| `maskUnits` | discrete | XML, CSS | paint | any | pending follow-up |
+| `method` | discrete | XML, CSS | paint | any | pending follow-up |
+| `mode` | discrete | XML, CSS | paint | any | pending follow-up |
+| `numOctaves` | integer | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `offset` | opacity | XML, CSS | paint | stop | implemented |
 | `opacity` | opacity | XML, CSS | paint | any | implemented |
-| `order` | integer | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `operator` | discrete | XML, CSS | paint | any | pending follow-up |
+| `order` | integer | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `orient` | angle | XML, CSS | paint | any | pending follow-up |
 | `overflow` | discrete | XML, CSS | paint | any | pending follow-up |
-| `pathLength` | number | XML, CSS | geometry, bounds, filter-buffer | filter-primitives | pending resource wiring |
+| `pathLength` | number | XML, CSS | geometry, bounds, filter-buffer | filter-primitives | implemented |
+| `patternContentUnits` | discrete | XML, CSS | paint | any | pending follow-up |
+| `patternTransform` | transform | XML, CSS | paint | any | pending follow-up |
+| `patternUnits` | discrete | XML, CSS | paint | any | pending follow-up |
 | `pointer-events` | discrete | XML, CSS | paint | any | pending follow-up |
 | `points` | points | XML, CSS | geometry, bounds | any | implemented |
-| `preserveAspectRatio` | discrete | XML | viewport, geometry, bounds | svg, symbol, view, marker, pattern | implemented |
+| `pointsAtX` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `pointsAtY` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `pointsAtZ` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `preserveAlpha` | discrete | XML, CSS | paint | any | pending follow-up |
+| `preserveAspectRatio` | discrete | XML | viewport, geometry, bounds | svg, symbol, view, marker, pattern, image | implemented |
+| `primitiveUnits` | discrete | XML, CSS | paint | any | pending follow-up |
 | `r` | length | XML, CSS | geometry, bounds | any | implemented |
+| `radius` | number-list | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `refX` | length | XML, CSS | paint | any | pending follow-up |
 | `refY` | length | XML, CSS | paint | any | pending follow-up |
+| `result` | discrete | XML, CSS | paint | any | pending follow-up |
 | `rotate` | number-list | XML, CSS | text-layout, bounds | any | pending follow-up |
 | `rx` | length | XML, CSS | geometry, bounds | any | implemented |
 | `ry` | length | XML, CSS | geometry, bounds | any | implemented |
-| `scale` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `scale` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `seed` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `shape-rendering` | discrete | XML, CSS | paint | any | pending follow-up |
-| `slope` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `specularConstant` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `specularExponent` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `startOffset` | length | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `side` | discrete | XML, CSS | paint | any | pending follow-up |
+| `slope` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `spacing` | discrete | XML, CSS | paint | any | pending follow-up |
+| `specularConstant` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `specularExponent` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `spreadMethod` | discrete | XML, CSS | paint | any | implemented |
+| `startOffset` | length | XML, CSS | text-layout, bounds | any | implemented |
+| `stdDeviation` | number-list | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `stitchTiles` | discrete | XML, CSS | paint | any | pending follow-up |
 | `stop-color` | color | XML, CSS | paint | stop | implemented |
 | `stop-opacity` | opacity | XML, CSS | paint | stop | implemented |
 | `stroke` | paint | XML, CSS | paint | any | implemented |
@@ -100,25 +135,29 @@ This report describes declarative animation wiring. Attribute rows cover `<anima
 | `stroke-miterlimit` | number | XML, CSS | paint | any | implemented |
 | `stroke-opacity` | opacity | XML, CSS | paint | any | implemented |
 | `stroke-width` | length | XML, CSS | paint | any | implemented |
-| `surfaceScale` | number | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `targetX` | integer | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
-| `targetY` | integer | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `surfaceScale` | number | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `tableValues` | number-list | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `targetX` | integer | XML, CSS | filter-buffer | filter-primitives | implemented |
+| `targetY` | integer | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `text-anchor` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
 | `text-decoration` | discrete | XML, CSS | text-layout, bounds | any | pending follow-up |
-| `textLength` | length | XML, CSS | text-layout, bounds | any | pending follow-up |
+| `textLength` | length | XML, CSS | text-layout, bounds | any | implemented |
 | `transform` | transform | XML, CSS | paint | any | pending follow-up |
-| `values` | number-list | XML, CSS | filter-buffer | filter-primitives | pending resource wiring |
+| `type` | discrete | XML, CSS | paint | any | pending follow-up |
+| `values` | number-list | XML, CSS | filter-buffer | filter-primitives | implemented |
 | `vector-effect` | discrete | XML, CSS | paint | any | pending follow-up |
-| `viewBox` | viewBox | XML | viewport, geometry, bounds | svg, symbol, view, marker, pattern | implemented |
+| `viewBox` | viewBox | XML | viewport, geometry, bounds | svg, symbol, view, marker, pattern, image | implemented |
 | `visibility` | discrete | XML, CSS | visibility | any | implemented |
 | `width` | length | XML, CSS | geometry, bounds | any | implemented |
 | `word-spacing` | length | XML, CSS | text-layout, bounds | any | implemented |
 | `x` | length | XML, CSS | geometry, bounds, text-layout | any | implemented |
 | `x1` | length | XML, CSS | geometry, bounds | any | implemented |
 | `x2` | length | XML, CSS | geometry, bounds | any | implemented |
+| `xChannelSelector` | discrete | XML, CSS | paint | any | pending follow-up |
 | `y` | length | XML, CSS | geometry, bounds, text-layout | any | implemented |
 | `y1` | length | XML, CSS | geometry, bounds | any | implemented |
 | `y2` | length | XML, CSS | geometry, bounds | any | implemented |
+| `yChannelSelector` | discrete | XML, CSS | paint | any | pending follow-up |
 
 ## Specialized animation elements
 
@@ -127,3 +166,4 @@ This report describes declarative animation wiring. Attribute rows cover `<anima
 | `<animateTransform>` | implemented | typed parser/sampler/composition tests; 18-frame `benchmark-06-animate-transform` |
 | `<animateMotion>` / `<mpath>` | implemented | metric/parser/composition tests; 18-frame `benchmark-07-animate-motion` |
 | CSS `@keyframes` | implemented | cascade/timing/value tests; 18-frame `benchmark-08-css-keyframes` |
+| Animated resources, filters, and nested text | implemented | resource/filter/text unit evidence; 9-frame `benchmark-09-animated-resources` |

--- a/packages/svg-to-swiftui-core/conformance/animation-report.ts
+++ b/packages/svg-to-swiftui-core/conformance/animation-report.ts
@@ -3,6 +3,7 @@ import { ANIMATION_ATTRIBUTE_REGISTRY } from "../src/renderTree/animationValues"
 const labels = {
   "render-node": "implemented",
   "gradient-stop": "implemented",
+  resource: "implemented",
   "pending-resource": "pending resource wiring",
   "pending-follow-up": "pending follow-up",
 } as const;
@@ -40,6 +41,7 @@ export function renderAnimationReport(): string {
     "| `<animateTransform>` | implemented | typed parser/sampler/composition tests; 18-frame `benchmark-06-animate-transform` |",
     "| `<animateMotion>` / `<mpath>` | implemented | metric/parser/composition tests; 18-frame `benchmark-07-animate-motion` |",
     "| CSS `@keyframes` | implemented | cascade/timing/value tests; 18-frame `benchmark-08-css-keyframes` |",
+    "| Animated resources, filters, and nested text | implemented | resource/filter/text unit evidence; 9-frame `benchmark-09-animated-resources` |",
     "",
   ];
   return lines.join("\n");

--- a/packages/svg-to-swiftui-core/docs/animated-resources.md
+++ b/packages/svg-to-swiftui-core/docs/animated-resources.md
@@ -1,0 +1,36 @@
+# Animated resources, filters, text, and nested documents
+
+Resource animation is compiled into pure functions of the SVG document time. Generated SwiftUI does not retain a previous frame, mutate a shared definition, or fetch a resource while rendering. The same timestamp therefore produces the same result even when frames are requested out of order.
+
+## Instance model
+
+Gradients, patterns, clips, masks, markers, and filters retain immutable parsed definitions. Each reference produces a consumer-specific instance with its own viewport, object bounding box, transform, font context, and filter-unit scale. Animated values are sampled at the consuming view's `documentTime`; one consumer cannot cache coordinates or filter parameters for another.
+
+The generated code currently samples:
+
+- linear and radial coordinates, focal values, transforms, spread modes, color interpolation, and stop offset/color/opacity;
+- pattern origin, size, transform, and complete animated vector content;
+- clip and mask content, clip transforms, and mask regions;
+- marker content, orientation, and marker-unit scaling;
+- filter regions, primitive subregions and inputs, spatial parameters, matrices, transfer tables/functions, convolution, deterministic turbulence, colors, compositing modes, and light sources;
+- text/tspan/textPath position, character `dx`/`dy`/`rotate`, text length, typography, paint, and path offset;
+- image placement through animated `preserveAspectRatio`, ordinary opacity/transforms, and nested SVG document time;
+- nested SVG viewport/viewBox animation and inherited presentation animation.
+
+`benchmark-09-animated-resources` is the independent WebKit comparison scene for these integrations. It renders exact microsecond timestamps through both engines and compares lossless premultiplied-sRGB RGBA frames. The generated MP4 is review-only.
+
+## Bounds and filters
+
+Animated filter regions and primitive subregions are rebuilt for each frame. Object-bounding-box numeric parameters are scaled independently for every consumer. Filter pixels stay premultiplied through the graph, with temporary unpremultiplication only where the Filter Effects formulas require it. Turbulence output is deterministic for the same sampled seed and parameters.
+
+Immutable parse data is shared. Generated playback has no monotonic-time cache and no unbounded frame cache. Conversion tests also cap generated source size and conversion time for a representative many-consumer resource graph; runtime filter pixel limits remain unchanged.
+
+## Nested time and resource safety
+
+Embedded SVG `<image>` and SVG-backed `<feImage>` documents receive the parent's canonical document time. Rendering never introduces network or filesystem access. Existing cycle, nesting, byte, decoded-pixel, filter-pixel, kernel, and octave limits apply before animation frames are produced.
+
+## Accessibility and conditional processing
+
+`<title>` and `<desc>` text, ARIA metadata, and conditional-processing selection are compiled as document semantics, not per-frame paint values. They are not accepted as SMIL/CSS interpolation targets in the native profile. This keeps the accessibility tree stable while visual attributes animate. Ordinary animated visibility continues to affect whether a rendered semantic element is exposed.
+
+Scripts, live HTML mutation in `foreignObject`, external audio/video playback, and runtime DOM mutation remain outside the native declarative renderer.

--- a/packages/svg-to-swiftui-core/src/renderTree/animation.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/animation.ts
@@ -19,7 +19,7 @@ import {
   parseAnimationValueSet,
   parseKeySplines,
   parseKeyTimes,
-  resolveAnimationAttribute,
+  resolveAnimationAttributeForTarget,
   sampleAnimationValue,
   validateAnimationCalculation,
 } from "./animationValues";
@@ -285,12 +285,69 @@ const GEOMETRY_TARGETS: Readonly<Record<string, readonly string[]>> = {
   y: ["rect", "svg", "image", "foreignObject", "text", "tspan", "use", "pattern", "mask", "filter"],
 };
 
+const FILTER_REGION_ATTRIBUTES = ["x", "y", "width", "height", "result", "color-interpolation-filters"];
+const FILTER_INPUT_ATTRIBUTES = [...FILTER_REGION_ATTRIBUTES, "in"];
+const FILTER_TARGET_ATTRIBUTES: Readonly<Record<string, readonly string[]>> = {
+  feblend: [...FILTER_INPUT_ATTRIBUTES, "in2", "mode"],
+  fecolormatrix: [...FILTER_INPUT_ATTRIBUTES, "type", "values"],
+  fecomponenttransfer: FILTER_INPUT_ATTRIBUTES,
+  fecomposite: [...FILTER_INPUT_ATTRIBUTES, "in2", "operator", "k1", "k2", "k3", "k4"],
+  feconvolvematrix: [
+    ...FILTER_INPUT_ATTRIBUTES,
+    "order",
+    "kernelMatrix",
+    "divisor",
+    "bias",
+    "targetX",
+    "targetY",
+    "edgeMode",
+    "kernelUnitLength",
+    "preserveAlpha",
+  ],
+  fediffuselighting: [
+    ...FILTER_INPUT_ATTRIBUTES,
+    "surfaceScale",
+    "diffuseConstant",
+    "kernelUnitLength",
+    "lighting-color",
+  ],
+  fedisplacementmap: [...FILTER_INPUT_ATTRIBUTES, "in2", "scale", "xChannelSelector", "yChannelSelector"],
+  fedistantlight: ["azimuth", "elevation"],
+  fedropshadow: [...FILTER_INPUT_ATTRIBUTES, "stdDeviation", "dx", "dy", "flood-color", "flood-opacity"],
+  feflood: [...FILTER_REGION_ATTRIBUTES, "flood-color", "flood-opacity"],
+  fefunca: ["type", "tableValues", "slope", "intercept", "amplitude", "exponent", "offset"],
+  fefuncb: ["type", "tableValues", "slope", "intercept", "amplitude", "exponent", "offset"],
+  fefuncg: ["type", "tableValues", "slope", "intercept", "amplitude", "exponent", "offset"],
+  fefuncr: ["type", "tableValues", "slope", "intercept", "amplitude", "exponent", "offset"],
+  fegaussianblur: [...FILTER_INPUT_ATTRIBUTES, "stdDeviation", "edgeMode"],
+  feimage: [...FILTER_REGION_ATTRIBUTES, "href", "preserveAspectRatio"],
+  femerge: FILTER_REGION_ATTRIBUTES,
+  femergenode: ["in"],
+  femorphology: [...FILTER_INPUT_ATTRIBUTES, "operator", "radius"],
+  feoffset: [...FILTER_INPUT_ATTRIBUTES, "dx", "dy"],
+  fepointlight: ["x", "y", "z"],
+  fespecularlighting: [
+    ...FILTER_INPUT_ATTRIBUTES,
+    "surfaceScale",
+    "specularConstant",
+    "specularExponent",
+    "kernelUnitLength",
+    "lighting-color",
+  ],
+  fespotlight: ["x", "y", "z", "pointsAtX", "pointsAtY", "pointsAtZ", "specularExponent", "limitingConeAngle"],
+  fetile: FILTER_INPUT_ATTRIBUTES,
+  feturbulence: [...FILTER_REGION_ATTRIBUTES, "baseFrequency", "numOctaves", "seed", "stitchTiles", "type"],
+};
+
 function propertyAppliesToTarget(attributeName: string | undefined, tagName: string | undefined): boolean {
   if (!attributeName || !tagName) return false;
+  const filterAttributes = FILTER_TARGET_ATTRIBUTES[tagName.toLowerCase()];
+  if (filterAttributes) return filterAttributes.includes(attributeName);
   const allowed = GEOMETRY_TARGETS[attributeName];
   if (allowed) return allowed.includes(tagName);
-  if (attributeName === "viewBox" || attributeName === "preserveAspectRatio")
-    return ["svg", "symbol", "view", "marker", "pattern"].includes(tagName);
+  if (attributeName === "viewBox") return ["svg", "symbol", "view", "marker", "pattern"].includes(tagName);
+  if (attributeName === "preserveAspectRatio")
+    return ["svg", "symbol", "view", "marker", "pattern", "image"].includes(tagName);
   if (["dx", "dy", "rotate", "textLength", "startOffset"].includes(attributeName))
     return ["text", "tspan", "textPath"].includes(tagName);
   if (attributeName === "offset") return tagName === "stop";
@@ -302,6 +359,7 @@ function parseValue(
   attributeName: string | undefined,
   context: AnimationValueContext,
   baseRaw?: string,
+  attributeSpec?: ReturnType<typeof resolveAnimationAttributeForTarget>,
 ): AnimationValue {
   const fromRaw = property(animation, "from");
   const toRaw = property(animation, "to");
@@ -320,6 +378,7 @@ function parseValue(
         ...(valuesRaw ? { values: valuesRaw } : {}),
       },
       context,
+      attributeSpec,
     );
     if (parsed) return parsed;
   }
@@ -340,14 +399,16 @@ function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSuppor
     )
   )
     return false;
-  const attribute = definition.attributeName ? resolveAnimationAttribute(definition.attributeName) : undefined;
+  const attribute = definition.attributeName
+    ? resolveAnimationAttributeForTarget(definition.attributeName, definition.attributeType, definition.target?.tagName)
+    : undefined;
   const resourceSupported =
     definition.target?.binding === "resource" &&
-    definition.target.tagName.toLowerCase() === "stop" &&
-    attribute?.runtimeBinding === "gradient-stop";
+    (attribute?.runtimeBinding === "gradient-stop" || attribute?.runtimeBinding === "resource");
   const renderNodeSupported =
     definition.target?.binding === "render-node" &&
     (attribute?.runtimeBinding === "render-node" ||
+      attribute?.runtimeBinding === "resource" ||
       (definition.kind === "animateTransform" && definition.attributeName === "transform") ||
       (definition.kind === "animateMotion" && definition.attributeName === "motion"));
   if (
@@ -568,7 +629,7 @@ export function buildAnimationProgram(
           ? "motion"
           : authoredAttributeName;
     const attributeSpec = effectiveAttributeName
-      ? resolveAnimationAttribute(effectiveAttributeName, attributeType)
+      ? resolveAnimationAttributeForTarget(effectiveAttributeName, attributeType, targetTag)
       : undefined;
     const attributeName = kind === "animateMotion" ? "motion" : attributeSpec?.canonicalName;
     if ((kind === "animate" || kind === "set" || kind === "animateTransform") && !authoredAttributeName)
@@ -662,7 +723,7 @@ export function buildAnimationProgram(
             },
             targetSnapshot?.context ?? animationValueContext,
           ) ?? { family: "unsupported" as const })
-        : parseValue(element, attributeName, targetSnapshot?.context ?? animationValueContext, baseRaw);
+        : parseValue(element, attributeName, targetSnapshot?.context ?? animationValueContext, baseRaw, attributeSpec);
     const calcModeSource = property(element, "calcMode");
     const defaultCalcMode = kind === "set" ? "discrete" : kind === "animateMotion" ? "paced" : "linear";
     const calcMode = ["discrete", "linear", "paced", "spline"].includes(calcModeSource ?? "")
@@ -997,7 +1058,7 @@ export function buildAnimationProgram(
       for (const attributeName of properties) {
         if (attributeName.startsWith("--")) continue;
         if (targetSnapshot.importantProperties?.[attributeName]) continue;
-        const attribute = resolveAnimationAttribute(attributeName, "CSS");
+        const attribute = resolveAnimationAttributeForTarget(attributeName, "CSS", targetSnapshot.tagName);
         if (!attribute || !attribute.animatable || !propertyAppliesToTarget(attributeName, targetSnapshot.tagName)) {
           diagnostic(
             diagnostics,

--- a/packages/svg-to-swiftui-core/src/renderTree/animationValues.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/animationValues.ts
@@ -44,7 +44,7 @@ export type AnimationInvalidationCategory =
 
 export interface AnimationAttributeRegistryEntry extends AnimationAttributeSpec {
   targetElements: readonly string[] | "graphics" | "text" | "filter-primitives" | "any";
-  runtimeBinding: "render-node" | "gradient-stop" | "pending-resource" | "pending-follow-up";
+  runtimeBinding: "render-node" | "gradient-stop" | "resource" | "pending-resource" | "pending-follow-up";
 }
 
 export interface AnimationValueContext {
@@ -129,7 +129,6 @@ const NUMBER_LIST = new RegExp(`^\\s*${NUMBER_SOURCE}(?:[\\s,]+${NUMBER_SOURCE})
 const NUMBER_ATTRIBUTES = new Set([
   "amplitude",
   "azimuth",
-  "baseFrequency",
   "bias",
   "diffuseConstant",
   "divisor",
@@ -143,7 +142,11 @@ const NUMBER_ATTRIBUTES = new Set([
   "k4",
   "limitingConeAngle",
   "pathLength",
+  "pointsAtX",
+  "pointsAtY",
+  "pointsAtZ",
   "scale",
+  "seed",
   "slope",
   "specularConstant",
   "specularExponent",
@@ -166,6 +169,7 @@ const HORIZONTAL_LENGTH_ATTRIBUTES = new Set([
 const VERTICAL_LENGTH_ATTRIBUTES = new Set(["cy", "dy", "fy", "height", "markerHeight", "refY", "y", "y1", "y2"]);
 const OTHER_LENGTH_ATTRIBUTES = new Set([
   "font-size",
+  "fr",
   "letter-spacing",
   "r",
   "rx",
@@ -178,31 +182,66 @@ const OTHER_LENGTH_ATTRIBUTES = new Set([
 const ANGLE_ATTRIBUTES = new Set(["glyph-orientation-horizontal", "glyph-orientation-vertical", "orient"]);
 const COLOR_ATTRIBUTES = new Set(["color", "flood-color", "lighting-color", "stop-color"]);
 const LENGTH_LIST_ATTRIBUTES = new Set(["stroke-dasharray"]);
+const NUMBER_LIST_ATTRIBUTES = new Set([
+  "baseFrequency",
+  "kernelMatrix",
+  "kernelUnitLength",
+  "radius",
+  "stdDeviation",
+  "tableValues",
+]);
 const DISCRETE_ATTRIBUTES = new Set([
   "alignment-baseline",
   "clip-path",
+  "clipPathUnits",
   "clip-rule",
   "color-interpolation",
   "color-interpolation-filters",
   "display",
+  "edgeMode",
   "dominant-baseline",
   "fill-rule",
   "filter",
+  "filterUnits",
   "font-family",
   "font-style",
   "font-weight",
+  "gradientUnits",
+  "href",
+  "in",
+  "in2",
+  "lengthAdjust",
+  "markerUnits",
+  "maskContentUnits",
+  "mask-type",
+  "maskUnits",
+  "method",
+  "mode",
+  "operator",
   "marker-end",
   "marker-mid",
   "marker-start",
   "mask",
   "overflow",
+  "patternContentUnits",
+  "patternUnits",
   "pointer-events",
   "preserveAspectRatio",
+  "preserveAlpha",
+  "primitiveUnits",
+  "result",
   "shape-rendering",
+  "side",
+  "spacing",
+  "spreadMethod",
+  "stitchTiles",
   "stroke-linecap",
   "stroke-linejoin",
   "text-anchor",
   "text-decoration",
+  "type",
+  "xChannelSelector",
+  "yChannelSelector",
   "vector-effect",
   "visibility",
 ]);
@@ -249,6 +288,7 @@ const TEXT_ATTRIBUTES = new Set([
 const FILTER_ATTRIBUTES = new Set([
   ...NUMBER_ATTRIBUTES,
   ...INTEGER_ATTRIBUTES,
+  ...NUMBER_LIST_ATTRIBUTES,
   "flood-color",
   "flood-opacity",
   "lighting-color",
@@ -360,15 +400,17 @@ function registryEntry(
         : TEXT_ATTRIBUTES.has(canonicalName)
           ? "any"
           : canonicalName === "viewBox" || canonicalName === "preserveAspectRatio"
-            ? ["svg", "symbol", "view", "marker", "pattern"]
+            ? ["svg", "symbol", "view", "marker", "pattern", "image"]
             : "any",
     runtimeBinding: ANIMATE_SET_RENDER_ATTRIBUTES.has(canonicalName)
       ? "render-node"
       : GRADIENT_STOP_ATTRIBUTES.has(canonicalName)
         ? "gradient-stop"
-        : FILTER_ATTRIBUTES.has(canonicalName) || RESOURCE_ATTRIBUTES.has(canonicalName)
-          ? "pending-resource"
-          : "pending-follow-up",
+        : FILTER_ATTRIBUTES.has(canonicalName)
+          ? "resource"
+          : RESOURCE_ATTRIBUTES.has(canonicalName)
+            ? "pending-resource"
+            : "pending-follow-up",
     ...options,
   };
 }
@@ -389,11 +431,12 @@ register(HORIZONTAL_LENGTH_ATTRIBUTES, "length", true, () => ({ axis: "horizonta
 register(VERTICAL_LENGTH_ATTRIBUTES, "length", true, () => ({ axis: "vertical" }));
 register(OTHER_LENGTH_ATTRIBUTES, "length", true, (name) => ({
   axis: "other",
-  ...(["r", "rx", "ry", "stroke-width"].includes(name) ? { clamp: "nonnegative" as const } : {}),
+  ...(["fr", "r", "rx", "ry", "stroke-width"].includes(name) ? { clamp: "nonnegative" as const } : {}),
 }));
 register(ANGLE_ATTRIBUTES, "angle", true);
 register(COLOR_ATTRIBUTES, "color", true);
 register(LENGTH_LIST_ATTRIBUTES, "length-list", true, () => ({ axis: "other" }));
+register(NUMBER_LIST_ATTRIBUTES, "number-list", true);
 register(DISCRETE_ATTRIBUTES, "discrete", false);
 registry.set("stroke-miterlimit", registryEntry("stroke-miterlimit", "number", true, { clamp: "nonnegative" }));
 registry.set("offset", registryEntry("offset", "opacity", true, { clamp: "unit" }));
@@ -401,11 +444,27 @@ registry.set("points", registryEntry("points", "points", true));
 registry.set("d", registryEntry("d", "path", false));
 registry.set("viewBox", registryEntry("viewBox", "viewBox", true));
 registry.set("transform", registryEntry("transform", "transform", true));
+registry.set("gradientTransform", registryEntry("gradientTransform", "transform", true));
+registry.set("patternTransform", registryEntry("patternTransform", "transform", true));
 registry.set("fill", registryEntry("fill", "paint", true));
 registry.set("stroke", registryEntry("stroke", "paint", true));
 registry.set("values", registryEntry("values", "number-list", true));
 registry.set("keyPoints", registryEntry("keyPoints", "number-list", true));
 registry.set("rotate", registryEntry("rotate", "number-list", true));
+for (const name of [
+  "color-interpolation",
+  "fr",
+  "fx",
+  "fy",
+  "gradientTransform",
+  "gradientUnits",
+  "spreadMethod",
+  "startOffset",
+  "textLength",
+]) {
+  const entry = registry.get(name);
+  if (entry) registry.set(name, { ...entry, runtimeBinding: "resource" });
+}
 
 /** Machine-readable registry shared by SMIL, CSS animation, code generation, and conformance reporting. */
 export const ANIMATION_ATTRIBUTE_REGISTRY: readonly AnimationAttributeRegistryEntry[] = [...registry.values()].sort(
@@ -424,6 +483,65 @@ export function resolveAnimationAttribute(
   const spec = registry.get(attributeName);
   if (!spec) return undefined;
   return attributeType === "auto" || spec.namespaces.includes(attributeType) ? spec : undefined;
+}
+
+/** Attribute names such as `offset` have target-specific value grammars in SVG. */
+export function resolveAnimationAttributeForTarget(
+  attributeName: string,
+  attributeType: "auto" | "XML" | "CSS" = "auto",
+  targetTagName?: string,
+): AnimationAttributeRegistryEntry | undefined {
+  const spec = resolveAnimationAttribute(attributeName, attributeType);
+  if (!spec) return undefined;
+  const tag = targetTagName?.toLowerCase() ?? "";
+  if (
+    (tag === "lineargradient" || tag === "radialgradient") &&
+    [
+      "x1",
+      "y1",
+      "x2",
+      "y2",
+      "cx",
+      "cy",
+      "r",
+      "fx",
+      "fy",
+      "fr",
+      "gradientUnits",
+      "gradientTransform",
+      "spreadMethod",
+      "color-interpolation",
+    ].includes(attributeName)
+  )
+    return { ...spec, runtimeBinding: "resource" };
+  if (tag === "pattern" && ["x", "y", "width", "height", "patternTransform"].includes(attributeName))
+    return { ...spec, runtimeBinding: "resource" };
+  if (tag === "filter" && ["x", "y", "width", "height"].includes(attributeName))
+    return { ...spec, runtimeBinding: "resource" };
+  if (["clippath", "mask", "marker"].includes(tag) && attributeName === "transform")
+    return { ...spec, runtimeBinding: "resource" };
+  if (tag === "mask" && ["x", "y", "width", "height"].includes(attributeName))
+    return { ...spec, runtimeBinding: "resource" };
+  if (
+    tag === "marker" &&
+    ["markerWidth", "markerHeight", "refX", "refY", "markerUnits", "orient", "viewBox", "preserveAspectRatio"].includes(
+      attributeName,
+    )
+  )
+    return { ...spec, runtimeBinding: "resource" };
+  if (["fepointlight", "fespotlight"].includes(tag) && ["x", "y", "z"].includes(attributeName))
+    return { ...spec, family: "number", axis: undefined, runtimeBinding: "resource" };
+  if (tag.startsWith("fe") && ["dx", "dy"].includes(attributeName))
+    return { ...spec, family: "number", axis: undefined, runtimeBinding: "resource" };
+  if (attributeName === "offset" && /^feFunc[RGBA]$/i.test(targetTagName ?? ""))
+    return { ...spec, family: "number", clamp: undefined, runtimeBinding: "resource" };
+  if (tag === "feconvolvematrix" && attributeName === "order")
+    return { ...spec, family: "number-list", clamp: "nonnegative", runtimeBinding: "resource" };
+  if (["text", "tspan", "textpath"].includes(tag) && ["x", "y", "dx", "dy"].includes(attributeName))
+    return { ...spec, family: "length-list", runtimeBinding: tag === "text" ? "render-node" : "resource" };
+  if (tag.startsWith("fe")) return { ...spec, runtimeBinding: "resource" };
+  if (["tspan", "textpath"].includes(tag)) return { ...spec, runtimeBinding: "resource" };
+  return spec;
 }
 
 function numbers(source: string): number[] | undefined {
@@ -785,8 +903,9 @@ export function parseAnimationValueSet(
   attributeName: string,
   raw: { base?: string; from?: string; to?: string; by?: string; values?: readonly string[] },
   context: AnimationValueContext,
+  targetAttribute?: AnimationAttributeSpec,
 ): AnimationValueSet | undefined {
-  const attribute = animationAttributeSpec(attributeName);
+  const attribute = targetAttribute ?? animationAttributeSpec(attributeName);
   if (!attribute?.animatable || raw.base === undefined) return undefined;
   const parse = (value: string | undefined) =>
     value === undefined ? undefined : parseAnimationValue(attribute, value, context);

--- a/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/buildRenderTree.ts
@@ -1035,11 +1035,13 @@ function buildText(
   }
   interface LengthScope {
     owner: ElementNode;
+    animationTargetKey: string;
     target: number;
     mode: RenderTextLengthAdjustment["mode"];
     characters: number[];
   }
   interface RawSegment {
+    animationTargetKey: string;
     text: string;
     preserveSpace: boolean;
     scopes: PositionScope[];
@@ -1239,6 +1241,7 @@ function buildText(
       if (sideValue !== "left" && sideValue !== "right")
         addDiagnostic(context, owner, "invalid-text-path-side", `Invalid textPath side '${sideValue}'.`);
       return {
+        animationTargetKey: animationTargetKey(owner, context),
         points: metrics.points,
         length: metrics.length,
         closed: metrics.closed,
@@ -1318,6 +1321,7 @@ function buildText(
           addDiagnostic(context, owner, "invalid-length-adjust", `Invalid lengthAdjust '${lengthAdjust}'.`);
         ownLengthScope = {
           owner,
+          animationTargetKey: animationTargetKey(owner, context),
           target: ownLength,
           mode: lengthAdjust === "spacingAndGlyphs" ? "spacingAndGlyphs" : "spacing",
           characters: [],
@@ -1365,6 +1369,7 @@ function buildText(
       .trim()
       .toLowerCase();
     const run: RawSegment["run"] = {
+      animationTargetKey: animationTargetKey(owner, context),
       font: {
         family: resolveTextFamily(owner, effective["font-family"], context),
         size,
@@ -1412,6 +1417,7 @@ function buildText(
       const decoded = textContent({ ...owner, children: [child] });
       if (!value && !decoded) continue;
       rawSegments.push({
+        animationTargetKey: animationTargetKey(owner, context),
         text: decoded,
         preserveSpace,
         scopes,
@@ -1493,6 +1499,7 @@ function buildText(
       previous.segment.writingMode !== character.segment.writingMode;
     if (startsChunk) {
       chunks.push({
+        animationTargetKey: character.segment.animationTargetKey,
         ...(character.x === undefined ? {} : { x: character.x }),
         ...(character.y === undefined ? {} : { y: character.y }),
         anchor: character.segment.anchor,
@@ -1533,9 +1540,11 @@ function buildText(
         .filter((index) => index >= 0);
       if (local.length === 0) continue;
       chunks[chunkIndex]!.lengthAdjustments.push({
+        animationTargetKey: scope.animationTargetKey,
         start: Math.min(...local),
         end: Math.max(...local) + 1,
         target: scope.target * (local.length / total),
+        animationScale: local.length / total,
         mode: scope.mode,
       });
     }
@@ -2251,10 +2260,18 @@ export function buildRenderDocument(
     styleResolver,
     resolved.effective,
     diagnostics,
+    (element) => animationTargetKeys.get(element),
   )) {
     resources.paints.set(id, paint);
   }
-  resources.masks = resolveMaskResources(svg, resources.maskElements, styleResolver, resolved.effective, diagnostics);
+  resources.masks = resolveMaskResources(
+    svg,
+    resources.maskElements,
+    styleResolver,
+    resolved.effective,
+    diagnostics,
+    (element) => animationTargetKey(element, context),
+  );
   resources.clips = resolveClipPathResources(
     svg,
     resources.clipElements,
@@ -2268,6 +2285,7 @@ export function buildRenderDocument(
     styleResolver,
     resolved.effective,
     diagnostics,
+    (element) => animationTargetKey(element, context),
   );
   resources.filters = resolveFilterResources(
     svg,
@@ -2277,6 +2295,7 @@ export function buildRenderDocument(
     resolved.effective,
     config,
     diagnostics,
+    (element) => animationTargetKey(element, context),
   );
 
   const filterPrimitiveElements = (filter: ElementNode) =>
@@ -2692,6 +2711,9 @@ export function buildRenderDocument(
         refX: ref.x,
         refY: ref.y,
         viewBoxTransform: boxTransform,
+        resource,
+        hostAngle: vertex.angle,
+        strokeWidth: shape.style.strokeStyle.width,
       },
       viewport: {
         rect: markerViewport,
@@ -3013,7 +3035,6 @@ export function buildRenderDocument(
     if (paint.type !== "pattern") continue;
     for (const instance of paint.instances.values()) materializeClipPaths(instance.children);
   }
-
   function diagnoseMaskOnce(node: RenderNode, code: string, message: string): void {
     if (diagnostics.some((item) => item.code === code && item.source === node.source && item.message === message))
       return;
@@ -3278,6 +3299,24 @@ export function buildRenderDocument(
   };
   collectAnimationTargetSnapshots(children);
   for (const paint of resources.paints.values()) {
+    if (paint.type !== "pattern") continue;
+    for (const instance of paint.instances.values()) collectAnimationTargetSnapshots(instance.children);
+    collectAnimationTargetSnapshots(paint.children);
+  }
+  for (const resource of resources.clips.values()) {
+    collectAnimationTargetSnapshots(resource.children);
+    for (const instance of resource.instances.values()) collectAnimationTargetSnapshots(instance.children);
+  }
+  for (const resource of resources.masks.values()) {
+    collectAnimationTargetSnapshots(resource.children);
+    for (const instance of resource.instances.values()) collectAnimationTargetSnapshots(instance.children);
+  }
+  for (const resource of resources.markers.values()) {
+    collectAnimationTargetSnapshots(resource.children);
+    for (const instances of resource.instances.values())
+      for (const instance of instances) collectAnimationTargetSnapshots([instance]);
+  }
+  for (const paint of resources.paints.values()) {
     if (paint.type !== "linearGradient" && paint.type !== "radialGradient") continue;
     for (const stop of paint.stops) {
       if (!stop.animationTargetKey || animationTargetSnapshots.has(stop.animationTargetKey)) continue;
@@ -3297,6 +3336,173 @@ export function buildRenderDocument(
         },
         baseValues: stop.animationBaseValues ?? {},
         importantProperties: {},
+      });
+    }
+  }
+  const resourceTags = new Set([
+    "linearGradient",
+    "radialGradient",
+    "pattern",
+    "clipPath",
+    "mask",
+    "marker",
+    "filter",
+    "feBlend",
+    "feColorMatrix",
+    "feComponentTransfer",
+    "feFuncA",
+    "feFuncB",
+    "feFuncG",
+    "feFuncR",
+    "feComposite",
+    "feConvolveMatrix",
+    "feDiffuseLighting",
+    "feDisplacementMap",
+    "feDistantLight",
+    "feDropShadow",
+    "feFlood",
+    "feGaussianBlur",
+    "feImage",
+    "feMerge",
+    "feMergeNode",
+    "feMorphology",
+    "feOffset",
+    "fePointLight",
+    "feSpecularLighting",
+    "feSpotLight",
+    "feTile",
+    "feTurbulence",
+    "textPath",
+    "tspan",
+  ]);
+  const collectedResourceElements = new Set<ElementNode>();
+  const collectResourceSnapshots = (element: ElementNode, inherited: Presentation): void => {
+    if (collectedResourceElements.has(element)) return;
+    collectedResourceElements.add(element);
+    const isResource = resourceTags.has(element.tagName ?? "");
+    const resolution = isResource ? styleResolver.resolve(element, inherited) : undefined;
+    if (resolution) {
+      const key = animationTargetKey(element, context);
+      if (!animationTargetSnapshots.has(key)) {
+        const baseValues: Record<string, string> = {};
+        for (const [name, value] of Object.entries(resolution.values)) baseValues[name] = String(value);
+        for (const [name, value] of Object.entries(element.properties ?? {}))
+          if (value !== undefined && value !== null && name !== "style") baseValues[name] = String(value);
+        animationTargetSnapshots.set(key, {
+          key,
+          tagName: element.tagName ?? "unknown",
+          binding: "resource",
+          context: {
+            length: {
+              viewport: properties.userViewport,
+              rootViewport: { width: properties.width, height: properties.height },
+              fontMetrics: defaultFontMetrics(),
+              percentageBasis: "viewport-diagonal",
+              axis: "other",
+            },
+            colorSpace:
+              String(
+                resolution.values["color-interpolation-filters"] ?? resolution.values["color-interpolation"] ?? "sRGB",
+              ).toLowerCase() === "linearrgb"
+                ? "linearRGB"
+                : "sRGB",
+          },
+          baseValues,
+          importantProperties: resolution.importantProperties,
+        });
+      }
+    }
+    for (const child of childElements(element)) collectResourceSnapshots(child, resolution?.values ?? inherited);
+  };
+  const resourceRoots = new Set<ElementNode>([
+    ...resources.paintElements.values(),
+    ...resources.maskElements.values(),
+    ...resources.clipElements.values(),
+    ...resources.markerElements.values(),
+    ...resources.filterElements.values(),
+  ]);
+  for (const root of resourceRoots) collectResourceSnapshots(root, resolved.effective);
+  const collectNestedTextResources = (element: ElementNode): void => {
+    for (const child of childElements(element)) {
+      if (child.tagName === "tspan" || child.tagName === "textPath")
+        collectResourceSnapshots(child, resolved.effective);
+      else collectNestedTextResources(child);
+    }
+  };
+  collectNestedTextResources(svg);
+  for (const paint of resources.paints.values()) {
+    if (paint.type !== "linearGradient" && paint.type !== "radialGradient" && paint.type !== "pattern") continue;
+    for (const [name, key] of Object.entries(paint.animationTargetKeys)) {
+      if (!key || paint.animationBaseValues[name] === undefined) continue;
+      const snapshot = animationTargetSnapshots.get(key);
+      if (!snapshot) continue;
+      animationTargetSnapshots.set(key, {
+        ...snapshot,
+        context:
+          paint.units === "objectBoundingBox"
+            ? {
+                ...snapshot.context,
+                length: {
+                  ...snapshot.context.length,
+                  viewport: { width: 1, height: 1 },
+                  percentageBasis: "viewport-diagonal",
+                },
+              }
+            : snapshot.context,
+        baseValues: { ...snapshot.baseValues, [name]: paint.animationBaseValues[name]! },
+      });
+    }
+  }
+  for (const marker of resources.markers.values()) {
+    for (const [name, key] of Object.entries(marker.animationTargetKeys)) {
+      const snapshot = animationTargetSnapshots.get(key);
+      if (!snapshot || marker.animationBaseValues[name] === undefined) continue;
+      animationTargetSnapshots.set(key, {
+        ...snapshot,
+        baseValues: { ...snapshot.baseValues, [name]: marker.animationBaseValues[name]! },
+      });
+    }
+  }
+  for (const mask of resources.masks.values()) {
+    for (const [name, key] of Object.entries(mask.animationTargetKeys)) {
+      const snapshot = animationTargetSnapshots.get(key);
+      if (!snapshot || mask.animationBaseValues[name] === undefined) continue;
+      animationTargetSnapshots.set(key, {
+        ...snapshot,
+        context:
+          mask.units === "objectBoundingBox"
+            ? {
+                ...snapshot.context,
+                length: {
+                  ...snapshot.context.length,
+                  viewport: { width: 1, height: 1 },
+                  percentageBasis: "viewport-diagonal",
+                },
+              }
+            : snapshot.context,
+        baseValues: { ...snapshot.baseValues, [name]: mask.animationBaseValues[name]! },
+      });
+    }
+  }
+  for (const filter of resources.filters.values()) {
+    for (const [name, key] of Object.entries(filter.animationTargetKeys)) {
+      if (!key || filter.animationBaseValues[name] === undefined) continue;
+      const snapshot = animationTargetSnapshots.get(key);
+      if (!snapshot) continue;
+      animationTargetSnapshots.set(key, {
+        ...snapshot,
+        context:
+          filter.units === "objectBoundingBox"
+            ? {
+                ...snapshot.context,
+                length: {
+                  ...snapshot.context.length,
+                  viewport: { width: 1, height: 1 },
+                  percentageBasis: "viewport-diagonal",
+                },
+              }
+            : snapshot.context,
+        baseValues: { ...snapshot.baseValues, [name]: filter.animationBaseValues[name]! },
       });
     }
   }

--- a/packages/svg-to-swiftui-core/src/renderTree/filters.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/filters.ts
@@ -450,7 +450,14 @@ function colorMatrix(element: ElementNode, diagnostics: RenderDiagnostic[]): num
   return type === "matrix" ? values : type === "saturate" ? saturateMatrix(values[0]!) : hueRotateMatrix(values[0]!);
 }
 
-function componentFunction(element: ElementNode, diagnostics: RenderDiagnostic[]): FilterComponentTransferFunction {
+function componentFunction(
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+  animationTargetKey?: (element: ElementNode) => string,
+): FilterComponentTransferFunction {
+  const target = animationTargetKey
+    ? { animationTargetKey: animationTargetKey(element), animationTargetTag: element.tagName ?? "unknown" }
+    : {};
   const rawType = String(attribute(element, "type") ?? "identity")
     .trim()
     .toLowerCase();
@@ -461,28 +468,34 @@ function componentFunction(element: ElementNode, diagnostics: RenderDiagnostic[]
       "invalid-filter-component-transfer-type",
       `Invalid component transfer type '${rawType}'; using identity.`,
     );
-    return { type: "identity" };
+    return { type: "identity", ...target };
   }
-  if (rawType === "identity") return { type: "identity" };
+  if (rawType === "identity") return { type: "identity", ...target };
   if (rawType === "table" || rawType === "discrete") {
     const values = numberList(element, "tableValues", diagnostics);
-    return values ? { type: rawType, values } : { type: "identity" };
+    return values ? { type: rawType, values, ...target } : { type: "identity", ...target };
   }
   if (rawType === "linear")
     return {
       type: "linear",
       slope: numberValue(element, "slope", 1, diagnostics),
       intercept: numberValue(element, "intercept", 0, diagnostics),
+      ...target,
     };
   return {
     type: "gamma",
     amplitude: numberValue(element, "amplitude", 1, diagnostics),
     exponent: numberValue(element, "exponent", 1, diagnostics),
     offset: numberValue(element, "offset", 0, diagnostics),
+    ...target,
   };
 }
 
-function componentFunctions(element: ElementNode, diagnostics: RenderDiagnostic[]): FilterComponentTransferFunctions {
+function componentFunctions(
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+  animationTargetKey?: (element: ElementNode) => string,
+): FilterComponentTransferFunctions {
   const functions: FilterComponentTransferFunctions = [
     { type: "identity" },
     { type: "identity" },
@@ -492,7 +505,7 @@ function componentFunctions(element: ElementNode, diagnostics: RenderDiagnostic[
   const channels: Readonly<Record<string, number>> = { fefuncr: 0, fefuncg: 1, fefuncb: 2, fefunca: 3 };
   for (const child of children(element)) {
     const channel = channels[child.tagName?.toLowerCase() ?? ""];
-    if (channel !== undefined) functions[channel] = componentFunction(child, diagnostics);
+    if (channel !== undefined) functions[channel] = componentFunction(child, diagnostics, animationTargetKey);
   }
   return functions;
 }
@@ -539,7 +552,11 @@ function lightingColor(element: ElementNode, presentation: Presentation, diagnos
   return { ...color, alpha: 1 };
 }
 
-function lightSource(element: ElementNode, diagnostics: RenderDiagnostic[]): FilterLightSourceSpec | undefined {
+function lightSource(
+  element: ElementNode,
+  diagnostics: RenderDiagnostic[],
+  animationTargetKey?: (element: ElementNode) => string,
+): FilterLightSourceSpec | undefined {
   const sources: FilterLightSourceSpec[] = [];
   for (const child of children(element)) {
     const tag = child.tagName?.toLowerCase() ?? "";
@@ -547,12 +564,16 @@ function lightSource(element: ElementNode, diagnostics: RenderDiagnostic[]): Fil
     if (tag === "fedistantlight") {
       sources.push({
         type: "distant",
+        ...(animationTargetKey ? { animationTargetKey: animationTargetKey(child) } : {}),
+        animationTargetTag: child.tagName ?? "feDistantLight",
         azimuth: numberValue(child, "azimuth", 0, diagnostics),
         elevation: numberValue(child, "elevation", 0, diagnostics),
       });
     } else if (tag === "fepointlight") {
       sources.push({
         type: "point",
+        ...(animationTargetKey ? { animationTargetKey: animationTargetKey(child) } : {}),
+        animationTargetTag: child.tagName ?? "fePointLight",
         x: numberValue(child, "x", 0, diagnostics),
         y: numberValue(child, "y", 0, diagnostics),
         z: numberValue(child, "z", 0, diagnostics),
@@ -560,6 +581,8 @@ function lightSource(element: ElementNode, diagnostics: RenderDiagnostic[]): Fil
     } else if (tag === "fespotlight") {
       sources.push({
         type: "spot",
+        ...(animationTargetKey ? { animationTargetKey: animationTargetKey(child) } : {}),
+        animationTargetTag: child.tagName ?? "feSpotLight",
         x: numberValue(child, "x", 0, diagnostics),
         y: numberValue(child, "y", 0, diagnostics),
         z: numberValue(child, "z", 0, diagnostics),
@@ -683,6 +706,7 @@ function buildPrimitiveSpecs(
   definitions: Map<string, ElementNode>,
   config: InternalGeneratorConfig,
   diagnostics: RenderDiagnostic[],
+  animationTargetKey?: (element: ElementNode) => string,
 ): FilterPrimitiveSpec[] {
   const specs: FilterPrimitiveSpec[] = [];
   const named = new Map<string, number>();
@@ -721,6 +745,14 @@ function buildPrimitiveSpecs(
     const input = resolveInput(element, attribute(element, "in"));
     const input2 = hasAttribute(element, "in2") ? resolveInput(element, attribute(element, "in2")) : undefined;
     const common = {
+      ...(animationTargetKey ? { animationTargetKey: animationTargetKey(element) } : {}),
+      animationTargetTag: element.tagName ?? "unknown",
+      animationBaseValues: Object.fromEntries(
+        ["x", "y", "width", "height", "in", "in2", "result"].flatMap((name) => {
+          const value = attribute(element, name);
+          return value === undefined ? [] : [[name, String(value)]];
+        }),
+      ),
       region: regionSpec(element, diagnostics),
       colorInterpolation: colorInterpolation(resolved["color-interpolation-filters"], element, diagnostics),
       source: sourceLocation(element),
@@ -743,7 +775,12 @@ function buildPrimitiveSpecs(
     } else if (tag === "fecolormatrix") {
       spec = { type: "colorMatrix", input, matrix: colorMatrix(element, diagnostics), ...common };
     } else if (tag === "fecomponenttransfer") {
-      spec = { type: "componentTransfer", input, functions: componentFunctions(element, diagnostics), ...common };
+      spec = {
+        type: "componentTransfer",
+        input,
+        functions: componentFunctions(element, diagnostics, animationTargetKey),
+        ...common,
+      };
     } else if (tag === "fecomposite") {
       const rawOperator = String(attribute(element, "operator") ?? "over")
         .trim()
@@ -943,7 +980,7 @@ function buildPrimitiveSpecs(
         diffuseConstant: nonNegativeNumber(element, "diffuseConstant", 1, diagnostics),
         ...(kernelUnitLength ? { kernelUnitLengthX: kernelUnitLength[0], kernelUnitLengthY: kernelUnitLength[1] } : {}),
         color: lightingColor(element, resolved, diagnostics),
-        light: lightSource(element, diagnostics),
+        light: lightSource(element, diagnostics, animationTargetKey),
         ...common,
       };
     } else if (tag === "fespecularlighting") {
@@ -956,7 +993,7 @@ function buildPrimitiveSpecs(
         specularExponent: rangedNumber(element, "specularExponent", 1, 1, 128, diagnostics),
         ...(kernelUnitLength ? { kernelUnitLengthX: kernelUnitLength[0], kernelUnitLengthY: kernelUnitLength[1] } : {}),
         color: lightingColor(element, resolved, diagnostics),
-        light: lightSource(element, diagnostics),
+        light: lightSource(element, diagnostics, animationTargetKey),
         ...common,
       };
     } else if (tag === "fegaussianblur") {
@@ -1034,6 +1071,7 @@ export function resolveFilterResources(
   rootPresentation: Presentation,
   config: InternalGeneratorConfig,
   diagnostics: RenderDiagnostic[],
+  animationTargetKey?: (element: ElementNode) => string,
 ): Map<string, FilterResource> {
   const resolutions = new Map<ElementNode, StyleResolution>();
   const walk = (element: ElementNode, inherited: Presentation): void => {
@@ -1110,12 +1148,45 @@ export function resolveFilterResources(
         ? units(attribute(element, "primitiveUnits"), "userSpaceOnUse", "primitiveUnits", element, diagnostics)
         : (base?.primitiveUnits ?? "userSpaceOnUse"),
       colorInterpolation: colorInterpolation(presentation["color-interpolation-filters"], element, diagnostics),
+      animationTargetKeys: Object.fromEntries(
+        ["x", "y", "width", "height", "filterUnits", "primitiveUnits", "color-interpolation-filters"].flatMap(
+          (name) => {
+            const key = hasAttribute(element, name) ? animationTargetKey?.(element) : base?.animationTargetKeys[name];
+            return key ? [[name, key]] : [];
+          },
+        ),
+      ),
+      animationBaseValues: {
+        x: String(attribute(element, "x") ?? base?.animationBaseValues.x ?? "-10%"),
+        y: String(attribute(element, "y") ?? base?.animationBaseValues.y ?? "-10%"),
+        width: String(attribute(element, "width") ?? base?.animationBaseValues.width ?? "120%"),
+        height: String(attribute(element, "height") ?? base?.animationBaseValues.height ?? "120%"),
+        filterUnits: String(
+          attribute(element, "filterUnits") ?? base?.animationBaseValues.filterUnits ?? "objectBoundingBox",
+        ),
+        primitiveUnits: String(
+          attribute(element, "primitiveUnits") ?? base?.animationBaseValues.primitiveUnits ?? "userSpaceOnUse",
+        ),
+        "color-interpolation-filters": String(
+          presentation["color-interpolation-filters"] ??
+            base?.animationBaseValues["color-interpolation-filters"] ??
+            "linearRGB",
+        ),
+      },
       ...(href ? { href } : {}),
       source: sourceLocation(element),
       element,
       primitives:
         primitiveElements.length > 0
-          ? buildPrimitiveSpecs(element, presentation, styleResolver, definitions, config, diagnostics)
+          ? buildPrimitiveSpecs(
+              element,
+              presentation,
+              styleResolver,
+              definitions,
+              config,
+              diagnostics,
+              animationTargetKey,
+            )
           : (base?.primitives ?? []),
       instances: new Map(),
       invalid: href !== undefined && (!base || base.invalid),
@@ -1226,12 +1297,30 @@ function resolveLightSource(
     const elevation = (source.elevation * Math.PI) / 180;
     return {
       type: "distant",
+      ...(source.animationTargetKey ? { animationTargetKey: source.animationTargetKey } : {}),
+      ...(source.animationTargetTag ? { animationTargetTag: source.animationTargetTag } : {}),
+      animationBaseValues: { azimuth: source.azimuth, elevation: source.elevation },
       x: Math.cos(azimuth) * Math.cos(elevation) * scaleX,
       y: Math.sin(azimuth) * Math.cos(elevation) * scaleY,
       z: Math.sin(elevation),
     };
   }
   const position = {
+    ...(source.animationTargetKey ? { animationTargetKey: source.animationTargetKey } : {}),
+    ...(source.animationTargetTag ? { animationTargetTag: source.animationTargetTag } : {}),
+    animationBaseValues:
+      source.type === "point"
+        ? { x: source.x, y: source.y, z: source.z }
+        : {
+            x: source.x,
+            y: source.y,
+            z: source.z,
+            pointsAtX: source.pointsAtX,
+            pointsAtY: source.pointsAtY,
+            pointsAtZ: source.pointsAtZ,
+            specularExponent: source.specularExponent,
+            ...(source.limitingConeAngle === undefined ? {} : { limitingConeAngle: source.limitingConeAngle }),
+          },
     x: originX + source.x * scaleX,
     y: originY + source.y * scaleY,
     z: source.z,
@@ -1274,6 +1363,8 @@ export function resolveFilterInstance(resource: FilterResource, node: RenderNode
   const primitives: FilterPrimitive[] = [];
   for (const spec of resource.primitives) {
     const common = {
+      animationScaleX: scaleX,
+      animationScaleY: scaleY,
       ...(spec.result ? { result: spec.result } : {}),
       subregion: subregion(spec, primitives, region, resource, node, bounds),
       colorInterpolation: spec.colorInterpolation,

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -11,10 +11,11 @@ import {
   addAnimationValues,
   animationAttributeSpec,
   parseAnimationValue,
+  resolveAnimationAttributeForTarget,
   swiftAnimationValueLiteral,
   type TypedAnimationValue,
 } from "./animationValues";
-import { renderNodeBounds } from "./bounds";
+import { objectBoundingBox, renderNodeBounds } from "./bounds";
 import { type ResolvedGradient, resolveGradientForShape } from "./gradients";
 import { type ResolvedPattern, resolvePatternForShape } from "./patterns";
 import { computeSMILRepeatingDuration, type SMILTimingInterval, sampleSMILProgram } from "./smilTiming";
@@ -30,6 +31,7 @@ import type {
   GradientStop,
   MaskInstance,
   Paint,
+  PaintServer,
   RenderDocument,
   RenderNode,
   RenderShape,
@@ -65,6 +67,10 @@ type GeneratedViewNode =
       paintOpacity: number;
       coordinateSpace: ViewBoxData;
       stopsExpression?: string;
+      coordinateExpressions?: Readonly<Record<string, string>>;
+      matrixExpression?: string;
+      spreadExpression?: string;
+      linearRGBExpression?: string;
     }
   | {
       type: "pattern";
@@ -73,6 +79,10 @@ type GeneratedViewNode =
       paintOpacity: number;
       coordinateSpace: ViewBoxData;
       patternIndex: number;
+      coordinateExpressions?: Readonly<Record<string, string>>;
+      rangeFactorX?: number;
+      rangeFactorY?: number;
+      transformCorrection?: string;
       tileClip?: string;
       contentNodes: GeneratedViewNode[];
     }
@@ -110,8 +120,10 @@ interface GeneratedMask {
 
 interface GeneratedFilter {
   instance: FilterInstance;
+  regionExpression?: string;
+  primitiveOverrides: ReadonlyArray<Readonly<Record<string, string>>>;
   canvas: ViewBoxData;
-  imageHelpers: Array<{ key: string; name: string }>;
+  imageHelpers: Array<{ key: string; name: string; animated?: boolean }>;
   maxOutputPixels: number;
 }
 
@@ -121,6 +133,7 @@ interface FilterImageHelper {
   primitive: Extract<FilterPrimitive, { type: "image" }>;
   canvas: ViewBoxData;
   subdocumentName?: string;
+  animated?: boolean;
 }
 
 interface GeneratedClipPath {
@@ -149,6 +162,25 @@ interface ViewBuildContext {
     fontSize?: string;
     letterSpacing?: string;
     wordSpacing?: string;
+    chunks: Array<{
+      x?: string;
+      y?: string;
+      startOffset?: string;
+      adjustmentTargets: Array<string | undefined>;
+      runs: Array<{
+        fontSize?: string;
+        letterSpacing?: string;
+        wordSpacing?: string;
+        fill?: string;
+        fillOpacity?: string;
+        stroke?: string;
+        strokeOpacity?: string;
+        strokeWidth?: string;
+        characterDX?: string;
+        characterDY?: string;
+        characterRotate?: string;
+      }>;
+    }>;
     animated: boolean;
   }>;
   imageHelpers: Array<{
@@ -156,6 +188,9 @@ interface ViewBuildContext {
     node: Extract<RenderNode, { type: "image" | "foreignObject" }>;
     transform: RenderNode["transform"];
     subdocumentName?: string;
+    subdocumentAnimated?: boolean;
+    animated?: boolean;
+    transformExpression?: string;
   }>;
   filterImageHelpers: FilterImageHelper[];
   subdocuments: string[][];
@@ -555,6 +590,7 @@ function buildViewNodes(
     node: RenderNode,
     transforms: RenderNode["transform"][],
     animatedSuffix?: string,
+    animatedBaseOverride?: string,
   ): string | undefined => {
     const metadata = node.transformAnimation ?? { base: node.transform, suffix: IDENTITY_TRANSFORM };
     const baseValue: TypedAnimationValue = {
@@ -575,10 +611,10 @@ function buildViewNodes(
     };
     const animatedBase = animatedValueExpression(node, "transform", baseValue);
     const animatedMotion = animatedMotionExpression(node);
-    if (!animatedBase && !animatedSuffix && !animatedMotion) return undefined;
+    if (!animatedBase && !animatedSuffix && !animatedMotion && !animatedBaseOverride) return undefined;
     const ancestors = transforms.reduce(multiplyTransforms, IDENTITY_TRANSFORM);
     const staticTransform = multiplyTransforms(ancestors, node.transform);
-    return `${context.rootName}.svgAnimatedTransformCorrection(animatedBase: ${animatedBase ? `${context.rootName}.svgAnimationTransform(${animatedBase})` : swiftTransform(metadata.base)}, animatedMotion: ${animatedMotion ?? "CGAffineTransform.identity"}, animatedSuffix: ${animatedSuffix ?? swiftTransform(metadata.suffix)}, ancestors: ${swiftTransform(ancestors)}, staticTransform: ${swiftTransform(staticTransform)}, outputSize: proxy.size, coordinateSpace: CGRect(x: ${formatNumber(context.options.viewBox.x)}, y: ${formatNumber(context.options.viewBox.y)}, width: ${formatNumber(context.options.viewBox.width)}, height: ${formatNumber(context.options.viewBox.height)}))`;
+    return `${context.rootName}.svgAnimatedTransformCorrection(animatedBase: ${animatedBaseOverride ?? (animatedBase ? `${context.rootName}.svgAnimationTransform(${animatedBase})` : swiftTransform(metadata.base))}, animatedMotion: ${animatedMotion ?? "CGAffineTransform.identity"}, animatedSuffix: ${animatedSuffix ?? swiftTransform(metadata.suffix)}, ancestors: ${swiftTransform(ancestors)}, staticTransform: ${swiftTransform(staticTransform)}, outputSize: proxy.size, coordinateSpace: CGRect(x: ${formatNumber(context.options.viewBox.x)}, y: ${formatNumber(context.options.viewBox.y)}, width: ${formatNumber(context.options.viewBox.width)}, height: ${formatNumber(context.options.viewBox.height)}))`;
   };
 
   const numericBase = (
@@ -667,6 +703,211 @@ function buildViewNodes(
           : gradientStopLiteral(stops[index]!, opacity),
       )
       .join(", ")}])`;
+  };
+
+  const animationsForResource = (key: string | undefined, attributeName: string) =>
+    key
+      ? context.document.animationProgram.animations.filter(
+          (candidate) =>
+            candidate.runtimeSupport === "typed" &&
+            candidate.target?.key === key &&
+            candidate.attributeName === attributeName,
+        )
+      : [];
+
+  const animatedGradientExpressions = (
+    server: Extract<PaintServer, { type: "linearGradient" | "radialGradient" }>,
+    gradient: ResolvedGradient,
+    node: RenderNode,
+  ) => {
+    const valueContextForGradient = {
+      ...valueContext(node),
+      length: {
+        ...valueContext(node).length,
+        ...(server.units === "objectBoundingBox"
+          ? { viewport: { width: 1, height: 1 }, rootViewport: { width: 1, height: 1 } }
+          : {}),
+      },
+    };
+    const coordinateExpressions: Record<string, string> = {};
+    for (const name of server.type === "linearGradient"
+      ? (["x1", "y1", "x2", "y2"] as const)
+      : (["cx", "cy", "r", "fx", "fy", "fr"] as const)) {
+      const animations = animationsForResource(server.animationTargetKeys[name], name);
+      if (animations.length === 0) continue;
+      const spec = animationAttributeSpec(name);
+      const base = spec
+        ? parseAnimationValue(spec, server.animationBaseValues[name] ?? String(gradient[name]), valueContextForGradient)
+        : undefined;
+      const expression = base ? animatedValueExpressionFromAnimations(animations, base) : undefined;
+      if (expression) coordinateExpressions[name] = `${context.rootName}.svgAnimationNumber(${expression})`;
+    }
+    const spreadAnimations = animationsForResource(server.animationTargetKeys.spreadMethod, "spreadMethod");
+    const spreadBase = parseAnimationValue(
+      animationAttributeSpec("spreadMethod")!,
+      server.animationBaseValues.spreadMethod ?? server.spreadMethod,
+      valueContextForGradient,
+    );
+    const spreadValue = animatedValueExpressionFromAnimations(spreadAnimations, spreadBase!);
+    const spreadExpression = spreadValue
+      ? `(${context.rootName}.svgAnimationSource(${spreadValue}) == "repeat" ? .repeating : (${context.rootName}.svgAnimationSource(${spreadValue}) == "reflect" ? .reflect : .pad))`
+      : undefined;
+    const interpolationAnimations = animationsForResource(
+      server.animationTargetKeys["color-interpolation"],
+      "color-interpolation",
+    );
+    const interpolationBase = parseAnimationValue(
+      animationAttributeSpec("color-interpolation")!,
+      server.animationBaseValues["color-interpolation"] ?? server.colorInterpolation,
+      valueContextForGradient,
+    );
+    const interpolationValue = animatedValueExpressionFromAnimations(interpolationAnimations, interpolationBase!);
+    const linearRGBExpression = interpolationValue
+      ? `${context.rootName}.svgAnimationSource(${interpolationValue}).lowercased() == "linearrgb"`
+      : undefined;
+    const transformAnimations = animationsForResource(
+      server.animationTargetKeys.gradientTransform,
+      "gradientTransform",
+    );
+    const transformBase = parseAnimationValue(
+      animationAttributeSpec("gradientTransform")!,
+      server.animationBaseValues.gradientTransform ?? "matrix(1 0 0 1 0 0)",
+      valueContextForGradient,
+    );
+    const transformValue = animatedValueExpressionFromAnimations(transformAnimations, transformBase!);
+    let matrixExpression: string | undefined;
+    if (transformValue) {
+      const transform = server.transform;
+      const determinant = transform.a * transform.d - transform.b * transform.c;
+      if (Math.abs(determinant) > 1e-12) {
+        const inverse = {
+          a: transform.d / determinant,
+          b: -transform.b / determinant,
+          c: -transform.c / determinant,
+          d: transform.a / determinant,
+          e: (transform.c * transform.f - transform.d * transform.e) / determinant,
+          f: (transform.b * transform.e - transform.a * transform.f) / determinant,
+        };
+        const prefix = multiplyTransforms(gradient.matrix, inverse);
+        matrixExpression = `${context.rootName}.svgOutputTransform(${context.rootName}.svgMultiplyTransform(${swiftTransform(prefix)}, ${context.rootName}.svgAnimationTransform(${transformValue})), size: size, coordinateSpace: CGRect(x: ${formatNumber(context.coordinateSpace.x)}, y: ${formatNumber(context.coordinateSpace.y)}, width: ${formatNumber(context.coordinateSpace.width)}, height: ${formatNumber(context.coordinateSpace.height)}))`;
+      }
+    }
+    return {
+      ...(Object.keys(coordinateExpressions).length > 0 ? { coordinateExpressions } : {}),
+      ...(matrixExpression ? { matrixExpression } : {}),
+      ...(spreadExpression ? { spreadExpression } : {}),
+      ...(linearRGBExpression ? { linearRGBExpression } : {}),
+    };
+  };
+
+  const animatedPatternExpressions = (pattern: ResolvedPattern, node: RenderNode) => {
+    const server = pattern.server;
+    const patternContext = {
+      ...valueContext(node),
+      length: {
+        ...valueContext(node).length,
+        ...(server.units === "objectBoundingBox"
+          ? { viewport: { width: 1, height: 1 }, rootViewport: { width: 1, height: 1 } }
+          : {}),
+      },
+    };
+    const coordinateExpressions: Record<string, string> = {};
+    let rangeFactorX = 1;
+    let rangeFactorY = 1;
+    for (const name of ["x", "y", "width", "height"] as const) {
+      const animations = animationsForResource(server.animationTargetKeys[name], name);
+      if (animations.length === 0) continue;
+      const baseSource = server.animationBaseValues[name] ?? String(pattern.tile[name]);
+      const base = parseAnimationValue(animationAttributeSpec(name)!, baseSource, patternContext);
+      const expression = base ? animatedValueExpressionFromAnimations(animations, base) : undefined;
+      if (expression) coordinateExpressions[name] = `${context.rootName}.svgAnimationNumber(${expression})`;
+      if (name === "width" || name === "height") {
+        const staticExtent = pattern.tile[name];
+        const candidates = animations.flatMap((animation) => {
+          if (animation.value.family === "unsupported") return [];
+          return [
+            animation.value.base,
+            animation.value.from,
+            animation.value.to,
+            animation.value.by,
+            ...(animation.value.values ?? []),
+          ].flatMap((value) =>
+            value && "value" in value && typeof value.value === "number" && value.value > 1e-9 ? [value.value] : [],
+          );
+        });
+        const minimum = Math.min(staticExtent, ...candidates);
+        if (minimum > 1e-9) {
+          const factor = Math.ceil(staticExtent / minimum);
+          if (name === "width") rangeFactorX = Math.max(rangeFactorX, factor);
+          else rangeFactorY = Math.max(rangeFactorY, factor);
+        }
+      }
+    }
+    const transformAnimations = animationsForResource(server.animationTargetKeys.patternTransform, "patternTransform");
+    const transformBase = parseAnimationValue(
+      animationAttributeSpec("patternTransform")!,
+      server.animationBaseValues.patternTransform ?? "matrix(1 0 0 1 0 0)",
+      patternContext,
+    );
+    const transformValue = transformBase
+      ? animatedValueExpressionFromAnimations(transformAnimations, transformBase)
+      : undefined;
+    let transformCorrection: string | undefined;
+    if (transformValue) {
+      const transform = server.transform;
+      const determinant = transform.a * transform.d - transform.b * transform.c;
+      if (Math.abs(determinant) > 1e-12) {
+        const inverse = {
+          a: transform.d / determinant,
+          b: -transform.b / determinant,
+          c: -transform.c / determinant,
+          d: transform.a / determinant,
+          e: (transform.c * transform.f - transform.d * transform.e) / determinant,
+          f: (transform.b * transform.e - transform.a * transform.f) / determinant,
+        };
+        const prefix = multiplyTransforms(pattern.matrix, inverse);
+        const coordinateSpace = `CGRect(x: ${formatNumber(context.coordinateSpace.x)}, y: ${formatNumber(context.coordinateSpace.y)}, width: ${formatNumber(context.coordinateSpace.width)}, height: ${formatNumber(context.coordinateSpace.height)})`;
+        const animatedOutput = `${context.rootName}.svgOutputTransform(${context.rootName}.svgMultiplyTransform(${swiftTransform(prefix)}, ${context.rootName}.svgAnimationTransform(${transformValue})), size: size, coordinateSpace: ${coordinateSpace})`;
+        const staticOutput = `${context.rootName}.svgOutputTransform(${swiftTransform(pattern.matrix)}, size: size, coordinateSpace: ${coordinateSpace})`;
+        transformCorrection = `${context.rootName}.svgMultiplyTransform(${animatedOutput}, ${staticOutput}.inverted())`;
+      }
+    }
+    return {
+      ...(Object.keys(coordinateExpressions).length > 0 ? { coordinateExpressions } : {}),
+      ...(rangeFactorX > 1 ? { rangeFactorX } : {}),
+      ...(rangeFactorY > 1 ? { rangeFactorY } : {}),
+      ...(transformCorrection ? { transformCorrection } : {}),
+    };
+  };
+
+  const animatedMarkerBase = (node: RenderNode): string | undefined => {
+    if (node.type !== "group" || !node.markerPlacement?.resource) return undefined;
+    const placement = node.markerPlacement;
+    const resource = placement.resource!;
+    const value = (name: "orient" | "markerUnits") => {
+      const animations = animationsForResource(resource.animationTargetKeys[name], name);
+      if (animations.length === 0) return undefined;
+      const spec = resolveAnimationAttributeForTarget(name, "auto", "marker");
+      const base = spec
+        ? parseAnimationValue(spec, resource.animationBaseValues[name]!, valueContext(node))
+        : undefined;
+      return base ? animatedValueExpressionFromAnimations(animations, base) : undefined;
+    };
+    const orient = value("orient");
+    const units = value("markerUnits");
+    if (!orient && !units) return undefined;
+    const hostAngle = placement.hostAngle ?? placement.angle;
+    const orientSource = orient ? `${context.rootName}.svgAnimationSource(${orient})` : swiftString("");
+    const angle = orient
+      ? `(${orientSource} == "auto" ? ${formatNumber(hostAngle)} : (${orientSource} == "auto-start-reverse" ? ${formatNumber(hostAngle + (placement.kind === "start" ? 180 : 0))} : ${context.rootName}.svgAnimationNumber(${orient})))`
+      : formatNumber(placement.angle);
+    const unitsSource = units ? `${context.rootName}.svgAnimationSource(${units})` : swiftString(resource.units);
+    const unitScale = `(${unitsSource} == "strokeWidth" ? ${formatNumber(placement.strokeWidth ?? placement.unitScale)} : 1)`;
+    const translation = `CGAffineTransform(translationX: ${formatNumber(placement.x)}, y: ${formatNumber(placement.y)})`;
+    const rotation = `CGAffineTransform(rotationAngle: (${angle}) * .pi / 180)`;
+    const scaling = `CGAffineTransform(scaleX: ${unitScale}, y: ${unitScale})`;
+    const reference = `CGAffineTransform(translationX: ${formatNumber(-placement.refX)}, y: ${formatNumber(-placement.refY)})`;
+    return `${context.rootName}.svgMultiplyTransform(${translation}, ${context.rootName}.svgMultiplyTransform(${rotation}, ${context.rootName}.svgMultiplyTransform(${scaling}, ${context.rootName}.svgMultiplyTransform(${reference}, ${swiftTransform(placement.viewBoxTransform)}))))`;
   };
 
   const presentationCondition = (node: RenderNode): string | undefined => {
@@ -967,6 +1208,7 @@ function buildViewNodes(
   const buildFilter = (
     filter: FilterInstance | undefined,
     targetTransforms: RenderNode["transform"][],
+    targetNode: RenderNode,
   ): GeneratedFilter | undefined => {
     if (!filter || filter.invalid) return undefined;
     const transform = targetTransforms.reduce(multiplyTransforms);
@@ -992,11 +1234,17 @@ function buildViewNodes(
       if (light.type === "distant")
         return {
           type: "distant",
+          ...(light.animationTargetKey ? { animationTargetKey: light.animationTargetKey } : {}),
+          ...(light.animationTargetTag ? { animationTargetTag: light.animationTargetTag } : {}),
+          ...(light.animationBaseValues ? { animationBaseValues: light.animationBaseValues } : {}),
           x: transform.a * light.x + transform.c * light.y,
           y: transform.b * light.x + transform.d * light.y,
           z: light.z * zScale,
         };
       const position = {
+        ...(light.animationTargetKey ? { animationTargetKey: light.animationTargetKey } : {}),
+        ...(light.animationTargetTag ? { animationTargetTag: light.animationTargetTag } : {}),
+        ...(light.animationBaseValues ? { animationBaseValues: light.animationBaseValues } : {}),
         x: transform.a * light.x + transform.c * light.y + transform.e,
         y: transform.b * light.x + transform.d * light.y + transform.f,
         z: light.z * zScale,
@@ -1103,12 +1351,475 @@ function buildViewNodes(
       region: transformRegion(filter.region),
       primitives: filter.primitives.map(transformPrimitive),
     };
-    const imageHelpers: Array<{ key: string; name: string }> = [];
+    let regionExpression: string | undefined;
+    const resource = filter.resource;
+    if (resource) {
+      const bounds = objectBoundingBox(targetNode);
+      const filterContext = {
+        ...valueContext(targetNode),
+        length: {
+          ...valueContext(targetNode).length,
+          ...(resource.units === "objectBoundingBox"
+            ? { viewport: { width: 1, height: 1 }, rootViewport: { width: 1, height: 1 } }
+            : {}),
+        },
+      };
+      const animatedCoordinate = (name: "x" | "y" | "width" | "height") => {
+        const key = resource.animationTargetKeys[name];
+        const animations = animationsForResource(key, name);
+        if (animations.length === 0) return undefined;
+        const spec = animationAttributeSpec(name)!;
+        const base = parseAnimationValue(spec, resource.animationBaseValues[name]!, filterContext);
+        const value = base ? animatedValueExpressionFromAnimations(animations, base) : undefined;
+        if (!value) return undefined;
+        const number = `${context.rootName}.svgAnimationNumber(${value})`;
+        if (resource.units !== "objectBoundingBox" || !bounds) return number;
+        const extent = name === "x" || name === "width" ? bounds.width : bounds.height;
+        if (name === "width" || name === "height") return `(${number} * ${formatNumber(extent)})`;
+        const origin = name === "x" ? bounds.x : bounds.y;
+        return `(${formatNumber(origin)} + ${number} * ${formatNumber(extent)})`;
+      };
+      const x = animatedCoordinate("x");
+      const y = animatedCoordinate("y");
+      const width = animatedCoordinate("width");
+      const height = animatedCoordinate("height");
+      if (x || y || width || height)
+        regionExpression = `${context.rootName}.svgTransformedFilterRegion(x: ${x ?? formatNumber(filter.region.x)}, y: ${y ?? formatNumber(filter.region.y)}, width: ${width ?? formatNumber(filter.region.width)}, height: ${height ?? formatNumber(filter.region.height)}, transform: ${swiftTransform(transform)})`;
+    }
+    const animatedFilterTargetValue = (
+      key: string | undefined,
+      attributeName: string,
+      baseValue: string,
+      targetTagName?: string,
+    ): string | undefined => {
+      const animations = animationsForResource(key, attributeName);
+      const spec = targetTagName
+        ? resolveAnimationAttributeForTarget(attributeName, "auto", targetTagName)
+        : animationAttributeSpec(attributeName);
+      const base = spec ? parseAnimationValue(spec, baseValue, valueContext(targetNode)) : undefined;
+      return base ? animatedValueExpressionFromAnimations(animations, base) : undefined;
+    };
+    const animatedFilterValue = (primitive: FilterPrimitive, attributeName: string, baseValue: string) =>
+      animatedFilterTargetValue(primitive.animationTargetKey, attributeName, baseValue, primitive.source.element);
+    const component = (expression: string, index: number) =>
+      `${context.rootName}.svgAnimationComponent(${expression}, index: ${index})`;
+    const primitiveOverrides = filter.primitives.map((source, index): Readonly<Record<string, string>> => {
+      const output = instance.primitives[index]!;
+      const overrides: Record<string, string> = {};
+      const scaleX = source.animationScaleX || 1;
+      const scaleY = source.animationScaleY || 1;
+      const pair = (attributeName: string, x: number, y: number) =>
+        animatedFilterValue(source, attributeName, `${formatNumber(x)} ${formatNumber(y)}`);
+      const discrete = (attributeName: string, baseValue: string) => {
+        const expression = animatedFilterValue(source, attributeName, baseValue);
+        return expression ? `${context.rootName}.svgAnimationSource(${expression})` : undefined;
+      };
+      const enumExpression = (value: string, cases: Readonly<Record<string, string>>, fallback: string) =>
+        Object.entries(cases).reduceRight(
+          (result, [sourceValue, swiftValue]) =>
+            `(${value} == ${swiftString(sourceValue)} ? ${swiftValue} : ${result})`,
+          fallback,
+        );
+      const inputExpression = (attributeName: "in" | "in2", fallback: FilterInput) => {
+        const baseValue =
+          source.animationBaseValues?.[attributeName] ??
+          (fallback.type === "result"
+            ? (filter.primitives[fallback.index]?.result ?? "SourceGraphic")
+            : {
+                sourceGraphic: "SourceGraphic",
+                sourceAlpha: "SourceAlpha",
+                backgroundImage: "BackgroundImage",
+                backgroundAlpha: "BackgroundAlpha",
+                fillPaint: "FillPaint",
+                strokePaint: "StrokePaint",
+              }[fallback.type]);
+        const animated = discrete(attributeName, baseValue);
+        if (!animated) return undefined;
+        const cases: Record<string, string> = {
+          SourceGraphic: ".sourceGraphic",
+          SourceAlpha: ".sourceAlpha",
+          BackgroundImage: ".backgroundImage",
+          BackgroundAlpha: ".backgroundAlpha",
+          FillPaint: ".fillPaint",
+          StrokePaint: ".strokePaint",
+        };
+        for (let previous = 0; previous < index; previous++) {
+          const name = filter.primitives[previous]?.result;
+          if (name) cases[name] = `.result(${previous})`;
+        }
+        return enumExpression(animated, cases, filterInputLiteral(fallback));
+      };
+      if ("input" in source) {
+        const input = inputExpression("in", source.input);
+        if (input) overrides.input = input;
+      }
+      if (source.input2) {
+        const input2 = inputExpression("in2", source.input2);
+        if (input2) overrides.input2 = input2;
+      }
+      const primitiveUnits = filter.resource?.primitiveUnits ?? "userSpaceOnUse";
+      const targetBounds = objectBoundingBox(targetNode);
+      const regionContext = {
+        ...valueContext(targetNode),
+        length: {
+          ...valueContext(targetNode).length,
+          ...(primitiveUnits === "objectBoundingBox"
+            ? { viewport: { width: 1, height: 1 }, rootViewport: { width: 1, height: 1 } }
+            : {}),
+        },
+      };
+      const regionCoordinate = (name: "x" | "y" | "width" | "height") => {
+        const animations = animationsForResource(source.animationTargetKey, name);
+        if (animations.length === 0) return undefined;
+        const axisScale = name === "x" || name === "width" ? scaleX : scaleY;
+        const origin = name === "x" ? (targetBounds?.x ?? 0) : name === "y" ? (targetBounds?.y ?? 0) : 0;
+        const resolved =
+          name === "x"
+            ? source.subregion.x
+            : name === "y"
+              ? source.subregion.y
+              : name === "width"
+                ? source.subregion.width
+                : source.subregion.height;
+        const computedBase =
+          primitiveUnits === "objectBoundingBox" && axisScale !== 0 ? (resolved - origin) / axisScale : resolved;
+        const baseSource = source.animationBaseValues?.[name] ?? formatNumber(computedBase);
+        const spec = animationAttributeSpec(name)!;
+        const base = parseAnimationValue(spec, baseSource, regionContext);
+        const expression = base ? animatedValueExpressionFromAnimations(animations, base) : undefined;
+        if (!expression) return undefined;
+        const number = `${context.rootName}.svgAnimationNumber(${expression})`;
+        if (primitiveUnits !== "objectBoundingBox") return number;
+        if (name === "width" || name === "height") return `(${number} * ${formatNumber(axisScale)})`;
+        return `(${formatNumber(origin)} + ${number} * ${formatNumber(axisScale)})`;
+      };
+      const regionX = regionCoordinate("x");
+      const regionY = regionCoordinate("y");
+      const regionWidth = regionCoordinate("width");
+      const regionHeight = regionCoordinate("height");
+      if (regionX || regionY || regionWidth || regionHeight)
+        overrides.region = `${context.rootName}.svgTransformedFilterRegion(x: ${regionX ?? formatNumber(source.subregion.x)}, y: ${regionY ?? formatNumber(source.subregion.y)}, width: ${regionWidth ?? formatNumber(source.subregion.width)}, height: ${regionHeight ?? formatNumber(source.subregion.height)}, transform: ${swiftTransform(transform)})`;
+      const interpolation = discrete("color-interpolation-filters", source.colorInterpolation);
+      if (interpolation) overrides.linearRGB = `${interpolation}.lowercased() == "linearrgb"`;
+      if (source.type === "blend") {
+        const mode = discrete("mode", source.mode);
+        if (mode)
+          overrides.mode = enumExpression(
+            mode,
+            Object.fromEntries(
+              [
+                "normal",
+                "multiply",
+                "screen",
+                "overlay",
+                "darken",
+                "lighten",
+                "color-dodge",
+                "color-burn",
+                "hard-light",
+                "soft-light",
+                "difference",
+                "exclusion",
+                "hue",
+                "saturation",
+                "color",
+                "luminosity",
+              ].map((name) => [name, `.${name.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase())}`]),
+            ),
+            ".normal",
+          );
+      }
+      if (source.type === "gaussianBlur" || source.type === "dropShadow") {
+        const expression = pair("stdDeviation", source.stdDeviationX / scaleX, source.stdDeviationY / scaleY);
+        if (expression) {
+          const x = `(${component(expression, 0)} * ${formatNumber(scaleX)})`;
+          const y = `(${component(expression, 1)} * ${formatNumber(scaleY)})`;
+          overrides.stdDeviationX = `hypot(${formatNumber(transform.a)} * ${x}, ${formatNumber(transform.c)} * ${y})`;
+          overrides.stdDeviationY = `hypot(${formatNumber(transform.b)} * ${x}, ${formatNumber(transform.d)} * ${y})`;
+        }
+      }
+      if (source.type === "offset" || source.type === "dropShadow") {
+        const dxExpression = animatedFilterValue(source, "dx", formatNumber(source.dx / scaleX));
+        const dyExpression = animatedFilterValue(source, "dy", formatNumber(source.dy / scaleY));
+        if (dxExpression || dyExpression) {
+          const x = dxExpression
+            ? `(${context.rootName}.svgAnimationNumber(${dxExpression}) * ${formatNumber(scaleX)})`
+            : formatNumber(source.dx);
+          const y = dyExpression
+            ? `(${context.rootName}.svgAnimationNumber(${dyExpression}) * ${formatNumber(scaleY)})`
+            : formatNumber(source.dy);
+          overrides.dx = `${formatNumber(transform.a)} * ${x} + ${formatNumber(transform.c)} * ${y}`;
+          overrides.dy = `${formatNumber(transform.b)} * ${x} + ${formatNumber(transform.d)} * ${y}`;
+        }
+      }
+      if (source.type === "morphology") {
+        const expression = pair("radius", source.radiusX / scaleX, source.radiusY / scaleY);
+        if (expression) {
+          const x = `(${component(expression, 0)} * ${formatNumber(scaleX)})`;
+          const y = `(${component(expression, 1)} * ${formatNumber(scaleY)})`;
+          overrides.radiusX = `hypot(${formatNumber(transform.a)} * ${x}, ${formatNumber(transform.b)} * ${x})`;
+          overrides.radiusY = `hypot(${formatNumber(transform.c)} * ${y}, ${formatNumber(transform.d)} * ${y})`;
+        }
+      }
+      if (source.type === "displacementMap") {
+        const authoredScale = scaleX === 0 ? 0 : source.displacement.a / scaleX;
+        const expression = animatedFilterValue(source, "scale", formatNumber(authoredScale));
+        if (expression) {
+          const scale = `${context.rootName}.svgAnimationNumber(${expression})`;
+          overrides.a = `${formatNumber(transform.a * scaleX)} * ${scale}`;
+          overrides.b = `${formatNumber(transform.b * scaleX)} * ${scale}`;
+          overrides.c = `${formatNumber(transform.c * scaleY)} * ${scale}`;
+          overrides.d = `${formatNumber(transform.d * scaleY)} * ${scale}`;
+        }
+      }
+      if (source.type === "composite") {
+        const operator = discrete("operator", source.operator);
+        if (operator)
+          overrides.operator = enumExpression(
+            operator,
+            {
+              over: ".over",
+              in: ".inside",
+              out: ".outside",
+              atop: ".atop",
+              xor: ".xor",
+              lighter: ".lighter",
+              arithmetic: ".arithmetic",
+            },
+            ".over",
+          );
+        for (const name of ["k1", "k2", "k3", "k4"] as const) {
+          const expression = animatedFilterValue(source, name, formatNumber(source[name]));
+          if (expression) overrides[name] = `${context.rootName}.svgAnimationNumber(${expression})`;
+        }
+      }
+      if (source.type === "colorMatrix" && source.matrix.length === 20) {
+        const expression = animatedFilterValue(
+          source,
+          "values",
+          source.matrix.map((value) => formatNumber(value)).join(" "),
+        );
+        if (expression) overrides.values = `${expression}.components`;
+      }
+      if (source.type === "componentTransfer") {
+        const functions = source.functions.map((fn) => {
+          const functionOverrides: Record<string, string> = {};
+          if (fn.type === "table" || fn.type === "discrete") {
+            const expression = animatedFilterTargetValue(
+              fn.animationTargetKey,
+              "tableValues",
+              fn.values.map((value) => formatNumber(value)).join(" "),
+              fn.animationTargetTag,
+            );
+            if (expression) functionOverrides.tableValues = `${expression}.components`;
+          } else if (fn.type === "linear") {
+            for (const name of ["slope", "intercept"] as const) {
+              const expression = animatedFilterTargetValue(
+                fn.animationTargetKey,
+                name,
+                formatNumber(fn[name]),
+                fn.animationTargetTag,
+              );
+              if (expression) functionOverrides[name] = `${context.rootName}.svgAnimationNumber(${expression})`;
+            }
+          } else if (fn.type === "gamma") {
+            for (const name of ["amplitude", "exponent", "offset"] as const) {
+              const expression = animatedFilterTargetValue(
+                fn.animationTargetKey,
+                name,
+                formatNumber(fn[name]),
+                fn.animationTargetTag,
+              );
+              if (expression) functionOverrides[name] = `${context.rootName}.svgAnimationNumber(${expression})`;
+            }
+          }
+          return filterComponentFunctionLiteral(fn, functionOverrides);
+        });
+        if (
+          functions.some(
+            (literal, functionIndex) => literal !== filterComponentFunctionLiteral(source.functions[functionIndex]!),
+          )
+        )
+          overrides.functions = `[${functions.join(", ")}]`;
+      }
+      if (source.type === "convolveMatrix") {
+        const order = pair("order", source.orderX, source.orderY);
+        if (order) {
+          overrides.orderX = `Int(${component(order, 0)})`;
+          overrides.orderY = `Int(${component(order, 1)})`;
+        }
+        const kernel = animatedFilterValue(
+          source,
+          "kernelMatrix",
+          source.kernelMatrix.map((value) => formatNumber(value)).join(" "),
+        );
+        if (kernel) overrides.kernelMatrix = `${kernel}.components`;
+        for (const name of ["divisor", "bias"] as const) {
+          const expression = animatedFilterValue(source, name, formatNumber(source[name]));
+          if (expression) overrides[name] = `${context.rootName}.svgAnimationNumber(${expression})`;
+        }
+        for (const name of ["targetX", "targetY"] as const) {
+          const expression = animatedFilterValue(source, name, formatNumber(source[name]));
+          if (expression) overrides[name] = `Int(${context.rootName}.svgAnimationNumber(${expression}))`;
+        }
+        if (source.kernelUnitLengthX !== undefined) {
+          const expression = pair(
+            "kernelUnitLength",
+            source.kernelUnitLengthX / scaleX,
+            source.kernelUnitLengthY! / scaleY,
+          );
+          if (expression) {
+            const x = `(${component(expression, 0)} * ${formatNumber(scaleX)})`;
+            const y = `(${component(expression, 1)} * ${formatNumber(scaleY)})`;
+            overrides.kernelUnitLengthX = `hypot(${formatNumber(transform.a)} * ${x}, ${formatNumber(transform.b)} * ${x})`;
+            overrides.kernelUnitLengthY = `hypot(${formatNumber(transform.c)} * ${y}, ${formatNumber(transform.d)} * ${y})`;
+          }
+        }
+        const edge = discrete("edgeMode", source.edgeMode);
+        if (edge)
+          overrides.edgeMode = enumExpression(edge, { none: ".none", duplicate: ".duplicate", wrap: ".wrap" }, ".none");
+        const preserve = discrete("preserveAlpha", source.preserveAlpha ? "true" : "false");
+        if (preserve) overrides.preserveAlpha = `${preserve}.lowercased() == "true"`;
+      }
+      if (source.type === "gaussianBlur") {
+        const edge = discrete("edgeMode", source.edgeMode);
+        if (edge)
+          overrides.edgeMode = enumExpression(edge, { none: ".none", duplicate: ".duplicate", wrap: ".wrap" }, ".none");
+      }
+      if (source.type === "morphology") {
+        const operation = discrete("operator", source.operator);
+        if (operation) overrides.operator = `(${operation} == "dilate" ? .dilate : .erode)`;
+      }
+      if (source.type === "displacementMap") {
+        for (const [attributeName, baseValue] of [
+          ["xChannelSelector", source.xChannel],
+          ["yChannelSelector", source.yChannel],
+        ] as const) {
+          const channel = discrete(attributeName, baseValue);
+          if (channel)
+            overrides[attributeName] = enumExpression(
+              `${channel}.uppercased()`,
+              { R: ".r", G: ".g", B: ".b", A: ".a" },
+              ".a",
+            );
+        }
+      }
+      if (source.type === "diffuseLighting" || source.type === "specularLighting") {
+        const zScale = Math.sqrt(Math.abs(scaleX * scaleY));
+        const surfaceScale = animatedFilterValue(source, "surfaceScale", formatNumber(source.surfaceScale / zScale));
+        if (surfaceScale)
+          overrides.surfaceScale = `${formatNumber(zScale * Math.sqrt(Math.abs(transform.a * transform.d - transform.b * transform.c)))} * ${context.rootName}.svgAnimationNumber(${surfaceScale})`;
+        const constantName = source.type === "diffuseLighting" ? "diffuseConstant" : "specularConstant";
+        const constant = animatedFilterValue(source, constantName, formatNumber(source[constantName]));
+        if (constant) overrides[constantName] = `${context.rootName}.svgAnimationNumber(${constant})`;
+        if (source.type === "specularLighting") {
+          const exponent = animatedFilterValue(source, "specularExponent", formatNumber(source.specularExponent));
+          if (exponent) overrides.specularExponent = `${context.rootName}.svgAnimationNumber(${exponent})`;
+        }
+        const light = source.light;
+        if (light?.animationTargetKey && light.animationBaseValues) {
+          let animated = false;
+          const number = (name: string) => {
+            const base = light.animationBaseValues?.[name] ?? 0;
+            const expression = animatedFilterTargetValue(
+              light.animationTargetKey,
+              name,
+              formatNumber(base),
+              light.animationTargetTag,
+            );
+            if (expression) animated = true;
+            return expression ? `${context.rootName}.svgAnimationNumber(${expression})` : formatNumber(base);
+          };
+          const determinantScale = Math.sqrt(Math.abs(transform.a * transform.d - transform.b * transform.c));
+          if (light.type === "distant") {
+            const azimuth = `(${number("azimuth")} * .pi / 180)`;
+            const elevation = `(${number("elevation")} * .pi / 180)`;
+            const x = `(cos(${azimuth}) * cos(${elevation}) * ${formatNumber(scaleX)})`;
+            const y = `(sin(${azimuth}) * cos(${elevation}) * ${formatNumber(scaleY)})`;
+            const z = `(sin(${elevation}) * ${formatNumber(determinantScale)})`;
+            if (animated)
+              overrides.light = `.distant(x: ${formatNumber(transform.a)} * ${x} + ${formatNumber(transform.c)} * ${y}, y: ${formatNumber(transform.b)} * ${x} + ${formatNumber(transform.d)} * ${y}, z: ${z})`;
+          } else {
+            const adjusted = (name: "x" | "y" | "z" | "pointsAtX" | "pointsAtY" | "pointsAtZ") => {
+              const staticValue = light[name];
+              const base = light.animationBaseValues?.[name] ?? 0;
+              const axisScale =
+                name === "x" || name === "pointsAtX" ? scaleX : name === "y" || name === "pointsAtY" ? scaleY : 1;
+              return `(${formatNumber(staticValue)} + (${number(name)} - ${formatNumber(base)}) * ${formatNumber(axisScale)})`;
+            };
+            const x = adjusted("x");
+            const y = adjusted("y");
+            const z = adjusted("z");
+            const outputX = `${formatNumber(transform.a)} * ${x} + ${formatNumber(transform.c)} * ${y} + ${formatNumber(transform.e)}`;
+            const outputY = `${formatNumber(transform.b)} * ${x} + ${formatNumber(transform.d)} * ${y} + ${formatNumber(transform.f)}`;
+            const outputZ = `${formatNumber(determinantScale)} * ${z}`;
+            if (light.type === "point") {
+              if (animated) overrides.light = `.point(x: ${outputX}, y: ${outputY}, z: ${outputZ})`;
+            } else {
+              const pointX = adjusted("pointsAtX");
+              const pointY = adjusted("pointsAtY");
+              const pointZ = adjusted("pointsAtZ");
+              const exponent = number("specularExponent");
+              const cone = light.limitingConeAngle === undefined ? "nil" : number("limitingConeAngle");
+              if (animated)
+                overrides.light = `.spot(x: ${outputX}, y: ${outputY}, z: ${outputZ}, pointsAtX: ${formatNumber(transform.a)} * ${pointX} + ${formatNumber(transform.c)} * ${pointY} + ${formatNumber(transform.e)}, pointsAtY: ${formatNumber(transform.b)} * ${pointX} + ${formatNumber(transform.d)} * ${pointY} + ${formatNumber(transform.f)}, pointsAtZ: ${formatNumber(determinantScale)} * ${pointZ}, exponent: ${exponent}, coneAngle: ${cone})`;
+            }
+          }
+        }
+      }
+      if (
+        source.type === "flood" ||
+        source.type === "dropShadow" ||
+        source.type === "diffuseLighting" ||
+        source.type === "specularLighting"
+      ) {
+        const attributeName =
+          source.type === "diffuseLighting" || source.type === "specularLighting" ? "lighting-color" : "flood-color";
+        const baseColor = `rgba(${source.color.red * 255} ${source.color.green * 255} ${source.color.blue * 255} / 1)`;
+        const parsedColor = parseAnimationValue(
+          animationAttributeSpec(attributeName)!,
+          baseColor,
+          valueContext(targetNode),
+        );
+        const colorExpression = animatedFilterValue(source, attributeName, baseColor);
+        const opacityExpression =
+          attributeName === "flood-color"
+            ? animatedFilterValue(source, "flood-opacity", formatNumber(source.color.alpha))
+            : undefined;
+        if (parsedColor && (colorExpression || opacityExpression)) {
+          const colorValue =
+            colorExpression ?? swiftAnimationValueLiteral(parsedColor, context.precision, `${context.rootName}.`);
+          const opacity = opacityExpression
+            ? `${context.rootName}.svgAnimationNumber(${opacityExpression})`
+            : formatNumber(source.color.alpha);
+          overrides.color = `${context.rootName}.svgAnimationFilterColor(${colorValue}, opacity: ${opacity})`;
+        }
+      }
+      if (source.type === "turbulence") {
+        const frequency = pair("baseFrequency", source.baseFrequencyX, source.baseFrequencyY);
+        if (frequency) {
+          overrides.baseFrequencyX = component(frequency, 0);
+          overrides.baseFrequencyY = component(frequency, 1);
+        }
+        const octaves = animatedFilterValue(source, "numOctaves", formatNumber(source.numOctaves));
+        if (octaves) overrides.numOctaves = `Int(${context.rootName}.svgAnimationNumber(${octaves}))`;
+        const seed = animatedFilterValue(source, "seed", formatNumber(source.seed));
+        if (seed) overrides.seed = `Int(${context.rootName}.svgAnimationNumber(${seed}))`;
+        const stitch = discrete("stitchTiles", source.stitchTiles ? "stitch" : "noStitch");
+        if (stitch) overrides.stitchTiles = `${stitch} == "stitch"`;
+        const type = discrete("type", source.noiseType);
+        if (type) overrides.type = `${type} == "fractalNoise"`;
+      }
+      void output;
+      return overrides;
+    });
+    const imageHelpers: Array<{ key: string; name: string; animated?: boolean }> = [];
     for (const [index, primitive] of instance.primitives.entries()) {
       if (primitive.type !== "image" || !primitive.image.resource) continue;
       const key = `filter-image-${index}`;
       const name = `FilterImageLayer${context.filterImageHelpers.length}`;
       let subdocumentName: string | undefined;
+      let animatedSubdocument = false;
       if (primitive.image.resource.type === "svg") {
         subdocumentName = `${context.rootName}FilterImageDocument${context.subdocuments.length}`;
         const child = primitive.image.resource.document;
@@ -1128,6 +1839,9 @@ function buildViewNodes(
           usageCommentPrefix: false,
         });
         context.subdocuments.push(generatedChild.lines);
+        animatedSubdocument = child.animationProgram.animations.some(
+          (animation) => animation.runtimeSupport === "typed",
+        );
       }
       context.filterImageHelpers.push({
         key,
@@ -1135,12 +1849,15 @@ function buildViewNodes(
         primitive,
         canvas: context.coordinateSpace,
         ...(subdocumentName ? { subdocumentName } : {}),
+        ...(animatedSubdocument ? { animated: true } : {}),
       });
-      imageHelpers.push({ key, name });
+      imageHelpers.push({ key, name, ...(animatedSubdocument ? { animated: true } : {}) });
     }
     const configuredMaxPixels = context.config.filters?.maxOutputPixels ?? 16_000_000;
     return {
       instance,
+      ...(regionExpression ? { regionExpression } : {}),
+      primitiveOverrides,
       canvas: context.coordinateSpace,
       imageHelpers,
       maxOutputPixels:
@@ -1153,20 +1870,57 @@ function buildViewNodes(
   const buildMask = (
     mask: MaskInstance | undefined,
     targetTransforms: RenderNode["transform"][],
+    targetNode: RenderNode,
   ): GeneratedMask | undefined => {
     if (!mask) return undefined;
-    let clipLines = handleElement(
-      {
-        type: "element",
-        tagName: "rect",
-        properties: { ...mask.region, fill: "black", stroke: "none" },
-        children: [],
+    const resource = mask.resource;
+    const bounds = objectBoundingBox(targetNode);
+    const maskContext = {
+      ...valueContext(targetNode),
+      length: {
+        ...valueContext(targetNode).length,
+        ...(resource?.units === "objectBoundingBox"
+          ? { viewport: { width: 1, height: 1 }, rootViewport: { width: 1, height: 1 } }
+          : {}),
       },
-      context.options,
-    );
+    };
+    const coordinate = (name: "x" | "y" | "width" | "height") => {
+      if (!resource) return undefined;
+      const animations = animationsForResource(resource.animationTargetKeys[name], name);
+      if (animations.length === 0) return undefined;
+      const base = parseAnimationValue(animationAttributeSpec(name)!, resource.animationBaseValues[name]!, maskContext);
+      const expression = base ? animatedValueExpressionFromAnimations(animations, base) : undefined;
+      if (!expression) return undefined;
+      const number = `${context.rootName}.svgAnimationNumber(${expression})`;
+      if (resource.units !== "objectBoundingBox" || !bounds) return number;
+      const extent = name === "x" || name === "width" ? bounds.width : bounds.height;
+      if (name === "width" || name === "height") return `(${number} * ${formatNumber(extent)})`;
+      const origin = name === "x" ? bounds.x : bounds.y;
+      return `(${formatNumber(origin)} + ${number} * ${formatNumber(extent)})`;
+    };
+    const x = coordinate("x");
+    const y = coordinate("y");
+    const width = coordinate("width");
+    const height = coordinate("height");
+    const dynamicRegion = x || y || width || height;
+    let clipLines = dynamicRegion
+      ? [
+          `path.addRect(CGRect(x: ${normalizedX(x ?? formatNumber(mask.region.x))}, y: ${normalizedY(y ?? formatNumber(mask.region.y))}, width: ${normalizedWidth(width ?? formatNumber(mask.region.width))}, height: ${normalizedHeight(height ?? formatNumber(mask.region.height))}))`,
+        ]
+      : handleElement(
+          {
+            type: "element",
+            tagName: "rect",
+            properties: { ...mask.region, fill: "black", stroke: "none" },
+            children: [],
+          },
+          context.options,
+        );
     for (let index = targetTransforms.length - 1; index >= 0; index--)
       clipLines = wrapWithTransform(clipLines, targetTransforms[index]!, context.options);
-    const clip = addHelper(context, `MaskClip${context.nextClip++}`, clipLines);
+    const clip = dynamicRegion
+      ? addAnimatedHelper(context, `MaskClip${context.nextClip++}`, clipLines)
+      : addHelper(context, `MaskClip${context.nextClip++}`, clipLines);
     const children = mask.invalid
       ? []
       : buildViewNodes(mask.children, context, [...targetTransforms, mask.contentTransform]);
@@ -1195,6 +1949,19 @@ function buildViewNodes(
       const targetTransforms = [...coverageTransforms, clipNode.transform];
       if (clipNode.type === "group") {
         const children = buildClipCoverage(clipNode.children, targetTransforms);
+        const animationTransform = transformCorrectionExpression(clipNode, coverageTransforms);
+        const renderedChildren: GeneratedViewNode[] = animationTransform
+          ? [
+              {
+                type: "group",
+                children,
+                opacity: 1,
+                isolated: false,
+                blendMode: "normal",
+                animationTransform,
+              },
+            ]
+          : children;
         const nested = buildClipPath(clipNode.clipPath, targetTransforms);
         if (nested) {
           const helpers = simpleClipPathHelpers(nested);
@@ -1202,9 +1969,9 @@ function buildViewNodes(
           // Simple nested regions become GraphicsContext clips on each leaf;
           // SwiftUI otherwise ignores nested view masks inside mask content.
           if (helpers && helpers.length > 0) {
-            coverage.push(...children.map((child) => addCoverageClip(child, helpers)));
+            coverage.push(...renderedChildren.map((child) => addCoverageClip(child, helpers)));
           } else {
-            for (const child of children)
+            for (const child of renderedChildren)
               coverage.push({
                 type: "group",
                 children: [child],
@@ -1214,10 +1981,10 @@ function buildViewNodes(
                 clipPath: nested,
               });
           }
-        } else if (children.length > 0) {
+        } else if (renderedChildren.length > 0) {
           coverage.push({
             type: "group",
-            children,
+            children: renderedChildren,
             opacity: 1,
             isolated: false,
             blendMode: "normal",
@@ -1238,11 +2005,15 @@ function buildViewNodes(
         ...clipNode,
         style: { ...clipNode.style, fillRule: clipNode.style.clipRule },
       };
-      let lines = renderShape(coverageShape, context.options, { fill: "black", stroke: "none" });
-      for (let index = coverageTransforms.length - 1; index >= 0; index--)
-        lines = wrapWithTransform(lines, coverageTransforms[index]!, context.options);
+      const dynamicLines = dynamicShapeLines(coverageShape, "fill", coverageTransforms);
+      let lines = dynamicLines ?? renderShape(coverageShape, context.options, { fill: "black", stroke: "none" });
+      if (!dynamicLines)
+        for (let index = coverageTransforms.length - 1; index >= 0; index--)
+          lines = wrapWithTransform(lines, coverageTransforms[index]!, context.options);
       if (lines.length === 0) continue;
-      const helper = addHelper(context, `ClipCoverage${context.nextClip++}`, lines);
+      const helper = dynamicLines
+        ? addAnimatedHelper(context, `ClipCoverage${context.nextClip++}`, lines)
+        : addHelper(context, `ClipCoverage${context.nextClip++}`, lines);
       const path: GeneratedViewNode = {
         type: "paint",
         helper,
@@ -1268,7 +2039,11 @@ function buildViewNodes(
     if (!clipPath) return undefined;
     const content = clipPath.children.map((node) =>
       node.type === "group"
-        ? { ...node, transform: multiplyTransforms(node.transform, clipPath.contentTransform) }
+        ? {
+            ...node,
+            transform: multiplyTransforms(node.transform, clipPath.contentTransform),
+            transformAnimation: { base: node.transform, suffix: clipPath.contentTransform },
+          }
         : node,
     );
     // clipPath's transform operates outside the clipPathUnits mapping:
@@ -1301,7 +2076,12 @@ function buildViewNodes(
         viewBoxBase && viewportRect && (animatedViewBox || animatedPreserve)
           ? `${context.rootName}.svgMultiplyTransform(${swiftTransform(node.transformAnimation?.viewportPrefix ?? IDENTITY_TRANSFORM)}, ${context.rootName}.svgViewBoxMatrix(${animatedViewBox ?? swiftAnimationValueLiteral(viewBoxBase, context.precision, `${context.rootName}.`)}, rect: CGRect(x: ${formatNumber(viewportRect.x)}, y: ${formatNumber(viewportRect.y)}, width: ${formatNumber(viewportRect.width)}, height: ${formatNumber(viewportRect.height)}), preserveAspectRatio: ${animatedPreserve ?? swiftString(preserveSource)}))`
           : undefined;
-      const animationTransform = transformCorrectionExpression(node, ancestorTransforms, animatedViewportSuffix);
+      const animationTransform = transformCorrectionExpression(
+        node,
+        ancestorTransforms,
+        animatedViewportSuffix,
+        animatedMarkerBase(node),
+      );
       let viewportClip: string | undefined;
       if (node.viewport?.clip) {
         const { rect, clipTransform } = node.viewport;
@@ -1336,8 +2116,8 @@ function buildViewNodes(
       const children = buildViewNodes(node.children, context, targetTransforms, childAnimationOwners);
       if (children.length > 0) {
         const clipPath = buildClipPath(node.clipPath, targetTransforms);
-        const mask = buildMask(node.mask, targetTransforms);
-        const filter = buildFilter(node.filter, targetTransforms);
+        const mask = buildMask(node.mask, targetTransforms, node);
+        const filter = buildFilter(node.filter, targetTransforms, node);
         generated.push({
           type: "group",
           children,
@@ -1394,6 +2174,100 @@ function buildViewNodes(
         Number(node.style.presentation["letter-spacing"] ?? 0),
       );
       const wordSpacing = animatedNumber(node, "word-spacing", Number(node.style.presentation["word-spacing"] ?? 0));
+      const textTargetValue = (
+        key: string | undefined,
+        attributeName: string,
+        baseValue: string,
+        targetTag = "tspan",
+      ) => {
+        const animations = animationsForResource(key, attributeName).filter(
+          (animation) =>
+            animation.target?.binding === "resource" ||
+            (animation.target?.binding === "render-node" && attributeName === "textLength"),
+        );
+        const spec = resolveAnimationAttributeForTarget(attributeName, "auto", targetTag);
+        const base = spec ? parseAnimationValue(spec, baseValue, valueContext(node)) : undefined;
+        return base ? animatedValueExpressionFromAnimations(animations, base) : undefined;
+      };
+      const textTargetNumber = (key: string | undefined, attributeName: string, baseValue: number) => {
+        const expression = textTargetValue(key, attributeName, formatNumber(baseValue));
+        return expression ? `${context.rootName}.svgAnimationNumber(${expression})` : undefined;
+      };
+      const textChunks = node.chunks.map((chunk) => {
+        const x = chunk.x === undefined ? undefined : textTargetNumber(chunk.animationTargetKey, "x", chunk.x);
+        const y = chunk.y === undefined ? undefined : textTargetNumber(chunk.animationTargetKey, "y", chunk.y);
+        const startOffset = chunk.textPath
+          ? textTargetNumber(chunk.textPath.animationTargetKey, "startOffset", chunk.textPath.startOffset)
+          : undefined;
+        const adjustmentTargets = chunk.lengthAdjustments.map((adjustment) => {
+          const expression = textTargetNumber(
+            adjustment.animationTargetKey,
+            "textLength",
+            adjustment.target / adjustment.animationScale,
+          );
+          return expression ? `(${expression} * ${formatNumber(adjustment.animationScale)})` : undefined;
+        });
+        const runs = chunk.runs.map((run) => {
+          const key = run.animationTargetKey;
+          const runFill = textTargetValue(key, "fill", paintValue(run.style.fill));
+          const runStroke = textTargetValue(key, "stroke", paintValue(run.style.stroke));
+          const characterDX = textTargetValue(
+            key,
+            "dx",
+            run.characters.map((character) => formatNumber(character.dx)).join(" "),
+          );
+          const characterDY = textTargetValue(
+            key,
+            "dy",
+            run.characters.map((character) => formatNumber(character.dy)).join(" "),
+          );
+          const characterRotate = textTargetValue(
+            key,
+            "rotate",
+            run.characters.map((character) => formatNumber(character.rotate)).join(" "),
+          );
+          return {
+            ...(textTargetNumber(key, "font-size", run.font.size)
+              ? { fontSize: textTargetNumber(key, "font-size", run.font.size) }
+              : {}),
+            ...(textTargetNumber(key, "letter-spacing", run.letterSpacing)
+              ? { letterSpacing: textTargetNumber(key, "letter-spacing", run.letterSpacing) }
+              : {}),
+            ...(textTargetNumber(key, "word-spacing", run.wordSpacing)
+              ? { wordSpacing: textTargetNumber(key, "word-spacing", run.wordSpacing) }
+              : {}),
+            ...(runFill ? { fill: runFill } : {}),
+            ...(textTargetNumber(key, "fill-opacity", run.style.fillOpacity)
+              ? { fillOpacity: textTargetNumber(key, "fill-opacity", run.style.fillOpacity) }
+              : {}),
+            ...(runStroke ? { stroke: runStroke } : {}),
+            ...(characterDX ? { characterDX } : {}),
+            ...(characterDY ? { characterDY } : {}),
+            ...(characterRotate ? { characterRotate } : {}),
+            ...(textTargetNumber(key, "stroke-opacity", run.style.strokeOpacity)
+              ? { strokeOpacity: textTargetNumber(key, "stroke-opacity", run.style.strokeOpacity) }
+              : {}),
+            ...(textTargetNumber(key, "stroke-width", run.style.strokeStyle.width)
+              ? { strokeWidth: textTargetNumber(key, "stroke-width", run.style.strokeStyle.width) }
+              : {}),
+          };
+        });
+        return {
+          ...(x ? { x } : {}),
+          ...(y ? { y } : {}),
+          ...(startOffset ? { startOffset } : {}),
+          adjustmentTargets,
+          runs,
+        };
+      });
+      const textResourceAnimated = textChunks.some(
+        (chunk) =>
+          !!chunk.x ||
+          !!chunk.y ||
+          !!chunk.startOffset ||
+          chunk.adjustmentTargets.some(Boolean) ||
+          chunk.runs.some((run) => Object.keys(run).length > 0),
+      );
       const textAnimated = !!(
         effectiveFillAnimation ||
         fillOpacity ||
@@ -1402,7 +2276,8 @@ function buildViewNodes(
         strokeWidth ||
         fontSize ||
         letterSpacing ||
-        wordSpacing
+        wordSpacing ||
+        textResourceAnimated
       );
       context.textHelpers.push({
         name,
@@ -1416,13 +2291,14 @@ function buildViewNodes(
         ...(fontSize ? { fontSize } : {}),
         ...(letterSpacing ? { letterSpacing } : {}),
         ...(wordSpacing ? { wordSpacing } : {}),
+        chunks: textChunks,
         animated: textAnimated,
       });
       const targetTransforms = [...ancestorTransforms, node.transform];
       const animationTransform = transformCorrectionExpression(node, ancestorTransforms);
       const clipPath = buildClipPath(node.clipPath, targetTransforms);
-      const mask = buildMask(node.mask, targetTransforms);
-      const filter = buildFilter(node.filter, targetTransforms);
+      const mask = buildMask(node.mask, targetTransforms, node);
+      const filter = buildFilter(node.filter, targetTransforms, node);
       generated.push({
         type: "group",
         children: [{ type: "text", helper: textAnimated ? `${name}(documentTime: documentTime)` : name }],
@@ -1462,6 +2338,7 @@ function buildViewNodes(
       const completeTransform = [...ancestorTransforms, node.transform].reduce(multiplyTransforms);
       const name = `${node.type === "foreignObject" ? "ForeignObject" : "Image"}Layer${context.imageHelpers.length}`;
       let subdocumentName: string | undefined;
+      let animatedSubdocument = false;
       if (node.type === "image" && node.resource.type === "svg") {
         subdocumentName = `${context.rootName}ImageDocument${context.subdocuments.length}`;
         const child = node.resource.document;
@@ -1481,21 +2358,47 @@ function buildViewNodes(
           usageCommentPrefix: false,
         });
         context.subdocuments.push(generatedChild.lines);
+        if (child.animationProgram.animations.some((animation) => animation.runtimeSupport === "typed")) {
+          // Referenced SVG images share the parent's canonical document time.
+          // This also keeps exact frame rendering independent of traversal order.
+          animatedSubdocument = true;
+        }
+      }
+      const preserveSource =
+        node.type === "image"
+          ? `${node.preserveAspectRatio.defer ? "defer " : ""}${node.preserveAspectRatio.align} ${node.preserveAspectRatio.meetOrSlice}`
+          : "none meet";
+      const animatedPreserve =
+        node.type === "image" ? animatedDiscrete(node, "preserveAspectRatio", preserveSource) : undefined;
+      const imageAnimated = animatedSubdocument || !!animatedPreserve;
+      let transformExpression: string | undefined;
+      if (animatedPreserve && node.type === "image") {
+        const intrinsic =
+          node.resource.type === "raster"
+            ? (node.resource.intrinsicSize ?? { width: node.viewport.width, height: node.viewport.height })
+            : { width: node.resource.document.viewport.width, height: node.resource.document.viewport.height };
+        const value = `${context.rootName}.SVGAnimationRuntimeValue(kind: .viewBox, components: [0, 0, ${formatNumber(intrinsic.width)}, ${formatNumber(intrinsic.height)}], signature: "", source: "0 0 ${formatNumber(intrinsic.width)} ${formatNumber(intrinsic.height)}")`;
+        const rect = `CGRect(x: ${formatNumber(node.viewport.x)}, y: ${formatNumber(node.viewport.y)}, width: ${formatNumber(node.viewport.width)}, height: ${formatNumber(node.viewport.height)})`;
+        const coordinateSpace = `CGRect(x: ${formatNumber(context.coordinateSpace.x)}, y: ${formatNumber(context.coordinateSpace.y)}, width: ${formatNumber(context.coordinateSpace.width)}, height: ${formatNumber(context.coordinateSpace.height)})`;
+        transformExpression = `${context.rootName}.svgOutputTransform(${context.rootName}.svgMultiplyTransform(${swiftTransform(completeTransform)}, ${context.rootName}.svgViewBoxMatrix(${value}, rect: ${rect}, preserveAspectRatio: ${animatedPreserve})), size: size, coordinateSpace: ${coordinateSpace})`;
       }
       context.imageHelpers.push({
         name,
         node,
         transform: completeTransform,
         ...(subdocumentName ? { subdocumentName } : {}),
+        ...(animatedSubdocument ? { subdocumentAnimated: true } : {}),
+        ...(imageAnimated ? { animated: true } : {}),
+        ...(transformExpression ? { transformExpression } : {}),
       });
       const targetTransforms = [...ancestorTransforms, node.transform];
       const animationTransform = transformCorrectionExpression(node, ancestorTransforms);
       const clipPath = buildClipPath(node.clipPath, targetTransforms);
-      const mask = buildMask(node.mask, targetTransforms);
-      const filter = buildFilter(node.filter, targetTransforms);
+      const mask = buildMask(node.mask, targetTransforms, node);
+      const filter = buildFilter(node.filter, targetTransforms, node);
       generated.push({
         type: "group",
-        children: [{ type: "image", helper: name }],
+        children: [{ type: "image", helper: imageAnimated ? `${name}(documentTime: documentTime)` : name }],
         opacity: opacityExpression(node),
         isolated:
           opacityExpression(node) !== 1 ||
@@ -1620,6 +2523,7 @@ function buildViewNodes(
             ...(animatedGradientStopsExpression(gradient.stops, node, paintOpacity)
               ? { stopsExpression: animatedGradientStopsExpression(gradient.stops, node, paintOpacity) }
               : {}),
+            ...animatedGradientExpressions(server, gradient, node),
           });
           return;
         }
@@ -1670,6 +2574,7 @@ function buildViewNodes(
             paintOpacity,
             coordinateSpace: context.coordinateSpace,
             patternIndex,
+            ...animatedPatternExpressions(pattern, node),
             ...(tileClip ? { tileClip } : {}),
             contentNodes,
           });
@@ -1696,8 +2601,8 @@ function buildViewNodes(
       const targetTransforms = [...ancestorTransforms, node.transform];
       const animationTransform = transformCorrectionExpression(node, ancestorTransforms);
       const clipPath = buildClipPath(node.clipPath, targetTransforms);
-      const mask = buildMask(node.mask, targetTransforms);
-      const filter = buildFilter(node.filter, targetTransforms);
+      const mask = buildMask(node.mask, targetTransforms, node);
+      const filter = buildFilter(node.filter, targetTransforms, node);
       generated.push({
         type: "group",
         children: paints,
@@ -1765,17 +2670,18 @@ function filterBlendModeLiteral(mode: Extract<FilterPrimitive, { type: "blend" }
 
 function filterComponentFunctionLiteral(
   fn: Extract<FilterPrimitive, { type: "componentTransfer" }>["functions"][number],
+  overrides: Readonly<Record<string, string>> = {},
 ): string {
   switch (fn.type) {
     case "identity":
       return ".identity";
     case "table":
     case "discrete":
-      return `.${fn.type}([${fn.values.map((value) => formatNumber(value)).join(", ")}])`;
+      return `.${fn.type}(${overrides.tableValues ?? `[${fn.values.map((value) => formatNumber(value)).join(", ")}]`})`;
     case "linear":
-      return `.linear(slope: ${formatNumber(fn.slope)}, intercept: ${formatNumber(fn.intercept)})`;
+      return `.linear(slope: ${overrides.slope ?? formatNumber(fn.slope)}, intercept: ${overrides.intercept ?? formatNumber(fn.intercept)})`;
     case "gamma":
-      return `.gamma(amplitude: ${formatNumber(fn.amplitude)}, exponent: ${formatNumber(fn.exponent)}, offset: ${formatNumber(fn.offset)})`;
+      return `.gamma(amplitude: ${overrides.amplitude ?? formatNumber(fn.amplitude)}, exponent: ${overrides.exponent ?? formatNumber(fn.exponent)}, offset: ${overrides.offset ?? formatNumber(fn.offset)})`;
   }
 }
 
@@ -1783,53 +2689,61 @@ function filterCompositeOperatorLiteral(operator: Extract<FilterPrimitive, { typ
   return `.${operator === "in" ? "inside" : operator === "out" ? "outside" : operator}`;
 }
 
-function filterPrimitiveLiteral(primitive: FilterPrimitive, index: number): string {
-  const region = filterRegionLiteral(primitive.subregion);
-  const linear = primitive.colorInterpolation === "linearRGB" ? "true" : "false";
+function filterPrimitiveLiteral(
+  primitive: FilterPrimitive,
+  index: number,
+  overrides: Readonly<Record<string, string>> = {},
+): string {
+  const value = (name: string, fallback: number) => overrides[name] ?? formatNumber(fallback);
+  const list = (name: string, fallback: number[]) =>
+    overrides[name] ?? `[${fallback.map((item) => formatNumber(item)).join(", ")}]`;
+  const input = (name: "input" | "input2", fallback: FilterInput) => overrides[name] ?? filterInputLiteral(fallback);
+  const region = overrides.region ?? filterRegionLiteral(primitive.subregion);
+  const linear = overrides.linearRGB ?? (primitive.colorInterpolation === "linearRGB" ? "true" : "false");
   const result = primitive.result ? swiftString(primitive.result) : "nil";
   switch (primitive.type) {
     case "blend":
-      return `.blend(input: ${filterInputLiteral(primitive.input)}, input2: ${filterInputLiteral(primitive.input2)}, mode: ${filterBlendModeLiteral(primitive.mode)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.blend(input: ${input("input", primitive.input)}, input2: ${input("input2", primitive.input2)}, mode: ${overrides.mode ?? filterBlendModeLiteral(primitive.mode)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "colorMatrix":
-      return `.colorMatrix(input: ${filterInputLiteral(primitive.input)}, matrix: [${primitive.matrix.map((value) => formatNumber(value)).join(", ")}], region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.colorMatrix(input: ${input("input", primitive.input)}, matrix: ${list("values", primitive.matrix)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "componentTransfer":
-      return `.componentTransfer(input: ${filterInputLiteral(primitive.input)}, functions: [${primitive.functions.map(filterComponentFunctionLiteral).join(", ")}], region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.componentTransfer(input: ${input("input", primitive.input)}, functions: ${overrides.functions ?? `[${primitive.functions.map((fn) => filterComponentFunctionLiteral(fn)).join(", ")}]`}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "composite":
-      return `.composite(input: ${filterInputLiteral(primitive.input)}, input2: ${filterInputLiteral(primitive.input2)}, operation: ${filterCompositeOperatorLiteral(primitive.operator)}, k1: ${formatNumber(primitive.k1)}, k2: ${formatNumber(primitive.k2)}, k3: ${formatNumber(primitive.k3)}, k4: ${formatNumber(primitive.k4)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.composite(input: ${input("input", primitive.input)}, input2: ${input("input2", primitive.input2)}, operation: ${overrides.operator ?? filterCompositeOperatorLiteral(primitive.operator)}, k1: ${value("k1", primitive.k1)}, k2: ${value("k2", primitive.k2)}, k3: ${value("k3", primitive.k3)}, k4: ${value("k4", primitive.k4)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "convolveMatrix":
-      return `.convolveMatrix(input: ${filterInputLiteral(primitive.input)}, orderX: ${primitive.orderX}, orderY: ${primitive.orderY}, kernel: [${primitive.kernelMatrix.map((value) => formatNumber(value)).join(", ")}], divisor: ${formatNumber(primitive.divisor)}, bias: ${formatNumber(primitive.bias)}, targetX: ${primitive.targetX}, targetY: ${primitive.targetY}, edge: .${primitive.edgeMode}, unitX: ${primitive.kernelUnitLengthX === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthX)}, unitY: ${primitive.kernelUnitLengthY === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthY)}, preserveAlpha: ${primitive.preserveAlpha}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.convolveMatrix(input: ${input("input", primitive.input)}, orderX: ${overrides.orderX ?? primitive.orderX}, orderY: ${overrides.orderY ?? primitive.orderY}, kernel: ${list("kernelMatrix", primitive.kernelMatrix)}, divisor: ${value("divisor", primitive.divisor)}, bias: ${value("bias", primitive.bias)}, targetX: ${overrides.targetX ?? primitive.targetX}, targetY: ${overrides.targetY ?? primitive.targetY}, edge: ${overrides.edgeMode ?? `.${primitive.edgeMode}`}, unitX: ${overrides.kernelUnitLengthX ?? (primitive.kernelUnitLengthX === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthX))}, unitY: ${overrides.kernelUnitLengthY ?? (primitive.kernelUnitLengthY === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthY))}, preserveAlpha: ${overrides.preserveAlpha ?? primitive.preserveAlpha}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "morphology":
-      return `.morphology(input: ${filterInputLiteral(primitive.input)}, operation: .${primitive.operator}, radiusX: ${formatNumber(primitive.radiusX)}, radiusY: ${formatNumber(primitive.radiusY)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.morphology(input: ${input("input", primitive.input)}, operation: ${overrides.operator ?? `.${primitive.operator}`}, radiusX: ${value("radiusX", primitive.radiusX)}, radiusY: ${value("radiusY", primitive.radiusY)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "displacementMap":
-      return `.displacementMap(input: ${filterInputLiteral(primitive.input)}, input2: ${filterInputLiteral(primitive.input2)}, a: ${formatNumber(primitive.displacement.a)}, b: ${formatNumber(primitive.displacement.b)}, c: ${formatNumber(primitive.displacement.c)}, d: ${formatNumber(primitive.displacement.d)}, xChannel: .${primitive.xChannel.toLowerCase()}, yChannel: .${primitive.yChannel.toLowerCase()}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.displacementMap(input: ${input("input", primitive.input)}, input2: ${input("input2", primitive.input2)}, a: ${value("a", primitive.displacement.a)}, b: ${value("b", primitive.displacement.b)}, c: ${value("c", primitive.displacement.c)}, d: ${value("d", primitive.displacement.d)}, xChannel: ${overrides.xChannelSelector ?? `.${primitive.xChannel.toLowerCase()}`}, yChannel: ${overrides.yChannelSelector ?? `.${primitive.yChannel.toLowerCase()}`}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "tile":
-      return `.tile(input: ${filterInputLiteral(primitive.input)}, tileRegion: ${filterRegionLiteral(primitive.tileRegion)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.tile(input: ${input("input", primitive.input)}, tileRegion: ${filterRegionLiteral(primitive.tileRegion)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "turbulence":
-      return `.turbulence(baseFrequencyX: ${formatNumber(primitive.baseFrequencyX)}, baseFrequencyY: ${formatNumber(primitive.baseFrequencyY)}, octaves: ${primitive.numOctaves}, seed: ${primitive.seed}, stitch: ${primitive.stitchTiles}, fractalNoise: ${primitive.noiseType === "fractalNoise"}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.turbulence(baseFrequencyX: ${value("baseFrequencyX", primitive.baseFrequencyX)}, baseFrequencyY: ${value("baseFrequencyY", primitive.baseFrequencyY)}, octaves: ${value("numOctaves", primitive.numOctaves)}, seed: ${value("seed", primitive.seed)}, stitch: ${overrides.stitchTiles ?? primitive.stitchTiles}, fractalNoise: ${overrides.type ?? primitive.noiseType === "fractalNoise"}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "image":
       return `.image(key: ${swiftString(`filter-image-${index}`)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "diffuseLighting":
-      return `.diffuseLighting(input: ${filterInputLiteral(primitive.input)}, surfaceScale: ${formatNumber(primitive.surfaceScale)}, diffuseConstant: ${formatNumber(primitive.diffuseConstant)}, unitX: ${primitive.kernelUnitLengthX === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthX)}, unitY: ${primitive.kernelUnitLengthY === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthY)}, color: ${filterColorLiteral(primitive.color)}, light: ${filterLightLiteral(primitive.light)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.diffuseLighting(input: ${input("input", primitive.input)}, surfaceScale: ${value("surfaceScale", primitive.surfaceScale)}, diffuseConstant: ${value("diffuseConstant", primitive.diffuseConstant)}, unitX: ${overrides.kernelUnitLengthX ?? (primitive.kernelUnitLengthX === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthX))}, unitY: ${overrides.kernelUnitLengthY ?? (primitive.kernelUnitLengthY === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthY))}, color: ${overrides.color ?? filterColorLiteral(primitive.color)}, light: ${overrides.light ?? filterLightLiteral(primitive.light)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "specularLighting":
-      return `.specularLighting(input: ${filterInputLiteral(primitive.input)}, surfaceScale: ${formatNumber(primitive.surfaceScale)}, specularConstant: ${formatNumber(primitive.specularConstant)}, specularExponent: ${formatNumber(primitive.specularExponent)}, unitX: ${primitive.kernelUnitLengthX === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthX)}, unitY: ${primitive.kernelUnitLengthY === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthY)}, color: ${filterColorLiteral(primitive.color)}, light: ${filterLightLiteral(primitive.light)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.specularLighting(input: ${input("input", primitive.input)}, surfaceScale: ${value("surfaceScale", primitive.surfaceScale)}, specularConstant: ${value("specularConstant", primitive.specularConstant)}, specularExponent: ${value("specularExponent", primitive.specularExponent)}, unitX: ${overrides.kernelUnitLengthX ?? (primitive.kernelUnitLengthX === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthX))}, unitY: ${overrides.kernelUnitLengthY ?? (primitive.kernelUnitLengthY === undefined ? "nil" : formatNumber(primitive.kernelUnitLengthY))}, color: ${overrides.color ?? filterColorLiteral(primitive.color)}, light: ${overrides.light ?? filterLightLiteral(primitive.light)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "gaussianBlur":
-      return `.gaussianBlur(input: ${filterInputLiteral(primitive.input)}, sigmaX: ${formatNumber(primitive.stdDeviationX)}, sigmaY: ${formatNumber(primitive.stdDeviationY)}, edge: .${primitive.edgeMode}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.gaussianBlur(input: ${input("input", primitive.input)}, sigmaX: ${value("stdDeviationX", primitive.stdDeviationX)}, sigmaY: ${value("stdDeviationY", primitive.stdDeviationY)}, edge: ${overrides.edgeMode ?? `.${primitive.edgeMode}`}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "offset":
-      return `.offset(input: ${filterInputLiteral(primitive.input)}, dx: ${formatNumber(primitive.dx)}, dy: ${formatNumber(primitive.dy)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.offset(input: ${input("input", primitive.input)}, dx: ${value("dx", primitive.dx)}, dy: ${value("dy", primitive.dy)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "flood":
-      return `.flood(color: ${filterColorLiteral(primitive.color)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.flood(color: ${overrides.color ?? filterColorLiteral(primitive.color)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "merge":
       return `.merge(inputs: [${primitive.inputs.map(filterInputLiteral).join(", ")}], region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "dropShadow":
-      return `.dropShadow(input: ${filterInputLiteral(primitive.input)}, sigmaX: ${formatNumber(primitive.stdDeviationX)}, sigmaY: ${formatNumber(primitive.stdDeviationY)}, dx: ${formatNumber(primitive.dx)}, dy: ${formatNumber(primitive.dy)}, color: ${filterColorLiteral(primitive.color)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.dropShadow(input: ${input("input", primitive.input)}, sigmaX: ${value("stdDeviationX", primitive.stdDeviationX)}, sigmaY: ${value("stdDeviationY", primitive.stdDeviationY)}, dx: ${value("dx", primitive.dx)}, dy: ${value("dy", primitive.dy)}, color: ${overrides.color ?? filterColorLiteral(primitive.color)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
     case "passthrough":
-      return `.passthrough(input: ${filterInputLiteral(primitive.input)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
+      return `.passthrough(input: ${input("input", primitive.input)}, region: ${region}, linearRGB: ${linear}, result: ${result})`;
   }
 }
 
 function filterDefinitionLiteral(filter: GeneratedFilter): string {
   const instance = filter.instance;
-  return `SVGFilterDefinition(region: ${filterRegionLiteral(instance.region)}, primitives: [${instance.primitives.map((primitive, index) => filterPrimitiveLiteral(primitive, index)).join(", ")}], fillPaint: ${filterColorLiteral(instance.fillPaint)}, strokePaint: ${filterColorLiteral(instance.strokePaint)}, maxOutputPixels: ${filter.maxOutputPixels})`;
+  return `SVGFilterDefinition(region: ${filter.regionExpression ?? filterRegionLiteral(instance.region)}, primitives: [${instance.primitives.map((primitive, index) => filterPrimitiveLiteral(primitive, index, filter.primitiveOverrides[index])).join(", ")}], fillPaint: ${filterColorLiteral(instance.fillPaint)}, strokePaint: ${filterColorLiteral(instance.strokePaint)}, maxOutputPixels: ${filter.maxOutputPixels})`;
 }
 
 function textGradientLength(
@@ -1902,9 +2816,11 @@ function createTextHelper(
   const i4 = indentation.repeat(4);
   const i5 = indentation.repeat(5);
   const chunks = helper.node.chunks
-    .map((chunk) => {
+    .map((chunk, chunkIndex) => {
+      const chunkExpressions = helper.chunks[chunkIndex]!;
       const runs = chunk.runs
-        .map((run) => {
+        .map((run, runIndex) => {
+          const runExpressions = chunkExpressions.runs[runIndex]!;
           const transform = multiplyTransforms(helper.transform, run.transform);
           const localOpacity = run.source.element === "tspan" ? run.style.opacity : 1;
           const order = run.style.paintOrder
@@ -1917,25 +2833,33 @@ function createTextHelper(
             .join(", ");
           const characters = run.characters
             .map(
-              (character) =>
-                `SVGTextCharacter(text: ${swiftString(character.text)}, dx: ${formatNumber(character.dx)}, dy: ${formatNumber(character.dy)}, rotation: ${formatNumber(character.rotate)})`,
+              (character, characterIndex) =>
+                `SVGTextCharacter(text: ${swiftString(character.text)}, dx: ${runExpressions.characterDX ? `${ownerName}.svgAnimationComponent(${runExpressions.characterDX}, index: ${characterIndex})` : formatNumber(character.dx)}, dy: ${runExpressions.characterDY ? `${ownerName}.svgAnimationComponent(${runExpressions.characterDY}, index: ${characterIndex})` : formatNumber(character.dy)}, rotation: ${runExpressions.characterRotate ? `${ownerName}.svgAnimationComponent(${runExpressions.characterRotate}, index: ${characterIndex})` : formatNumber(character.rotate)})`,
             )
             .join(", ");
           const bidi = run.unicodeBidi.replace(/-([a-z])/g, (_match, letter: string) => letter.toUpperCase());
-          return `SVGTextRun(text: ${swiftString(run.text)}, characters: [${characters}], dx: ${formatNumber(run.dx)}, dy: ${formatNumber(run.dy)}, family: ${swiftString(run.font.family)}, size: ${helper.fontSize ?? formatNumber(run.font.size)}, weight: ${formatNumber(run.font.weight)}, width: ${formatNumber(run.font.width)}, italic: ${run.font.italic}, smallCaps: ${run.font.smallCaps}, sizeAdjust: ${run.font.sizeAdjust === undefined ? "nil" : formatNumber(run.font.sizeAdjust)}, letterSpacing: ${helper.letterSpacing ?? formatNumber(run.letterSpacing)}, wordSpacing: ${helper.wordSpacing ?? formatNumber(run.wordSpacing)}, kerning: ${run.kerning}, baseline: .${baseline}, baselineShift: ${formatNumber(run.baselineShift)}, decorations: [${decorations}], direction: .${run.direction}, unicodeBidi: .${bidi}, textOrientation: .${run.textOrientation}, fill: ${textPaintLiteral(run.style.fill, run.style.fillOpacity * localOpacity, helper.node, document, transform, helper.fillAnimation ? { value: helper.fillAnimation, opacity: helper.fillOpacity ?? formatNumber(run.style.fillOpacity * localOpacity) } : undefined)}, stroke: ${textPaintLiteral(run.style.stroke, run.style.strokeOpacity * localOpacity, helper.node, document, transform, helper.strokeAnimation ? { value: helper.strokeAnimation, opacity: helper.strokeOpacity ?? formatNumber(run.style.strokeOpacity * localOpacity) } : undefined)}, strokeWidth: ${helper.strokeWidth ?? formatNumber(run.style.strokeStyle.width)}, lineCap: .${run.style.strokeStyle.lineCap}, lineJoin: .${run.style.strokeStyle.lineJoin}, miterLimit: ${formatNumber(run.style.strokeStyle.miterLimit)}, paintOrder: [${order}], transform: ${swiftTransform(transform)})`;
+          const fillAnimation = runExpressions.fill ?? helper.fillAnimation;
+          const fillOpacity =
+            runExpressions.fillOpacity ?? helper.fillOpacity ?? formatNumber(run.style.fillOpacity * localOpacity);
+          const strokeAnimation = runExpressions.stroke ?? helper.strokeAnimation;
+          const strokeOpacity =
+            runExpressions.strokeOpacity ??
+            helper.strokeOpacity ??
+            formatNumber(run.style.strokeOpacity * localOpacity);
+          return `SVGTextRun(text: ${swiftString(run.text)}, characters: [${characters}], dx: ${formatNumber(run.dx)}, dy: ${formatNumber(run.dy)}, family: ${swiftString(run.font.family)}, size: ${runExpressions.fontSize ?? helper.fontSize ?? formatNumber(run.font.size)}, weight: ${formatNumber(run.font.weight)}, width: ${formatNumber(run.font.width)}, italic: ${run.font.italic}, smallCaps: ${run.font.smallCaps}, sizeAdjust: ${run.font.sizeAdjust === undefined ? "nil" : formatNumber(run.font.sizeAdjust)}, letterSpacing: ${runExpressions.letterSpacing ?? helper.letterSpacing ?? formatNumber(run.letterSpacing)}, wordSpacing: ${runExpressions.wordSpacing ?? helper.wordSpacing ?? formatNumber(run.wordSpacing)}, kerning: ${run.kerning}, baseline: .${baseline}, baselineShift: ${formatNumber(run.baselineShift)}, decorations: [${decorations}], direction: .${run.direction}, unicodeBidi: .${bidi}, textOrientation: .${run.textOrientation}, fill: ${textPaintLiteral(run.style.fill, run.style.fillOpacity * localOpacity, helper.node, document, transform, fillAnimation ? { value: fillAnimation, opacity: fillOpacity } : undefined)}, stroke: ${textPaintLiteral(run.style.stroke, run.style.strokeOpacity * localOpacity, helper.node, document, transform, strokeAnimation ? { value: strokeAnimation, opacity: strokeOpacity } : undefined)}, strokeWidth: ${runExpressions.strokeWidth ?? helper.strokeWidth ?? formatNumber(run.style.strokeStyle.width)}, lineCap: .${run.style.strokeStyle.lineCap}, lineJoin: .${run.style.strokeStyle.lineJoin}, miterLimit: ${formatNumber(run.style.strokeStyle.miterLimit)}, paintOrder: [${order}], transform: ${swiftTransform(transform)})`;
         })
         .join(", ");
       const adjustments = chunk.lengthAdjustments
         .map(
-          (adjustment) =>
-            `SVGTextLengthAdjustment(start: ${adjustment.start}, end: ${adjustment.end}, target: ${formatNumber(adjustment.target)}, mode: .${adjustment.mode})`,
+          (adjustment, adjustmentIndex) =>
+            `SVGTextLengthAdjustment(start: ${adjustment.start}, end: ${adjustment.end}, target: ${chunkExpressions.adjustmentTargets[adjustmentIndex] ?? formatNumber(adjustment.target)}, mode: .${adjustment.mode})`,
         )
         .join(", ");
       const path = chunk.textPath
-        ? `SVGTextPath(points: [${chunk.textPath.points.map((point) => `SVGTextPathPoint(x: ${formatNumber(point.x)}, y: ${formatNumber(point.y)}, distance: ${formatNumber(point.distance)}, move: ${point.move})`).join(", ")}], length: ${formatNumber(chunk.textPath.length)}, closed: ${chunk.textPath.closed}, distanceScale: ${formatNumber(chunk.textPath.distanceScale)}, startOffset: ${formatNumber(chunk.textPath.startOffset)}, method: .${chunk.textPath.method}, spacing: .${chunk.textPath.spacing}, side: .${chunk.textPath.side})`
+        ? `SVGTextPath(points: [${chunk.textPath.points.map((point) => `SVGTextPathPoint(x: ${formatNumber(point.x)}, y: ${formatNumber(point.y)}, distance: ${formatNumber(point.distance)}, move: ${point.move})`).join(", ")}], length: ${formatNumber(chunk.textPath.length)}, closed: ${chunk.textPath.closed}, distanceScale: ${formatNumber(chunk.textPath.distanceScale)}, startOffset: ${chunkExpressions.startOffset ?? formatNumber(chunk.textPath.startOffset)}, method: .${chunk.textPath.method}, spacing: .${chunk.textPath.spacing}, side: .${chunk.textPath.side})`
         : "nil";
       const writingMode = chunk.writingMode.replace(/-([a-z])/g, (_match, letter: string) => letter.toUpperCase());
-      return `SVGTextChunk(x: ${chunk.x === undefined ? "nil" : formatNumber(chunk.x)}, y: ${chunk.y === undefined ? "nil" : formatNumber(chunk.y)}, anchor: .${chunk.anchor}, direction: .${chunk.direction}, writingMode: .${writingMode}, lengthAdjustments: [${adjustments}], textPath: ${path}, runs: [${runs}])`;
+      return `SVGTextChunk(x: ${chunk.x === undefined ? "nil" : (chunkExpressions.x ?? formatNumber(chunk.x))}, y: ${chunk.y === undefined ? "nil" : (chunkExpressions.y ?? formatNumber(chunk.y))}, anchor: .${chunk.anchor}, direction: .${chunk.direction}, writingMode: .${writingMode}, lengthAdjustments: [${adjustments}], textPath: ${path}, runs: [${runs}])`;
     })
     .join(`,\n${i3}`);
 
@@ -2306,16 +3230,20 @@ function renderGradientNode(
   const nested = indentation.repeat(level + 2);
   const deep = indentation.repeat(level + 3);
   const gradient = node.gradient;
-  const matrix = gradient.matrix;
+  const coordinate = (name: string, value: number) =>
+    node.coordinateExpressions?.[name] ? `CGFloat(${node.coordinateExpressions[name]})` : formatNumber(value);
   const stops =
     node.stopsExpression ??
     `[${gradient.stops.map((stop) => gradientStopLiteral(stop, node.paintOpacity)).join(", ")}]`;
-  const transform = runtimeTransform(matrix, node.coordinateSpace);
+  const transform = node.matrixExpression ?? runtimeTransform(gradient.matrix, node.coordinateSpace);
+  const spread =
+    node.spreadExpression ?? `.${gradient.spreadMethod === "repeat" ? "repeating" : gradient.spreadMethod}`;
+  const linearRGB = node.linearRGBExpression ?? String(gradient.colorInterpolation === "linearRGB");
   const lines = [
     `${prefix}Canvas { context, size in`,
     `${inner}let clipPath = ${shapeHelperCall(node.helper)}.path(in: CGRect(origin: .zero, size: size))`,
     `${inner}let stops = ${stops}`,
-    `${inner}if let gradient = svgGradient(stops: stops, spread: .${gradient.spreadMethod === "repeat" ? "repeating" : gradient.spreadMethod}, startT: ${formatNumber(gradient.startT)}, endT: ${formatNumber(gradient.endT)}, linearRGB: ${gradient.colorInterpolation === "linearRGB"}) {`,
+    `${inner}if let gradient = svgGradient(stops: stops, spread: ${spread}, startT: ${formatNumber(gradient.startT)}, endT: ${formatNumber(gradient.endT)}, linearRGB: ${linearRGB}) {`,
     `${nested}context.withCGContext { graphics in`,
     `${deep}graphics.saveGState()`,
     `${deep}graphics.addPath(clipPath.cgPath)`,
@@ -2323,21 +3251,24 @@ function renderGradientNode(
     `${deep}graphics.concatenate(${transform})`,
   ];
   if (gradient.type === "linearGradient") {
-    const dx = gradient.x2 - gradient.x1;
-    const dy = gradient.y2 - gradient.y1;
-    const startX = gradient.x1 + dx * gradient.startT;
-    const startY = gradient.y1 + dy * gradient.startT;
-    const endX = gradient.x1 + dx * gradient.endT;
-    const endY = gradient.y1 + dy * gradient.endT;
+    const x1 = coordinate("x1", gradient.x1);
+    const y1 = coordinate("y1", gradient.y1);
+    const x2 = coordinate("x2", gradient.x2);
+    const y2 = coordinate("y2", gradient.y2);
     lines.push(
-      `${deep}graphics.drawLinearGradient(gradient, start: CGPoint(x: ${formatNumber(startX)}, y: ${formatNumber(startY)}), end: CGPoint(x: ${formatNumber(endX)}, y: ${formatNumber(endY)}), options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
+      `${deep}let gradientStart = CGPoint(x: ${x1} + (${x2} - ${x1}) * ${formatNumber(gradient.startT)}, y: ${y1} + (${y2} - ${y1}) * ${formatNumber(gradient.startT)})`,
+      `${deep}let gradientEnd = CGPoint(x: ${x1} + (${x2} - ${x1}) * ${formatNumber(gradient.endT)}, y: ${y1} + (${y2} - ${y1}) * ${formatNumber(gradient.endT)})`,
+      `${deep}graphics.drawLinearGradient(gradient, start: gradientStart, end: gradientEnd, options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
     );
   } else {
-    const dx = gradient.cx - gradient.fx;
-    const dy = gradient.cy - gradient.fy;
-    const dr = gradient.r - gradient.fr;
+    const cx = coordinate("cx", gradient.cx);
+    const cy = coordinate("cy", gradient.cy);
+    const radius = coordinate("r", gradient.r);
+    const fx = coordinate("fx", gradient.fx);
+    const fy = coordinate("fy", gradient.fy);
+    const fr = coordinate("fr", gradient.fr);
     lines.push(
-      `${deep}graphics.drawRadialGradient(gradient, startCenter: CGPoint(x: ${formatNumber(gradient.fx + dx * gradient.startT)}, y: ${formatNumber(gradient.fy + dy * gradient.startT)}), startRadius: ${formatNumber(gradient.fr + dr * gradient.startT)}, endCenter: CGPoint(x: ${formatNumber(gradient.fx + dx * gradient.endT)}, y: ${formatNumber(gradient.fy + dy * gradient.endT)}), endRadius: ${formatNumber(gradient.fr + dr * gradient.endT)}, options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
+      `${deep}graphics.drawRadialGradient(gradient, startCenter: CGPoint(x: ${fx} + (${cx} - ${fx}) * ${formatNumber(gradient.startT)}, y: ${fy} + (${cy} - ${fy}) * ${formatNumber(gradient.startT)}), startRadius: ${fr} + (${radius} - ${fr}) * ${formatNumber(gradient.startT)}, endCenter: CGPoint(x: ${fx} + (${cx} - ${fx}) * ${formatNumber(gradient.endT)}, y: ${fy} + (${cy} - ${fy}) * ${formatNumber(gradient.endT)}), endRadius: ${fr} + (${radius} - ${fr}) * ${formatNumber(gradient.endT)}, options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
     );
   }
   lines.push(`${deep}graphics.restoreGState()`, `${nested}}`, `${inner}}`, `${prefix}}`);
@@ -2371,7 +3302,12 @@ function renderGradientCommands(
   const inner = indentation.repeat(level + 1);
   const nested = indentation.repeat(level + 2);
   const gradient = node.gradient;
-  const transform = runtimeTransform(gradient.matrix, node.coordinateSpace);
+  const coordinate = (name: string, value: number) =>
+    node.coordinateExpressions?.[name] ? `CGFloat(${node.coordinateExpressions[name]})` : formatNumber(value);
+  const transform = node.matrixExpression ?? runtimeTransform(gradient.matrix, node.coordinateSpace);
+  const spread =
+    node.spreadExpression ?? `.${gradient.spreadMethod === "repeat" ? "repeating" : gradient.spreadMethod}`;
+  const linearRGB = node.linearRGBExpression ?? String(gradient.colorInterpolation === "linearRGB");
   const stops =
     node.stopsExpression ??
     `[${gradient.stops.map((stop) => gradientStopLiteral(stop, node.paintOpacity)).join(", ")}]`;
@@ -2379,24 +3315,29 @@ function renderGradientCommands(
     `${prefix}do {`,
     `${inner}let clipPath = ${shapeHelperCall(node.helper)}.path(in: CGRect(origin: .zero, size: size))`,
     `${inner}let stops = ${stops}`,
-    `${inner}if let gradient = svgGradient(stops: stops, spread: .${gradient.spreadMethod === "repeat" ? "repeating" : gradient.spreadMethod}, startT: ${formatNumber(gradient.startT)}, endT: ${formatNumber(gradient.endT)}, linearRGB: ${gradient.colorInterpolation === "linearRGB"}) {`,
+    `${inner}if let gradient = svgGradient(stops: stops, spread: ${spread}, startT: ${formatNumber(gradient.startT)}, endT: ${formatNumber(gradient.endT)}, linearRGB: ${linearRGB}) {`,
     `${nested}${graphicsName}.saveGState()`,
     `${nested}${graphicsName}.addPath(clipPath.cgPath)`,
     `${nested}${graphicsName}.clip()`,
     `${nested}${graphicsName}.concatenate(${transform})`,
   ];
   if (gradient.type === "linearGradient") {
-    const dx = gradient.x2 - gradient.x1;
-    const dy = gradient.y2 - gradient.y1;
+    const x1 = coordinate("x1", gradient.x1);
+    const y1 = coordinate("y1", gradient.y1);
+    const x2 = coordinate("x2", gradient.x2);
+    const y2 = coordinate("y2", gradient.y2);
     lines.push(
-      `${nested}${graphicsName}.drawLinearGradient(gradient, start: CGPoint(x: ${formatNumber(gradient.x1 + dx * gradient.startT)}, y: ${formatNumber(gradient.y1 + dy * gradient.startT)}), end: CGPoint(x: ${formatNumber(gradient.x1 + dx * gradient.endT)}, y: ${formatNumber(gradient.y1 + dy * gradient.endT)}), options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
+      `${nested}${graphicsName}.drawLinearGradient(gradient, start: CGPoint(x: ${x1} + (${x2} - ${x1}) * ${formatNumber(gradient.startT)}, y: ${y1} + (${y2} - ${y1}) * ${formatNumber(gradient.startT)}), end: CGPoint(x: ${x1} + (${x2} - ${x1}) * ${formatNumber(gradient.endT)}, y: ${y1} + (${y2} - ${y1}) * ${formatNumber(gradient.endT)}), options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
     );
   } else {
-    const dx = gradient.cx - gradient.fx;
-    const dy = gradient.cy - gradient.fy;
-    const dr = gradient.r - gradient.fr;
+    const cx = coordinate("cx", gradient.cx);
+    const cy = coordinate("cy", gradient.cy);
+    const radius = coordinate("r", gradient.r);
+    const fx = coordinate("fx", gradient.fx);
+    const fy = coordinate("fy", gradient.fy);
+    const fr = coordinate("fr", gradient.fr);
     lines.push(
-      `${nested}${graphicsName}.drawRadialGradient(gradient, startCenter: CGPoint(x: ${formatNumber(gradient.fx + dx * gradient.startT)}, y: ${formatNumber(gradient.fy + dy * gradient.startT)}), startRadius: ${formatNumber(gradient.fr + dr * gradient.startT)}, endCenter: CGPoint(x: ${formatNumber(gradient.fx + dx * gradient.endT)}, y: ${formatNumber(gradient.fy + dy * gradient.endT)}), endRadius: ${formatNumber(gradient.fr + dr * gradient.endT)}, options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
+      `${nested}${graphicsName}.drawRadialGradient(gradient, startCenter: CGPoint(x: ${fx} + (${cx} - ${fx}) * ${formatNumber(gradient.startT)}, y: ${fy} + (${cy} - ${fy}) * ${formatNumber(gradient.startT)}), startRadius: ${fr} + (${radius} - ${fr}) * ${formatNumber(gradient.startT)}, endCenter: CGPoint(x: ${fx} + (${cx} - ${fx}) * ${formatNumber(gradient.endT)}, y: ${fy} + (${cy} - ${fy}) * ${formatNumber(gradient.endT)}), endRadius: ${fr} + (${radius} - ${fr}) * ${formatNumber(gradient.endT)}, options: [.drawsBeforeStartLocation, .drawsAfterEndLocation])`,
     );
   }
   lines.push(`${nested}${graphicsName}.restoreGState()`, `${inner}}`, `${prefix}}`);
@@ -2495,6 +3436,7 @@ function simpleClipPathHelpers(clipPath: GeneratedClipPath): string[] | undefine
         node.viewportClip ||
         node.clipPath ||
         node.mask ||
+        node.animationTransform ||
         !visit(node.children)
       )
         return false;
@@ -2611,17 +3553,25 @@ function renderPatternCommands(
   const inner = indentation.repeat(level + 1);
   const pattern = node.pattern;
   const matrix = pattern.matrix;
+  const coordinate = (name: string, fallback: number) =>
+    node.coordinateExpressions?.[name] ? `CGFloat(${node.coordinateExpressions[name]})` : formatNumber(fallback);
+  const tileX = coordinate("x", pattern.tile.x);
+  const tileY = coordinate("y", pattern.tile.y);
+  const tileWidth = coordinate("width", pattern.tile.width);
+  const tileHeight = coordinate("height", pattern.tile.height);
+  const factorX = node.rangeFactorX ?? 1;
+  const factorY = node.rangeFactorY ?? 1;
   const runtime: PatternRepeatRuntime = {
-    minRow: pattern.minRow,
-    maxRow: pattern.maxRow,
-    minColumn: pattern.minColumn,
-    maxColumn: pattern.maxColumn,
-    columnX: formatNumber(matrix.a * pattern.tile.width),
-    columnY: formatNumber(matrix.b * pattern.tile.width),
-    rowX: formatNumber(matrix.c * pattern.tile.height),
-    rowY: formatNumber(matrix.d * pattern.tile.height),
-    originX: formatNumber(matrix.a * pattern.tile.x + matrix.c * pattern.tile.y),
-    originY: formatNumber(matrix.b * pattern.tile.x + matrix.d * pattern.tile.y),
+    minRow: factorY === 1 ? pattern.minRow : pattern.minRow * factorY - factorY,
+    maxRow: factorY === 1 ? pattern.maxRow : (pattern.maxRow + 1) * factorY + factorY,
+    minColumn: factorX === 1 ? pattern.minColumn : pattern.minColumn * factorX - factorX,
+    maxColumn: factorX === 1 ? pattern.maxColumn : (pattern.maxColumn + 1) * factorX + factorX,
+    columnX: `${formatNumber(matrix.a)} * ${tileWidth}`,
+    columnY: `${formatNumber(matrix.b)} * ${tileWidth}`,
+    rowX: `${formatNumber(matrix.c)} * ${tileHeight}`,
+    rowY: `${formatNumber(matrix.d)} * ${tileHeight}`,
+    originX: `${formatNumber(matrix.a)} * ${tileX} + ${formatNumber(matrix.c)} * ${tileY}`,
+    originY: `${formatNumber(matrix.b)} * ${tileX} + ${formatNumber(matrix.d)} * ${tileY}`,
     scaleX: `size.width / ${formatNumber(node.coordinateSpace.width)}`,
     scaleY: `size.height / ${formatNumber(node.coordinateSpace.height)}`,
     suffix: node.patternIndex,
@@ -2633,6 +3583,7 @@ function renderPatternCommands(
     `${inner}${graphicsName}.addPath(${shapeHelperCall(node.helper)}.path(in: CGRect(origin: .zero, size: size)).cgPath)`,
     `${inner}${graphicsName}.clip()`,
   ];
+  if (node.transformCorrection) lines.push(`${inner}${graphicsName}.concatenate(${node.transformCorrection})`);
   if (node.paintOpacity !== 1) {
     lines.push(
       `${inner}${graphicsName}.setAlpha(${formatNumber(node.paintOpacity)})`,
@@ -2737,8 +3688,8 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
         ...renderGeneratedCommands(node.children, "graphics", level + 1, indentation),
         `${prefix}}, renderFilterImages: { size, scale in`,
         `${prefix}${indentation}var images: [String: CGImage] = [:]`,
-        ...node.filter.imageHelpers.flatMap(({ key, name }) => [
-          `${prefix}${indentation}let ${name}Renderer = ImageRenderer(content: ${name}().frame(width: size.width, height: size.height))`,
+        ...node.filter.imageHelpers.flatMap(({ key, name, animated }) => [
+          `${prefix}${indentation}let ${name}Renderer = ImageRenderer(content: ${name}${animated ? "(documentTime: documentTime)" : "()"}.frame(width: size.width, height: size.height))`,
           `${prefix}${indentation}${name}Renderer.scale = scale`,
           `${prefix}${indentation}if let image = ${name}Renderer.cgImage { images[${swiftString(key)}] = image }`,
         ]),
@@ -2895,6 +3846,20 @@ private struct SVGFilterRegion {
     let width: CGFloat
     let height: CGFloat
 
+}
+
+private static func svgTransformedFilterRegion(x: CGFloat, y: CGFloat, width: CGFloat, height: CGFloat, transform: CGAffineTransform) -> SVGFilterRegion {
+    let points = [
+        CGPoint(x: x, y: y).applying(transform),
+        CGPoint(x: x + width, y: y).applying(transform),
+        CGPoint(x: x, y: y + height).applying(transform),
+        CGPoint(x: x + width, y: y + height).applying(transform),
+    ]
+    let xs = points.map(\\.x)
+    let ys = points.map(\\.y)
+    let minimumX = xs.min() ?? 0
+    let minimumY = ys.min() ?? 0
+    return SVGFilterRegion(x: minimumX, y: minimumY, width: max(0, (xs.max() ?? minimumX) - minimumX), height: max(0, (ys.max() ?? minimumY) - minimumY))
 }
 
 private enum SVGFilterInput {
@@ -4104,10 +5069,11 @@ function createImageHelper(
       : "default";
   const body: string[] = [
     `private struct ${helper.name}: View {`,
+    ...(helper.animated ? [`${indentation}let documentTime: Double`, ""] : []),
     `${indentation}var body: some View {`,
     `${i2}Canvas { context, size in`,
     `${i3}context.clip(to: Path(CGRect(x: ${formatNumber(node.viewport.x)}, y: ${formatNumber(node.viewport.y)}, width: ${formatNumber(node.viewport.width)}, height: ${formatNumber(node.viewport.height)})).applying(${runtimeTransform(helper.transform, coordinateSpace)}))`,
-    `${i3}context.transform = ${runtimeTransform(imageTransform, coordinateSpace)}`,
+    `${i3}context.transform = ${helper.transformExpression ?? runtimeTransform(imageTransform, coordinateSpace)}`,
   ];
   if (quality !== "default") body.push(`${i3}context.withCGContext { $0.interpolationQuality = .${quality} }`);
   if (resource.type === "svg") {
@@ -4116,7 +5082,7 @@ function createImageHelper(
       `${i4}context.draw(image, in: CGRect(x: 0, y: 0, width: ${formatNumber(intrinsic.width)}, height: ${formatNumber(intrinsic.height)}))`,
       `${i3}}`,
       `${i2}} symbols: {`,
-      `${i3}${helper.subdocumentName!}()`,
+      `${i3}${helper.subdocumentName!}${helper.subdocumentAnimated ? "(documentTime: documentTime)" : "()"}`,
       `${i3}.frame(width: ${formatNumber(intrinsic.width)}, height: ${formatNumber(intrinsic.height)})`,
       `${i3}.tag(0)`,
       `${i2}}`,
@@ -4182,6 +5148,7 @@ function createFilterImageHelper(helper: FilterImageHelper, indentationSize: num
       : { x: 0, y: 0, width: intrinsic.width, height: intrinsic.height };
   const body = [
     `private struct ${helper.name}: View {`,
+    ...(helper.animated ? [`${indentation}let documentTime: Double`, ""] : []),
     `${indentation}var body: some View {`,
     `${i2}Canvas { context, size in`,
     `${i3}guard size.width > 0, size.height > 0 else { return }`,
@@ -4196,7 +5163,7 @@ function createFilterImageHelper(helper: FilterImageHelper, indentationSize: num
       `${i4}context.draw(image, in: CGRect(x: ${formatNumber(drawRect.x)}, y: ${formatNumber(drawRect.y)}, width: ${formatNumber(drawRect.width)}, height: ${formatNumber(drawRect.height)}))`,
       `${i3}}`,
       `${i2}} symbols: {`,
-      `${i3}${helper.subdocumentName!}()`,
+      `${i3}${helper.subdocumentName!}${helper.animated ? "(documentTime: documentTime)" : "()"}`,
       `${i3}.frame(width: ${formatNumber(intrinsic.width)}, height: ${formatNumber(intrinsic.height)})`,
       `${i3}.tag(0)`,
       `${i2}}`,
@@ -4344,7 +5311,10 @@ function createView(
   indentationSize: number,
 ): string[] {
   const indentation = " ".repeat(indentationSize);
-  const animated = document.animationProgram.animations.length > 0;
+  const animated =
+    document.animationProgram.animations.length > 0 ||
+    imageHelpers.some((helper) => helper.animated) ||
+    filterImageHelpers.some((helper) => helper.animated);
   const content = [
     `${indentation}ZStack {`,
     ...nodes.flatMap((node) => renderViewNode(node, 2, indentation)),
@@ -4552,6 +5522,22 @@ function createView(
         `${indentation}value.components.first ?? 0`,
         "}",
         "",
+        "private static func svgAnimationComponent(_ value: SVGAnimationRuntimeValue, index: Int) -> Double {",
+        `${indentation}guard !value.components.isEmpty else { return 0 }`,
+        `${indentation}return value.components[min(index, value.components.count - 1)]`,
+        "}",
+        "",
+        ...(containsFilterNode(nodes)
+          ? [
+              "private static func svgAnimationFilterColor(_ value: SVGAnimationRuntimeValue, opacity: Double) -> SVGFilterColor {",
+              `${indentation}func encoded(_ channel: Double) -> Double { channel <= 0.0031308 ? channel * 12.92 : 1.055 * pow(channel, 1 / 2.4) - 0.055 }`,
+              `${indentation}let components = value.components + [0, 0, 0, 1]`,
+              `${indentation}let linear = value.signature == "linearRGB"`,
+              `${indentation}return SVGFilterColor(red: min(1, max(0, linear ? encoded(components[0]) : components[0])), green: min(1, max(0, linear ? encoded(components[1]) : components[1])), blue: min(1, max(0, linear ? encoded(components[2]) : components[2])), alpha: min(1, max(0, components[3] * opacity)))`,
+              "}",
+              "",
+            ]
+          : []),
         "private static func svgAnimationSource(_ value: SVGAnimationRuntimeValue) -> String { value.source }",
         "",
         "private static func svgAnimationLengths(_ value: SVGAnimationRuntimeValue, scale: CGFloat) -> [CGFloat] {",
@@ -4969,7 +5955,11 @@ export function generateView(
   };
   const nodes = buildViewNodes(document.children, context);
   const imports = new Set<string>();
-  if (document.animationProgram.animations.length > 0) {
+  if (
+    document.animationProgram.animations.length > 0 ||
+    context.imageHelpers.some((helper) => helper.animated) ||
+    context.filterImageHelpers.some((helper) => helper.animated)
+  ) {
     imports.add("Foundation");
     imports.add("SwiftUI");
   }

--- a/packages/svg-to-swiftui-core/src/renderTree/gradients.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/gradients.ts
@@ -311,6 +311,26 @@ export function resolvePaintServers(
 
     const stopOwner = chain.find((candidate) => children(candidate).some((child) => child.tagName === "stop"));
     const stops = stopOwner ? stopsFor(stopOwner, presentations, diagnostics, animationTargetKey) : [];
+    const animationOwner = (name: string) =>
+      chain.find((candidate) => candidate.properties?.[name] !== undefined) ?? element;
+    const animationTargetKeys = Object.fromEntries(
+      [
+        "gradientUnits",
+        "gradientTransform",
+        "spreadMethod",
+        "color-interpolation",
+        "x1",
+        "y1",
+        "x2",
+        "y2",
+        "cx",
+        "cy",
+        "r",
+        "fx",
+        "fy",
+        "fr",
+      ].map((name) => [name, animationTargetKey?.(animationOwner(name)) ?? ""]),
+    );
     const base = {
       id,
       units,
@@ -320,6 +340,13 @@ export function resolvePaintServers(
       colorInterpolation,
       ...(href(element)?.startsWith("#") ? { href: href(element)!.slice(1) } : {}),
       source: sourceLocation(element),
+      animationTargetKeys,
+      animationBaseValues: {
+        gradientUnits: units,
+        gradientTransform: String(transformSource ?? "matrix(1 0 0 1 0 0)"),
+        spreadMethod,
+        "color-interpolation": colorInterpolation,
+      },
     };
 
     let paint: GradientPaint;
@@ -331,6 +358,13 @@ export function resolvePaintServers(
         y1: parsedLength(property(chain, "y1"), "0%", "linear gradient y1", element, diagnostics),
         x2: parsedLength(property(chain, "x2"), "100%", "linear gradient x2", element, diagnostics),
         y2: parsedLength(property(chain, "y2"), "0%", "linear gradient y2", element, diagnostics),
+        animationBaseValues: {
+          ...base.animationBaseValues,
+          x1: String(property(chain, "x1") ?? "0%"),
+          y1: String(property(chain, "y1") ?? "0%"),
+          x2: String(property(chain, "x2") ?? "100%"),
+          y2: String(property(chain, "y2") ?? "0%"),
+        },
       };
     } else {
       const cx = parsedLength(property(chain, "cx"), "50%", "radial gradient cx", element, diagnostics);
@@ -352,6 +386,15 @@ export function resolvePaintServers(
         fx: fxSource === undefined ? cx : parsedLength(fxSource, "50%", "radial gradient fx", element, diagnostics),
         fy: fySource === undefined ? cy : parsedLength(fySource, "50%", "radial gradient fy", element, diagnostics),
         fr: fr.value < 0 ? { ...fr, value: 0 } : fr,
+        animationBaseValues: {
+          ...base.animationBaseValues,
+          cx: String(property(chain, "cx") ?? "50%"),
+          cy: String(property(chain, "cy") ?? "50%"),
+          r: String(property(chain, "r") ?? "50%"),
+          fx: String(fxSource ?? property(chain, "cx") ?? "50%"),
+          fy: String(fySource ?? property(chain, "cy") ?? "50%"),
+          fr: String(property(chain, "fr") ?? "0%"),
+        },
       };
     }
     result.set(id, paint);

--- a/packages/svg-to-swiftui-core/src/renderTree/markers.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/markers.ts
@@ -140,6 +140,7 @@ export function resolveMarkerResources(
   styleResolver: SVGStyleResolver,
   rootPresentation: Presentation,
   diagnostics: RenderDiagnostic[],
+  animationTargetKey?: (element: ElementNode) => string,
 ): Map<string, MarkerResource> {
   const resolutions = new Map<ElementNode, StyleResolution>();
   const walk = (element: ElementNode, inherited: Presentation): void => {
@@ -198,6 +199,33 @@ export function resolveMarkerResources(
       ...(viewBox ? { viewBox } : {}),
       preserveAspectRatio,
       overflow: String(authoredOverflow ?? "hidden").toLowerCase(),
+      animationTargetKeys: Object.fromEntries(
+        [
+          "markerWidth",
+          "markerHeight",
+          "refX",
+          "refY",
+          "markerUnits",
+          "orient",
+          "viewBox",
+          "preserveAspectRatio",
+          "overflow",
+        ].flatMap((name) => {
+          const key = animationTargetKey?.(element);
+          return key ? [[name, key]] : [];
+        }),
+      ),
+      animationBaseValues: {
+        markerWidth: String(element.properties?.markerWidth ?? "3"),
+        markerHeight: String(element.properties?.markerHeight ?? "3"),
+        refX: String(element.properties?.refX ?? "0"),
+        refY: String(element.properties?.refY ?? "0"),
+        markerUnits: String(element.properties?.markerUnits ?? "strokeWidth"),
+        orient: String(element.properties?.orient ?? "0"),
+        preserveAspectRatio: String(element.properties?.preserveAspectRatio ?? "xMidYMid meet"),
+        overflow: String(authoredOverflow ?? "hidden"),
+        ...(element.properties?.viewBox === undefined ? {} : { viewBox: String(element.properties.viewBox) }),
+      },
       source: sourceLocation(element),
       element,
       contentElements: children(element).filter((child) => !DESCRIPTIVE_ELEMENTS.has(child.tagName ?? "")),

--- a/packages/svg-to-swiftui-core/src/renderTree/masks.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/masks.ts
@@ -74,6 +74,7 @@ export function resolveMaskResources(
   styleResolver: SVGStyleResolver,
   rootPresentation: Presentation,
   diagnostics: RenderDiagnostic[],
+  animationTargetKey?: (element: ElementNode) => string,
 ): Map<string, MaskResource> {
   const resolutions = new Map<ElementNode, StyleResolution>();
   const walk = (element: ElementNode, inherited: Presentation): void => {
@@ -116,6 +117,21 @@ export function resolveMaskResources(
         diagnostics,
       ),
       maskType,
+      animationTargetKeys: Object.fromEntries(
+        ["x", "y", "width", "height", "maskUnits", "maskContentUnits", "mask-type"].flatMap((name) => {
+          const key = animationTargetKey?.(element);
+          return key ? [[name, key]] : [];
+        }),
+      ),
+      animationBaseValues: {
+        x: String(element.properties?.x ?? "-10%"),
+        y: String(element.properties?.y ?? "-10%"),
+        width: String(element.properties?.width ?? "120%"),
+        height: String(element.properties?.height ?? "120%"),
+        maskUnits: String(element.properties?.maskUnits ?? "objectBoundingBox"),
+        maskContentUnits: String(element.properties?.maskContentUnits ?? "userSpaceOnUse"),
+        "mask-type": maskType,
+      },
       source: sourceLocation(element),
       element,
       contentElements: children(element),

--- a/packages/svg-to-swiftui-core/src/renderTree/patterns.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/patterns.ts
@@ -18,6 +18,7 @@ import type {
 
 export interface ResolvedPattern {
   type: "pattern";
+  server: PatternPaint;
   matrix: AffineTransform;
   tile: RenderBounds;
   contentTransform: AffineTransform;
@@ -130,6 +131,7 @@ export function resolvePatternPaintServers(
   styleResolver: SVGStyleResolver,
   rootPresentation: Presentation,
   diagnostics: RenderDiagnostic[],
+  animationTargetKey?: (element: ElementNode) => string | undefined,
 ): Map<string, PaintServer> {
   const resolutions = new Map<ElementNode, StyleResolution>();
   const walk = (element: ElementNode, inherited: Presentation): void => {
@@ -288,6 +290,43 @@ export function resolvePatternPaintServers(
       diagnostic(diagnostics, element, "negative-pattern-height", "Pattern height cannot be negative.");
 
     const authoredOverflow = resolved?.provenance.overflow ? resolved.values.overflow : "hidden";
+    const animatedProperties = [
+      "x",
+      "y",
+      "width",
+      "height",
+      "patternUnits",
+      "patternContentUnits",
+      "patternTransform",
+      "viewBox",
+      "preserveAspectRatio",
+      "overflow",
+      "href",
+    ];
+    const animationTargetKeys = Object.fromEntries(
+      animatedProperties.flatMap((name) => {
+        const owner = chain.find((candidate) => candidate.properties?.[name] !== undefined) ?? element;
+        const key = animationTargetKey?.(owner);
+        return key ? [[name, key]] : [];
+      }),
+    );
+    const animationBaseValues = Object.fromEntries(
+      animatedProperties.flatMap((name) => {
+        const value = property(chain, name);
+        return value === undefined ? [] : [[name, String(value)]];
+      }),
+    );
+    Object.assign(animationBaseValues, {
+      x: String(property(chain, "x") ?? "0"),
+      y: String(property(chain, "y") ?? "0"),
+      width: String(property(chain, "width") ?? "0"),
+      height: String(property(chain, "height") ?? "0"),
+      patternUnits,
+      patternContentUnits: contentUnits,
+      patternTransform: String(property(chain, "patternTransform") ?? "matrix(1 0 0 1 0 0)"),
+      preserveAspectRatio: String(property(chain, "preserveAspectRatio") ?? "xMidYMid meet"),
+      overflow: String(authoredOverflow ?? "hidden"),
+    });
     const paint: PatternPaint = {
       type: "pattern",
       id,
@@ -298,6 +337,8 @@ export function resolvePatternPaintServers(
       units: patternUnits,
       contentUnits,
       transform,
+      animationTargetKeys,
+      animationBaseValues,
       ...(viewBox ? { viewBox } : {}),
       preserveAspectRatio,
       overflow: String(authoredOverflow ?? "hidden").toLowerCase(),
@@ -441,6 +482,7 @@ export function resolvePatternForShape(
 
   return {
     type: "pattern",
+    server: pattern,
     matrix: multiplyTransforms(localToRoot(shape, ancestors), patternToLocal),
     tile,
     contentTransform,

--- a/packages/svg-to-swiftui-core/src/renderTree/types.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/types.ts
@@ -84,6 +84,9 @@ interface GradientPaintBase {
   colorInterpolation: GradientColorInterpolation;
   href?: string;
   source: SourceLocation;
+  /** Per-attribute source identity preserves href-inherited animation ownership. */
+  animationTargetKeys: Readonly<Record<string, string>>;
+  animationBaseValues: Readonly<Record<string, string>>;
 }
 
 export interface LinearGradientPaint extends GradientPaintBase {
@@ -135,42 +138,54 @@ export type FilterChannelSelector = "R" | "G" | "B" | "A";
 export type FilterMorphologyOperator = "erode" | "dilate";
 export type FilterTurbulenceType = "turbulence" | "fractalNoise";
 
-export type FilterLightSourceSpec =
-  | { type: "distant"; azimuth: number; elevation: number }
-  | { type: "point"; x: number; y: number; z: number }
-  | {
-      type: "spot";
-      x: number;
-      y: number;
-      z: number;
-      pointsAtX: number;
-      pointsAtY: number;
-      pointsAtZ: number;
-      specularExponent: number;
-      limitingConeAngle?: number;
-    };
+interface FilterAnimationTarget {
+  animationTargetKey?: string;
+  animationTargetTag?: string;
+  animationBaseValues?: Readonly<Record<string, number>>;
+}
 
-export type FilterLightSource =
-  | { type: "distant"; x: number; y: number; z: number }
-  | { type: "point"; x: number; y: number; z: number }
-  | {
-      type: "spot";
-      x: number;
-      y: number;
-      z: number;
-      pointsAtX: number;
-      pointsAtY: number;
-      pointsAtZ: number;
-      specularExponent: number;
-      limitingConeAngle?: number;
-    };
+export type FilterLightSourceSpec = FilterAnimationTarget &
+  (
+    | { type: "distant"; azimuth: number; elevation: number }
+    | { type: "point"; x: number; y: number; z: number }
+    | {
+        type: "spot";
+        x: number;
+        y: number;
+        z: number;
+        pointsAtX: number;
+        pointsAtY: number;
+        pointsAtZ: number;
+        specularExponent: number;
+        limitingConeAngle?: number;
+      }
+  );
 
-export type FilterComponentTransferFunction =
-  | { type: "identity" }
-  | { type: "table"; values: number[] }
-  | { type: "discrete"; values: number[] }
-  | { type: "linear"; slope: number; intercept: number }
-  | { type: "gamma"; amplitude: number; exponent: number; offset: number };
+export type FilterLightSource = FilterAnimationTarget &
+  (
+    | { type: "distant"; x: number; y: number; z: number }
+    | { type: "point"; x: number; y: number; z: number }
+    | {
+        type: "spot";
+        x: number;
+        y: number;
+        z: number;
+        pointsAtX: number;
+        pointsAtY: number;
+        pointsAtZ: number;
+        specularExponent: number;
+        limitingConeAngle?: number;
+      }
+  );
+
+export type FilterComponentTransferFunction = FilterAnimationTarget &
+  (
+    | { type: "identity" }
+    | { type: "table"; values: number[] }
+    | { type: "discrete"; values: number[] }
+    | { type: "linear"; slope: number; intercept: number }
+    | { type: "gamma"; amplitude: number; exponent: number; offset: number }
+  );
 
 export type FilterComponentTransferFunctions = [
   FilterComponentTransferFunction,
@@ -225,6 +240,8 @@ export interface MaskResource {
   units: MaskUnits;
   contentUnits: MaskUnits;
   maskType: MaskType;
+  animationTargetKeys: Readonly<Record<string, string>>;
+  animationBaseValues: Readonly<Record<string, string>>;
   source: SourceLocation;
   element: ElementNode;
   contentElements: ElementNode[];
@@ -264,6 +281,9 @@ export interface FilterPrimitiveRegionSpec {
 }
 
 interface FilterPrimitiveSpecBase {
+  animationTargetKey?: string;
+  animationTargetTag?: string;
+  animationBaseValues?: Readonly<Record<string, string>>;
   input?: FilterInput;
   input2?: FilterInput;
   result?: string;
@@ -379,6 +399,12 @@ export type FilterPrimitiveSpec =
   | (FilterPrimitiveSpecBase & { type: "passthrough"; input: FilterInput; element: string });
 
 interface FilterPrimitiveBase {
+  animationTargetKey?: string;
+  animationTargetTag?: string;
+  animationBaseValues?: Readonly<Record<string, string>>;
+  /** Converts authored primitive-unit values into this consumer's user space. */
+  animationScaleX: number;
+  animationScaleY: number;
   result?: string;
   input2?: FilterInput;
   subregion: RenderBounds;
@@ -501,6 +527,8 @@ export interface FilterResource {
   units: FilterUnits;
   primitiveUnits: FilterUnits;
   colorInterpolation: FilterColorInterpolation;
+  animationTargetKeys: Readonly<Record<string, string>>;
+  animationBaseValues: Readonly<Record<string, string>>;
   href?: string;
   source: SourceLocation;
   element: ElementNode;
@@ -562,6 +590,8 @@ export interface PatternPaint {
   units: PatternUnits;
   contentUnits: PatternUnits;
   transform: AffineTransform;
+  animationTargetKeys: Readonly<Record<string, string>>;
+  animationBaseValues: Readonly<Record<string, string>>;
   viewBox?: ViewBoxData;
   preserveAspectRatio: PreserveAspectRatio;
   overflow: string;
@@ -623,6 +653,8 @@ export interface MarkerResource {
   viewBox?: ViewBoxData;
   preserveAspectRatio: PreserveAspectRatio;
   overflow: string;
+  animationTargetKeys: Readonly<Record<string, string>>;
+  animationBaseValues: Readonly<Record<string, string>>;
   source: SourceLocation;
   element: ElementNode;
   contentElements: ElementNode[];
@@ -709,6 +741,9 @@ export interface MarkerPlacement {
   refX: number;
   refY: number;
   viewBoxTransform: AffineTransform;
+  resource?: MarkerResource;
+  hostAngle?: number;
+  strokeWidth?: number;
 }
 
 export interface RenderGroup {
@@ -759,6 +794,7 @@ export interface RenderText {
 }
 
 export interface RenderTextChunk {
+  animationTargetKey?: string;
   x?: number;
   y?: number;
   runs: RenderTextRun[];
@@ -778,10 +814,13 @@ export interface RenderTextCharacter {
 }
 
 export interface RenderTextLengthAdjustment {
+  animationTargetKey?: string;
   /** Character range local to the containing chunk. */
   start: number;
   end: number;
   target: number;
+  /** Share of the owning textLength range represented by this chunk. */
+  animationScale: number;
   mode: "spacing" | "spacingAndGlyphs";
 }
 
@@ -794,6 +833,7 @@ export interface RenderTextPathPoint {
 }
 
 export interface RenderTextPath {
+  animationTargetKey?: string;
   points: RenderTextPathPoint[];
   length: number;
   closed: boolean;
@@ -807,6 +847,7 @@ export interface RenderTextPath {
 }
 
 export interface RenderTextRun {
+  animationTargetKey?: string;
   text: string;
   characters: RenderTextCharacter[];
   dx: number;

--- a/packages/svg-to-swiftui-core/src/tests/animationTargets.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/animationTargets.test.ts
@@ -44,7 +44,7 @@ describe("animation target registry", () => {
       "gradient-stop",
     );
     expect(ANIMATION_ATTRIBUTE_REGISTRY.find((entry) => entry.canonicalName === "baseFrequency")?.runtimeBinding).toBe(
-      "pending-resource",
+      "resource",
     );
   });
 
@@ -103,6 +103,13 @@ describe("animation target registry", () => {
         strict: true,
       }),
     ).toThrow(/incompatible-animation-attribute-type/);
+  });
+
+  test("rejects attributes that do not apply to a filter primitive", () => {
+    const result = convertWithDiagnostics(`
+      <svg><defs><filter id="f"><feGaussianBlur id="blur"><animate attributeName="cx" values="0;10" dur="1s"/></feGaussianBlur></filter></defs><rect width="10" height="10" filter="url(#f)"/></svg>
+    `);
+    expect(result.diagnostics.map((item) => item.code)).toContain("non-animatable-target-property");
   });
 });
 
@@ -225,6 +232,158 @@ describe("pure animate/set presentation sampling", () => {
     expect(swift).toContain("kind: .opacity");
   });
 
+  test("wires animated gradient coordinates, transforms, spread, and interpolation", () => {
+    const source = `
+      <svg viewBox="0 0 40 20"><defs>
+        <linearGradient id="paint" x2="40%" spreadMethod="pad">
+          <animate attributeName="x2" values="40%;100%" dur="2s"/>
+          <animate attributeName="spreadMethod" values="pad;reflect" dur="2s" calcMode="discrete"/>
+          <animate attributeName="color-interpolation" values="sRGB;linearRGB" dur="2s" calcMode="discrete"/>
+          <animate attributeName="gradientTransform" values="rotate(0 .5 .5);rotate(25 .5 .5)" dur="2s"/>
+          <stop stop-color="#38bdf8"/><stop offset="1" stop-color="#f97316"/>
+        </linearGradient>
+      </defs><rect width="40" height="20" fill="url(#paint)"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(document.animationProgram.animations).toHaveLength(4);
+    expect(document.animationProgram.animations.every((item) => item.runtimeSupport === "typed")).toBe(true);
+    const swift = convert(source, { structName: "AnimatedGradientGeometry", strict: true });
+    expect(swift).toContain("svgAnimationNumber(");
+    expect(swift).toContain("svgAnimationTransform(");
+    expect(swift).toContain('== "reflect"');
+    expect(swift).toContain('lowercased() == "linearrgb"');
+  });
+
+  test("renders animated pattern, clip, mask, and marker content at document time", () => {
+    const source = `
+      <svg viewBox="0 0 80 30"><defs>
+        <pattern id="p" x="0" width="10" height="10" patternUnits="userSpaceOnUse">
+          <animate attributeName="x" values="0;4" dur="2s"/><animate attributeName="width" values="10;5" dur="2s"/>
+          <animate attributeName="patternTransform" values="translate(0 0);translate(3 1)" dur="2s"/>
+          <rect width="4" height="10" fill="#38bdf8"><animate attributeName="width" values="2;8" dur="2s"/></rect>
+        </pattern>
+        <clipPath id="c" transform="translate(0 0)"><animateTransform attributeName="transform" type="translate" values="0 0;2 1" dur="2s"/><circle cx="15" cy="15" r="4"><animate attributeName="r" values="4;12" dur="2s"/></circle></clipPath>
+        <mask id="m" x="-10%" width="120%"><animate attributeName="x" values="-10%;0%" dur="2s"/><animate attributeName="width" values="120%;100%" dur="2s"/><rect x="0" width="30" height="30" fill="white"><animate attributeName="x" values="0;12" dur="2s"/></rect></mask>
+        <marker id="arrow" markerWidth="8" markerHeight="8" refX="8" refY="4" orient="0" markerUnits="userSpaceOnUse"><animate attributeName="orient" values="0;45" dur="2s"/><animate attributeName="markerUnits" values="userSpaceOnUse;strokeWidth" dur="2s" calcMode="discrete"/><path d="M0 0L8 4L0 8Z" fill="red"><animate attributeName="fill" values="red;yellow" dur="2s"/></path></marker>
+      </defs>
+      <rect width="30" height="30" fill="url(#p)" clip-path="url(#c)" mask="url(#m)"/>
+      <path d="M40 15H75" stroke="white" marker-end="url(#arrow)"/>
+      </svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(document.animationProgram.animations).toHaveLength(12);
+    expect(document.animationProgram.animations.every((item) => item.runtimeSupport === "typed")).toBe(true);
+    const swift = convert(source, { structName: "AnimatedResourceContent", strict: true });
+    expect(swift.match(/svgAnimatedValue\(documentTime: documentTime/g)?.length).toBeGreaterThanOrEqual(4);
+    expect(swift).toContain("graphics.concatenate(AnimatedResourceContent.svgMultiplyTransform(");
+    expect(swift).toContain("svgAnimatedTransformCorrection(animatedBase:");
+    expect(swift).toMatch(/MaskClip\d+\(documentTime: documentTime\)/);
+    expect(swift).toContain('== "strokeWidth"');
+    expect(swift).toMatch(/columnX:|let offsetX/);
+    expect(swift).not.toContain("@State private var");
+  });
+
+  test("samples filter parameters per consumer without mutable frame caches", () => {
+    const source = `
+      <svg viewBox="0 0 80 30"><defs><filter id="fx" x="-10%" width="120%" primitiveUnits="objectBoundingBox">
+        <animate attributeName="x" values="-10%;-20%" dur="2s"/>
+        <animate attributeName="width" values="120%;150%" dur="2s"/>
+        <feGaussianBlur stdDeviation=".02 .04"><animate attributeName="stdDeviation" values=".02 .04;.08 .02" dur="2s"/></feGaussianBlur>
+        <feOffset x="-.1" width="1.2" dx=".02" dy=".04"><animate attributeName="x" values="-.1;0" dur="2s"/><animate attributeName="width" values="1.2;.9" dur="2s"/><animate attributeName="dx" values=".02;.12" dur="2s"/><animate attributeName="dy" values=".04;-.04" dur="2s"/></feOffset>
+      </filter></defs>
+      <rect x="5" y="5" width="25" height="20" fill="#38bdf8" filter="url(#fx)"/>
+      <rect x="45" y="8" width="30" height="14" fill="#f97316" filter="url(#fx)"/>
+      </svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(document.animationProgram.animations).toHaveLength(7);
+    expect(document.animationProgram.animations.every((item) => item.runtimeSupport === "typed")).toBe(true);
+    const swift = convert(source, { structName: "AnimatedFilterParameters", strict: true });
+    expect(swift).toContain("svgAnimationComponent(");
+    expect(swift).toMatch(/sigmaX: hypot\(/);
+    expect(swift).toMatch(/dx: 1 \* \(/);
+    expect(swift.match(/svgTransformedFilterRegion\(x:/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(swift).not.toContain("@State private var");
+  });
+
+  test("wires animated filter matrices, transfer functions, colors, noise, convolution, and lights", () => {
+    const source = `
+      <svg viewBox="0 0 80 40"><defs><filter id="fx" x="-20%" y="-20%" width="140%" height="140%">
+        <feTurbulence baseFrequency=".02 .03" numOctaves="1" seed="2" result="noise">
+          <animate attributeName="baseFrequency" values=".02 .03;.06 .04" dur="2s"/>
+          <animate attributeName="numOctaves" values="1;2" dur="2s"/>
+          <animate attributeName="seed" values="2;8" dur="2s"/>
+          <animate attributeName="stitchTiles" values="noStitch;stitch" dur="2s" calcMode="discrete"/>
+          <animate attributeName="type" values="turbulence;fractalNoise" dur="2s" calcMode="discrete"/>
+        </feTurbulence>
+        <feColorMatrix in="noise" values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1 0" result="matrix">
+          <animate attributeName="values" values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1 0;.5 0 0 0 0 0 .8 0 0 0 0 0 1 0 0 0 0 0 1 0" dur="2s"/>
+        </feColorMatrix>
+        <feComponentTransfer in="matrix" result="transfer"><feFuncR type="linear" slope="1" intercept="0">
+          <animate attributeName="slope" values="1;.5" dur="2s"/><animate attributeName="intercept" values="0;.2" dur="2s"/>
+        </feFuncR></feComponentTransfer>
+        <feConvolveMatrix in="transfer" order="3" kernelMatrix="0 0 0 0 1 0 0 0 0" divisor="1" bias="0" result="convolved">
+          <animate attributeName="kernelMatrix" values="0 0 0 0 1 0 0 0 0;0 -1 0 -1 5 -1 0 -1 0" dur="2s"/>
+          <animate attributeName="bias" values="0;.05" dur="2s"/>
+          <animate attributeName="edgeMode" values="none;wrap" dur="2s" calcMode="discrete"/>
+          <animate attributeName="preserveAlpha" values="false;true" dur="2s" calcMode="discrete"/>
+        </feConvolveMatrix>
+        <feComposite in="convolved" in2="SourceGraphic" operator="arithmetic" k1="0" k2="1" k3="0" k4="0" result="composite">
+          <animate attributeName="k3" values="0;.5" dur="2s"/>
+          <animate attributeName="operator" values="arithmetic;over" dur="2s" calcMode="discrete"/>
+        </feComposite>
+        <feFlood flood-color="#38bdf8" flood-opacity="1" result="flood">
+          <animate attributeName="flood-color" values="#38bdf8;#f97316" dur="2s"/>
+          <animate attributeName="flood-opacity" values="1;.4" dur="2s"/>
+        </feFlood>
+        <feDiffuseLighting in="composite" surfaceScale="1" diffuseConstant="1" lighting-color="white" result="lit">
+          <animate attributeName="surfaceScale" values="1;3" dur="2s"/>
+          <animate attributeName="lighting-color" values="white;#facc15" dur="2s"/>
+          <fePointLight x="20" y="10" z="30"><animate attributeName="x" values="20;60" dur="2s"/></fePointLight>
+        </feDiffuseLighting>
+        <feBlend in="lit" in2="flood" mode="screen"><animate attributeName="in" values="lit;flood" dur="2s" calcMode="discrete"/><animate attributeName="in2" values="flood;lit" dur="2s" calcMode="discrete"/><animate attributeName="mode" values="screen;multiply" dur="2s" calcMode="discrete"/></feBlend>
+      </filter></defs><rect x="10" y="8" width="60" height="24" fill="#a78bfa" filter="url(#fx)"/></svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(document.animationProgram.animations).toHaveLength(22);
+    expect(document.animationProgram.animations.every((item) => item.runtimeSupport === "typed")).toBe(true);
+    const swift = convert(source, { structName: "AnimatedFilterGraph", strict: true });
+    expect(swift).toContain(".components");
+    expect(swift).toContain("svgAnimationFilterColor(");
+    expect(swift).toContain(".linear(slope:");
+    expect(swift).toContain(".point(x:");
+    expect(swift).toContain("octaves: Int(");
+    expect(swift).toContain('== "stitch"');
+    expect(swift).toContain("? .multiply");
+    expect(swift).toMatch(/input: \([^\n]+\? \.result\(/);
+    expect(swift).toContain("? .wrap");
+    expect(swift).not.toContain("@State private var");
+  });
+
+  test("wires tspan positioning, length, paint, typography, and textPath offset", () => {
+    const source = `
+      <svg viewBox="0 0 160 50"><defs><path id="curve" d="M10 35H150"/></defs>
+        <text x="10" y="18" font-size="10"><tspan x="12" dx="0 1 2 3 4" rotate="0 2 4 6 8" textLength="44" fill="red">Swift
+          <animate attributeName="x" values="12;70" dur="2s"/>
+          <animate attributeName="textLength" values="44;70" dur="2s"/>
+          <animate attributeName="font-size" values="10;16" dur="2s"/>
+          <animate attributeName="fill" values="red;blue" dur="2s"/>
+          <animate attributeName="dx" values="0 1 2 3 4;4 3 2 1 0" dur="2s"/>
+          <animate attributeName="rotate" values="0 2 4 6 8;8 6 4 2 0" dur="2s"/>
+        </tspan></text>
+        <text font-size="9"><textPath href="#curve" startOffset="0">Path
+          <animate attributeName="startOffset" values="0;100" dur="2s"/>
+        </textPath></text>
+      </svg>`;
+    const document = __testing.parseRenderDocument(source);
+    expect(document.animationProgram.animations).toHaveLength(7);
+    expect(document.animationProgram.animations.every((item) => item.runtimeSupport === "typed")).toBe(true);
+    const swift = convert(source, { structName: "AnimatedTextResources", strict: true });
+    expect(swift).toMatch(/SVGTextChunk\(x: AnimatedTextResources\.svgAnimationNumber/);
+    expect(swift).toMatch(/target: \(AnimatedTextResources\.svgAnimationNumber/);
+    expect(swift).toMatch(/startOffset: AnimatedTextResources\.svgAnimationNumber/);
+    expect(swift).toMatch(/size: AnimatedTextResources\.svgAnimationNumber/);
+    expect(swift).toContain("svgAnimationColor(");
+    expect(swift).toMatch(/SVGTextCharacter\(text: "S", dx: AnimatedTextResources\.svgAnimationComponent/);
+    expect(swift).toMatch(/rotation: AnimatedTextResources\.svgAnimationComponent/);
+  });
+
   test("recomputes nested viewport mapping from the sampled viewBox", () => {
     const swift = convert(
       `
@@ -240,5 +399,27 @@ describe("pure animate/set presentation sampling", () => {
     expect(swift).toContain("svgAnimatedViewBoxTransform(value:");
     expect(swift).toContain("outputSize: proxy.size");
     expect(swift).toContain("staticTransform: CGAffineTransform");
+  });
+
+  test("keeps shared animated resources deterministic and bounded across many consumers", () => {
+    const consumers = Array.from({ length: 48 }, (_, index) => {
+      const x = (index % 12) * 10;
+      const y = Math.floor(index / 12) * 10;
+      const width = 5 + (index % 4);
+      return `<rect x="${x}" y="${y}" width="${width}" height="7" fill="url(#p)" filter="url(#f)"/>`;
+    }).join("");
+    const source = `<svg viewBox="0 0 120 40"><defs>
+      <pattern id="p" width=".25" height=".25"><rect width=".15" height=".25" fill="red"><animate attributeName="width" values=".15;.25" dur="1s" repeatCount="indefinite"/></rect></pattern>
+      <filter id="f" primitiveUnits="objectBoundingBox"><feGaussianBlur stdDeviation=".01"><animate attributeName="stdDeviation" values=".01;.04" dur="1s" repeatCount="indefinite"/></feGaussianBlur></filter>
+    </defs>${consumers}</svg>`;
+    const started = performance.now();
+    const first = convert(source, { structName: "ManyAnimatedConsumers", strict: true });
+    const elapsed = performance.now() - started;
+    const second = convert(source, { structName: "ManyAnimatedConsumers", strict: true });
+    expect(second).toBe(first);
+    expect(first.length).toBeLessThan(2_000_000);
+    expect(elapsed).toBeLessThan(2_000);
+    expect(first).not.toContain("Dictionary<Double");
+    expect(first).not.toContain("lastDocumentTime");
   });
 });

--- a/packages/svg-to-swiftui-core/src/tests/filterSpatialNoiseImage.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/filterSpatialNoiseImage.test.ts
@@ -47,6 +47,18 @@ function pixels(image: FilterBitmap): number[][] {
 }
 
 describe("spatial, noise, and image filter parsing", () => {
+  test("passes canonical document time into animated SVG feImage subdocuments", () => {
+    const nested = `<svg xmlns="http://www.w3.org/2000/svg" width="8" height="4" viewBox="0 0 8 4"><rect width="2" height="4"><animate attributeName="width" values="2;8" dur="2s"/></rect></svg>`;
+    const href = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(nested)}`;
+    const swift = convert(
+      `<svg viewBox="0 0 20 10"><defs><filter id="f"><feImage href="${href}"/></filter></defs><rect width="20" height="10" filter="url(#f)"/></svg>`,
+      { structName: "AnimatedFilterImage", strict: true },
+    );
+    expect(swift).toContain("FilterImageLayer0(documentTime: documentTime)");
+    expect(swift).toContain("AnimatedFilterImageFilterImageDocument0(documentTime: documentTime)");
+    expect(swift).toContain("init(documentTime: Double? = nil");
+  });
+
   test("retains every primitive attribute, comma pairs, defaults, and graph inputs", () => {
     const graph = primitives(`<svg viewBox="0 0 100 50"><defs><filter id="f">
       <feConvolveMatrix order="3,2" kernelMatrix="1 2 3,4 5 6" divisor="7" bias=".25"

--- a/packages/svg-to-swiftui-core/src/tests/images.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/images.test.ts
@@ -51,6 +51,48 @@ describe("SVG image resources", () => {
     expect(output).toContain("red: 0.0706");
   });
 
+  test("passes the canonical parent document time into animated SVG image documents", () => {
+    const nested = `<svg xmlns="http://www.w3.org/2000/svg" width="8" height="4" viewBox="0 0 8 4"><rect width="2" height="4"><animate attributeName="width" values="2;8" dur="2s"/></rect></svg>`;
+    const href = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(nested)}`;
+    const output = convert(source(`<image href="${href}" x="4" y="5" width="24" height="12"/>`), {
+      structName: "AnimatedNestedImage",
+      strict: true,
+    });
+
+    expect(output).toContain("struct AnimatedNestedImageImageDocument0: View");
+    expect(output).toContain("init(documentTime: Double? = nil");
+    expect(output).toContain("ImageLayer0(documentTime: documentTime)");
+    expect(output).toContain("AnimatedNestedImageImageDocument0(documentTime: documentTime)");
+    expect(output).toMatch(/if let documentTime[\s\S]*content\(at: Self\.sanitizedDocumentTime\(documentTime\)\)/);
+  });
+
+  test("samples image preserveAspectRatio into the placement transform", () => {
+    const href = `data:image/png;base64,${Buffer.from(pngWithDimensions(8, 4)).toString("base64")}`;
+    const output = convert(
+      source(
+        `<image href="${href}" x="4" y="5" width="24" height="18" preserveAspectRatio="xMidYMid meet"><animate attributeName="preserveAspectRatio" values="xMidYMid meet;none" dur="2s"/></image>`,
+      ),
+      { structName: "AnimatedImagePlacement", strict: true },
+    );
+    expect(output).toContain("ImageLayer0(documentTime: documentTime)");
+    expect(output).toContain("svgViewBoxMatrix(");
+    expect(output).toContain("preserveAspectRatio: AnimatedImagePlacement.svgAnimationSource(");
+  });
+
+  test("does not pass document time into a static nested SVG when only image placement animates", () => {
+    const nested = `<svg xmlns="http://www.w3.org/2000/svg" width="8" height="4" viewBox="0 0 8 4"><rect width="8" height="4"/></svg>`;
+    const href = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(nested)}`;
+    const output = convert(
+      source(
+        `<image href="${href}" width="24" height="18"><animate attributeName="preserveAspectRatio" values="xMidYMid meet;none" dur="2s"/></image>`,
+      ),
+      { structName: "AnimatedStaticNestedImage", strict: true },
+    );
+    expect(output).toContain("ImageLayer0(documentTime: documentTime)");
+    expect(output).toContain("AnimatedStaticNestedImageImageDocument0()\n");
+    expect(output).not.toContain("AnimatedStaticNestedImageImageDocument0(documentTime: documentTime)");
+  });
+
   test("accepts legacy xlink:href and derives omitted dimensions from raster intrinsic size", () => {
     const document = __testing.parseRenderDocument(source(`<image xlink:href="pixel.png" x="1" y="2"/>`), {
       resources: { supplied: { "pixel.png": { bytes: PNG, mimeType: "image/png" } } },


### PR DESCRIPTION
Closes #103.

## What changed

- Compiles animated gradient geometry, transforms, spread/interpolation, inherited stops, and per-consumer coordinates.
- Compiles animated pattern geometry/content, clip and mask content/regions, marker content/orientation/units, and nested resource consumers.
- Rebuilds animated filter regions, primitive subregions, graph inputs, numeric/discrete parameters, matrices, transfer functions, convolution, turbulence, colors, and lighting at document time.
- Samples animated text/tspan/textPath positioning, character transforms, lengths, typography, and paint.
- Propagates canonical document time into animated nested SVG images and filter images, while keeping static nested views source-compatible.
- Keeps evaluation pure and consumer-specific, including object-bounding-box scaling and out-of-order frame safety.
- Adds the 9-frame `benchmark-09-animated-resources` WebKit oracle scene, a nested SVG asset, focused unit/performance coverage, and the animated-resource contract.

## Why

Static resources were parsed correctly, but their animation targets were either rejected or frozen into one conversion-time value. The generated Swift now samples supported resource values at the requested document timestamp without shared mutable frame caches.

## Validation

- 405 core tests pass.
- Core typecheck, lint, formatting, conformance report, and animation manifest checks pass.
- Full temporal suite: 9 reference probes pass; 155/155 Swift-vs-SVG RGBA frames pass.
- Monorepo tests and build pass.

## Existing repository check failures

- Root typecheck still fails in the unrelated shared Prettier package because Node typings are unavailable there.
- Root lint/format still reports unrelated pre-existing Next.js formatting/import-order issues.
