### PR TITLE
Add deterministic SVG event timing and discard

### DIFF
--- a/packages/svg-to-swiftui-core/README.md
+++ b/packages/svg-to-swiftui-core/README.md
@@ -250,6 +250,8 @@ Generated animated views expose deterministic and production clock paths. See th
 
 SMIL scheduling is compiled separately from drawing. See the [SMIL timing contract](docs/smil-timing.md) for supported syntax, state samples, deterministic events, dependency ordering, and strict/permissive fallbacks.
 
+Eventbase timing, native gesture/focus/accessibility adapters, immutable event traces, and timed `<discard>` removal are covered by the [event timing and discard contract](docs/event-timing-discard.md). The temporal harness supplies the same serialized trace to WebKit and generated Swift before comparing every scheduled frame.
+
 Typed interpolation, paced/spline sampling, additive composition, and repeat accumulation are documented in the [SVG animation value contract](docs/animation-values.md).
 
 `<animate>` and `<set>` now drive native geometry, presentation, text, viewport, inheritance, and gradient-stop rendering. See the [property contract](docs/animate-set-properties.md) and generated [animation attribute report](conformance/ANIMATION_REPORT.md) for exact implemented and pending properties.

--- a/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
+++ b/packages/svg-to-swiftui-core/animation-tests/animation-fixture-manifest.json
@@ -93,6 +93,20 @@
         "sampleTimesMicroseconds": [0, 299999, 300000, 399999, 400000, 799999, 800000]
       }
     },
+    "event-discard-interactions": {
+      "mode": "comparison",
+      "referenceBackend": "webkit",
+      "width": 96,
+      "height": 48,
+      "expectedMode": "view",
+      "tags": ["accessibility", "clip", "deterministic-events", "discard", "eventbase", "transform", "use"],
+      "events": [{ "timeMicroseconds": 300000, "targetId": "trigger", "name": "click", "order": 0 }],
+      "timeline": {
+        "durationMicroseconds": 1000000,
+        "framesPerSecond": 30,
+        "sampleTimesMicroseconds": [0, 299999, 300000, 499999, 500000, 699999, 700000, 899999, 900001, 1000000]
+      }
+    },
     "reference-smil-edge-cases": {
       "mode": "reference-probe",
       "referenceBackend": "webkit",

--- a/packages/svg-to-swiftui-core/animation-tests/batch-render.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/batch-render.ts
@@ -33,6 +33,14 @@ export interface AnimationBatchItem {
   fonts: string[];
   expectedMode: ExpectedOutputMode;
   usesDocumentTime: boolean;
+  usesAnimationEvents: boolean;
+  events: Array<{
+    timeMicroseconds: number;
+    name: string;
+    targetId?: string;
+    order?: number;
+    payload?: { x?: number; y?: number; button?: number; key?: string };
+  }>;
   tolerance: RgbaTolerance;
   frames: AnimationBatchFrame[];
 }
@@ -64,6 +72,21 @@ function swiftString(value: string): string {
   return JSON.stringify(value).replaceAll("/", "/");
 }
 
+function swiftOptional(value: number | string | undefined): string {
+  return value === undefined ? "nil" : typeof value === "string" ? swiftString(value) : String(value);
+}
+
+function swiftEvents(item: AnimationBatchItem): string {
+  return `[${item.events
+    .map((event) => {
+      const payload = event.payload
+        ? `${item.swiftTypeName}.SVGAnimationEvent.Payload(x: ${swiftOptional(event.payload.x)}, y: ${swiftOptional(event.payload.y)}, button: ${swiftOptional(event.payload.button)}, key: ${swiftOptional(event.payload.key)})`
+        : "nil";
+      return `${item.swiftTypeName}.SVGAnimationEvent(time: ${event.timeMicroseconds}e-6, name: ${swiftString(event.name)}, targetID: ${swiftOptional(event.targetId)}, order: ${swiftOptional(event.order)}, payload: ${payload})`;
+    })
+    .join(", ")}]`;
+}
+
 function generatedSource(support: string, items: AnimationBatchItem[]): string {
   const declarations = items
     .map(
@@ -74,6 +97,8 @@ function generatedSource(support: string, items: AnimationBatchItem[]): string {
   const factories = items
     .map((item) => {
       if (item.expectedMode === "shape") return `    { _ in AnyView(${item.swiftTypeName}().fill(Color.black)) }`;
+      if (item.usesAnimationEvents)
+        return `    { time in AnyView(${item.swiftTypeName}(documentTime: Double(time) / 1_000_000, animationEvents: ${swiftEvents(item)})) }`;
       return item.usesDocumentTime
         ? `    { time in AnyView(${item.swiftTypeName}(documentTime: Double(time) / 1_000_000)) }`
         : `    { _ in AnyView(${item.swiftTypeName}()) }`;
@@ -181,6 +206,8 @@ export async function runAnimationBatch(
             fonts: item.fonts,
             expectedMode: item.expectedMode,
             usesDocumentTime: item.usesDocumentTime,
+            usesAnimationEvents: item.usesAnimationEvents,
+            events: item.events,
             timeMicroseconds: frame.timeMicroseconds,
           }),
           ...item.fonts.map((font) => readFileSync(resolve(__dirname, font))),

--- a/packages/svg-to-swiftui-core/animation-tests/fixtures/event-discard-interactions.svg
+++ b/packages/svg-to-swiftui-core/animation-tests/fixtures/event-discard-interactions.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="48" viewBox="0 0 96 48">
+  <defs>
+    <rect id="tile" width="18" height="18" rx="4"/>
+    <clipPath id="stageClip"><rect x="4" y="4" width="88" height="40" rx="8"/></clipPath>
+  </defs>
+  <rect width="96" height="48" fill="#172033"/>
+  <g clip-path="url(#stageClip)">
+    <g id="trigger" transform="translate(8 15)" aria-label="Start animation">
+      <use href="#tile" fill="#60a5fa"/>
+    </g>
+    <rect id="moving" x="34" y="15" width="18" height="18" rx="4" fill="#f97316">
+      <animate attributeName="x" from="34" to="62" begin="trigger.click" dur="400ms" fill="freeze"/>
+    </rect>
+    <g id="removed" transform="translate(70 15)">
+      <use href="#tile" fill="#a78bfa"/>
+    </g>
+  </g>
+  <!-- WebKit does not implement SVG2 discard; this equivalent SMIL set keeps it a visual oracle. -->
+  <set href="#removed" attributeName="display" to="none" begin="trigger.click+600ms"/>
+  <discard href="#removed" begin="trigger.click+600ms"/>
+</svg>

--- a/packages/svg-to-swiftui-core/animation-tests/manifest.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/manifest.ts
@@ -173,6 +173,8 @@ export interface AnimationTimelineEvent {
   timeMicroseconds: number;
   name: string;
   targetId?: string;
+  order?: number;
+  payload?: { x?: number; y?: number; button?: number; key?: string };
 }
 
 interface RawAnimationFixture {
@@ -479,10 +481,14 @@ export function validateAnimationManifest(): string[] {
           event.timeMicroseconds < 0 ||
           event.timeMicroseconds > fixture.timeline.durationMicroseconds ||
           event.name.trim() === "" ||
+          (event.order !== undefined && !Number.isSafeInteger(event.order)) ||
+          (event.payload?.x !== undefined && !Number.isFinite(event.payload.x)) ||
+          (event.payload?.y !== undefined && !Number.isFinite(event.payload.y)) ||
+          (event.payload?.button !== undefined && !Number.isSafeInteger(event.payload.button)) ||
           (index > 0 && event.timeMicroseconds < fixture.events[index - 1]!.timeMicroseconds),
       )
     )
-      errors.push(`${prefix} events must be named, ordered, safe microsecond times inside the timeline`);
+      errors.push(`${prefix} events and payloads must be named, ordered, finite, and inside the timeline`);
     if (fixture.frames.length === 0) errors.push(`${prefix} timeline must produce at least one frame`);
     if (fixture.frames.length > 10_000) errors.push(`${prefix} timeline must not exceed 10,000 frames`);
     const times = fixture.frames.map((frame) => frame.timeMicroseconds);

--- a/packages/svg-to-swiftui-core/animation-tests/run-animation-tests.ts
+++ b/packages/svg-to-swiftui-core/animation-tests/run-animation-tests.ts
@@ -626,6 +626,8 @@ async function main(): Promise<void> {
           fonts: fixture.fonts,
           expectedMode,
           usesDocumentTime: swiftCode.includes("init(documentTime: Double? = nil"),
+          usesAnimationEvents: swiftCode.includes("animationEvents: [SVGAnimationEvent] = []"),
+          events: fixture.events,
           tolerance: fixture.tolerance,
           frames: fixture.frames.map((frame) => ({
             ...frame,

--- a/packages/svg-to-swiftui-core/animation-tests/webkit-animation-reference.swift
+++ b/packages/svg-to-swiftui-core/animation-tests/webkit-animation-reference.swift
@@ -10,6 +10,7 @@ struct AnimationEventTask: Decodable {
     let timeMicroseconds: Int64
     let name: String
     let targetId: String?
+    let order: Int?
 }
 
 struct AnimationRenderTask: Decodable {
@@ -61,9 +62,10 @@ final class AnimationSnapshotRenderer: NSObject, WKNavigationDelegate {
         let milliseconds = Double(frame.timeMicroseconds) / 1_000
         let events = task.events
             .filter { $0.timeMicroseconds <= frame.timeMicroseconds }
-            .map { event in
+            .enumerated()
+            .map { index, event in
                 let target = event.targetId.map { "document.getElementById(\(javascriptString($0)))" } ?? "root"
-                let key = "\(event.timeMicroseconds):\(event.targetId ?? ""):\(event.name)"
+                let key = "\(event.timeMicroseconds):\(event.order ?? index):\(event.targetId ?? ""):\(event.name)"
                 return "{ key: \(javascriptString(key)), time: \(Double(event.timeMicroseconds) / 1_000_000), target: \(target), name: \(javascriptString(event.name)) }"
             }
             .joined(separator: ",")

--- a/packages/svg-to-swiftui-core/docs/event-timing-discard.md
+++ b/packages/svg-to-swiftui-core/docs/event-timing-discard.md
@@ -1,0 +1,36 @@
+# Event timing and discard contract
+
+Event-driven SVG animation is compiled into deterministic SwiftUI. It does not execute JavaScript, SVG event-handler attributes, or arbitrary DOM mutation.
+
+## Deterministic input
+
+Generated event-driven views add this initializer:
+
+```swift
+View(
+    documentTime: seconds,
+    animationEvents: [
+        .init(time: 0.3, name: "click", targetID: "button", order: 0)
+    ]
+)
+```
+
+Each event contains document time, a lowercase event name, optional target ID, optional repeat iteration, stable equal-time order, and an optional serializable payload (`x`, `y`, `button`, and `key`). The compiler treats the supplied array as immutable input. Invalid non-finite times are ignored. Events are ordered by time, explicit order, then input order, so the same time and trace always produce the same RGBA result.
+
+Supported eventbase names are `activate`, `blur`, `click`, `focus`, `focusin`, `focusout`, `mousedown`, `mouseenter`, `mouseleave`, `mouseout`, `mouseover`, `mouseup`, `pointerdown`, and `pointerup`. Unqualified eventbase references target the animation target. `id.beginEvent`, `id.endEvent`, and `id.repeatEvent` are deterministic lifecycle aliases. Unknown events and missing or duplicate target IDs produce structured diagnostics; strict conversion rejects them.
+
+## Production interaction adapters
+
+Generated views map authored event dependencies onto native SwiftUI gestures, hover, focus, and accessibility default actions. Adapters are attached to the resolved SVG target after group, transform, clip, and `<use>` expansion. `pointer-events="none"` disables hit testing. Eventless documents do not gain gesture state or hit-testing modifiers.
+
+The exact-time initializer is the test and replay API. `View()` uses the normal document clock and records native interactions at the sampled document time. Scene deactivation pauses that clock and resume does not jump. Recreating the view resets its clock and interaction trace; callers can force a reset with normal SwiftUI identity, such as `.id(resetToken)`. A supplied trace remains caller-owned and unchanged.
+
+Reduced Motion preserves authored timing by default. `respectsReducedMotion: true` opts into the existing time-zero production rendering; explicit document-time and event-trace evaluation stays exact.
+
+## `<discard>`
+
+`<discard>` is a timed, permanent removal of its resolved render target. Before the selected begin instant the target renders normally. At and after the instant it is absent from painting, resource consumers, accessibility, and later native event targeting. Begin lists, eventbase timing, syncbase dependencies, repeat/restart interval construction, transforms, clips, groups, and `<use>` targets share the same pure timing evaluator.
+
+The macOS comparison fixture supplies the same serialized click trace to WebKit and generated Swift, then compares lossless frames before and after removal. WebKit does not implement SVG2 `<discard>`, so that fixture includes an equivalent SMIL `display="none"` assertion solely to keep WebKit a visual oracle; independent pure tests assert the exact `<discard>` boundary.
+
+Nested external SVG documents own separate clocks and traces. Browser scripting and payload-dependent DOM behavior remain outside the native SwiftUI profile.

--- a/packages/svg-to-swiftui-core/docs/smil-timing.md
+++ b/packages/svg-to-swiftui-core/docs/smil-timing.md
@@ -10,13 +10,16 @@ The implementation follows the W3C [SMIL timing model](https://www.w3.org/TR/SMI
 - semicolon-separated `begin` and `end` lists
 - syncbase `id.begin` and `id.end` references with offsets
 - `id.repeat(n)` references
-- deterministic eventbase references supplied as `{ time, targetId, name, order }`
+- deterministic eventbase references supplied as `{ time, targetId, name, order, payload }`
+- lifecycle aliases `id.beginEvent`, `id.endEvent`, and `id.repeatEvent`
 - finite or indefinite `dur`, `repeatCount`, and `repeatDur`
 - `min`, `max`, `restart="always|whenNotActive|never"`, and `fill="remove|freeze"`
 
 The sample reports inactive, active, frozen, or completed state; simple time and progress; active/simple duration; repeat iteration; exact begin/end/repeat boundaries; selected begin; and the effective interval. Equal timestamps use dependency order, document order, then event input order.
 
 Dependency cycles and missing references remain unresolved and produce source-located diagnostics. They never recurse at runtime.
+
+Supported native events, production adapters, ordering, and `<discard>` removal are specified in the [event timing and discard contract](event-timing-discard.md).
 
 ## Deterministic fallbacks
 

--- a/packages/svg-to-swiftui-core/src/index.ts
+++ b/packages/svg-to-swiftui-core/src/index.ts
@@ -75,7 +75,9 @@ export type {
 export {
   computeSMILActiveDuration,
   computeSMILRepeatingDuration,
+  normalizeDeterministicTimingEvents,
   resolveSMILIntervals,
+  sampleDiscardedTargets,
   sampleSMILProgram,
   sampleSMILTiming,
 } from "./renderTree/smilTiming";

--- a/packages/svg-to-swiftui-core/src/renderTree/animation.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/animation.ts
@@ -33,6 +33,7 @@ export type AnimationTime =
   | { type: "offset"; seconds: number }
   | { type: "syncbase"; animationId: string; phase: "begin" | "end"; offsetSeconds: number }
   | { type: "repeat"; animationId: string; iteration: number; offsetSeconds: number }
+  | { type: "repeatEvent"; animationId: string; offsetSeconds: number }
   | { type: "event"; targetId?: string; event: string; offsetSeconds: number }
   | { type: "accessKey"; key: string; offsetSeconds: number }
   | { type: "wallclock"; value: string }
@@ -134,6 +135,25 @@ const ANIMATION_TAGS = new Map<string, AnimationKind>([
   ["discard", "discard"],
 ]);
 
+export const SUPPORTED_ANIMATION_EVENTS = [
+  "activate",
+  "blur",
+  "click",
+  "focus",
+  "focusin",
+  "focusout",
+  "mousedown",
+  "mouseenter",
+  "mouseleave",
+  "mouseout",
+  "mouseover",
+  "mouseup",
+  "pointerdown",
+  "pointerup",
+] as const;
+
+const SUPPORTED_ANIMATION_EVENT_SET = new Set<string>(SUPPORTED_ANIMATION_EVENTS);
+
 function children(element: ElementNode): ElementNode[] {
   return element.children.filter(
     (child): child is ElementNode => typeof child !== "string" && child.type === "element",
@@ -220,6 +240,20 @@ function parseTime(raw: string): AnimationTime {
           phase: reference[2]!.toLowerCase() as "begin" | "end",
           offsetSeconds: parsedOffset,
         };
+  }
+  const lifecycle = /^([\w:.-]+)\.(beginEvent|endEvent|repeatEvent)([+-].+)?$/i.exec(value);
+  if (lifecycle) {
+    const parsedOffset = lifecycle[3] ? parseClock(lifecycle[3]) : 0;
+    if (parsedOffset === undefined) return { type: "invalid", syntax: value };
+    const eventName = lifecycle[2]!.toLowerCase();
+    if (eventName === "repeatevent")
+      return { type: "repeatEvent", animationId: lifecycle[1]!, offsetSeconds: parsedOffset };
+    return {
+      type: "syncbase",
+      animationId: lifecycle[1]!,
+      phase: eventName === "beginevent" ? "begin" : "end",
+      offsetSeconds: parsedOffset,
+    };
   }
   const event = /^(?:([\w:.-]+)\.)?([a-z][\w-]*)([+-].+)?$/i.exec(value);
   if (event) {
@@ -393,6 +427,16 @@ function parseValue(
 }
 
 function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSupport">): boolean {
+  const deterministicTime = (time: AnimationTime) =>
+    ["offset", "syncbase", "repeat", "repeatEvent", "event", "indefinite"].includes(time.type) &&
+    (time.type !== "event" || SUPPORTED_ANIMATION_EVENT_SET.has(time.event.toLowerCase()));
+  if (definition.kind === "discard")
+    return (
+      !!definition.target?.renderable &&
+      definition.target.binding === "render-node" &&
+      definition.timing.begin.every(deterministicTime) &&
+      definition.timing.end.every(deterministicTime)
+    );
   if (
     !(["animate", "set", "animateTransform", "animateMotion", "cssAnimation"] as AnimationKind[]).includes(
       definition.kind,
@@ -426,7 +470,6 @@ function isRuntimeSupported(definition: Omit<AnimationDefinition, "runtimeSuppor
       (!Number.isFinite(definition.timing.duration.seconds) || definition.timing.duration.seconds < 0))
   )
     return false;
-  const deterministicTime = (time: AnimationTime) => ["offset", "syncbase", "repeat", "indefinite"].includes(time.type);
   if (!definition.timing.begin.every(deterministicTime) || !definition.timing.end.every(deterministicTime))
     return false;
   if (
@@ -747,8 +790,8 @@ export function buildAnimationProgram(
     if (parsedMotion) diagnostics.push(...parsedMotion.diagnostics);
     const dependencies = [...timing.begin, ...timing.end]
       .filter(
-        (time): time is Extract<AnimationTime, { type: "syncbase" | "repeat" }> =>
-          time.type === "syncbase" || time.type === "repeat",
+        (time): time is Extract<AnimationTime, { type: "syncbase" | "repeat" | "repeatEvent" }> =>
+          time.type === "syncbase" || time.type === "repeat" || time.type === "repeatEvent",
       )
       .map((time) => time.animationId);
     const baseDefinition = {
@@ -769,7 +812,11 @@ export function buildAnimationProgram(
       dependencies,
     };
     let runtimeSupport: AnimationDefinition["runtimeSupport"] = target ? "pending" : "invalid";
-    if (isRuntimeSupported(baseDefinition)) runtimeSupport = "typed";
+    const eventSourcesAvailable = [...timing.begin, ...timing.end].every(
+      (time) =>
+        time.type !== "event" || !time.targetId || (!duplicateIds.has(time.targetId) && definitions.has(time.targetId)),
+    );
+    if (eventSourcesAvailable && isRuntimeSupported(baseDefinition)) runtimeSupport = "typed";
     const definition: AnimationDefinition = { ...baseDefinition, runtimeSupport };
     animations.push(definition);
 
@@ -845,6 +892,26 @@ export function buildAnimationProgram(
           "accessKey timing has no deterministic native input mapping; the instance remains unresolved.",
           timing.begin.includes(time) ? "begin" : "end",
         );
+      if (time.type === "event") {
+        if (!SUPPORTED_ANIMATION_EVENT_SET.has(time.event.toLowerCase()))
+          diagnostic(
+            diagnostics,
+            element,
+            "unsupported-animation-event",
+            `Event '${time.event}' has no deterministic native adapter; the timing instance remains unresolved.`,
+            timing.begin.includes(time) ? "begin" : "end",
+          );
+        if (time.targetId && (duplicateIds.has(time.targetId) || !definitions.has(time.targetId)))
+          diagnostic(
+            diagnostics,
+            element,
+            duplicateIds.has(time.targetId) ? "ambiguous-animation-event-target" : "missing-animation-event-target",
+            duplicateIds.has(time.targetId)
+              ? `Event target #${time.targetId} is ambiguous because that id is duplicated.`
+              : `Event target #${time.targetId} does not exist.`,
+            timing.begin.includes(time) ? "begin" : "end",
+          );
+      }
     }
     if (timing.repeatCount.type === "count" && !Number.isFinite(timing.repeatCount.value))
       diagnostic(
@@ -928,7 +995,7 @@ export function buildAnimationProgram(
         );
       }
     }
-    if (value.family === "unsupported" && kind !== "animateMotion")
+    if (value.family === "unsupported" && kind !== "animateMotion" && kind !== "discard")
       diagnostic(
         diagnostics,
         element,

--- a/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/generateSwiftUI.ts
@@ -6,7 +6,7 @@ import { createFunctionTemplate, createStructTemplate } from "../templates";
 import { IDENTITY_TRANSFORM, multiplyTransforms, wrapWithTransform } from "../transformUtils";
 import type { SVGElementProperties, SwiftUIGeneratorConfig, TranspilerOptions, ViewBoxData } from "../types";
 import { viewBoxTransform } from "../viewports";
-import type { AnimationDefinition } from "./animation";
+import type { AnimationDefinition, AnimationTime } from "./animation";
 import {
   addAnimationValues,
   animationAttributeSpec,
@@ -18,7 +18,12 @@ import {
 import { objectBoundingBox, renderNodeBounds } from "./bounds";
 import { type ResolvedGradient, resolveGradientForShape } from "./gradients";
 import { type ResolvedPattern, resolvePatternForShape } from "./patterns";
-import { computeSMILRepeatingDuration, type SMILTimingInterval, sampleSMILProgram } from "./smilTiming";
+import {
+  computeSMILActiveDuration,
+  computeSMILRepeatingDuration,
+  type SMILTimingInterval,
+  sampleSMILProgram,
+} from "./smilTiming";
 import type {
   AccessibilityMetadata,
   ClipPathInstance,
@@ -110,6 +115,7 @@ type GeneratedViewNode =
       animationOffsetY?: string;
       presentationCondition?: string;
       animationTransform?: string;
+      interaction?: { targetId: string; events: readonly string[]; pointerEvents: string };
     };
 
 interface GeneratedMask {
@@ -182,6 +188,7 @@ interface ViewBuildContext {
       }>;
     }>;
     animated: boolean;
+    eventDriven?: boolean;
   }>;
   imageHelpers: Array<{
     name: string;
@@ -191,12 +198,54 @@ interface ViewBuildContext {
     subdocumentAnimated?: boolean;
     animated?: boolean;
     transformExpression?: string;
+    eventDriven?: boolean;
   }>;
   filterImageHelpers: FilterImageHelper[];
   subdocuments: string[][];
   rootName: string;
   config: SwiftUIGeneratorConfig;
   animationIntervals: ReadonlyMap<string, readonly SMILTimingInterval[]>;
+  dynamicTimingIds: ReadonlySet<string>;
+  eventTargets: ReadonlyMap<string, readonly string[]>;
+}
+
+function dynamicTimingIds(document: RenderDocument): ReadonlySet<string> {
+  const dynamic = new Set(
+    document.animationProgram.animations
+      .filter(
+        (animation) =>
+          animation.runtimeSupport === "typed" &&
+          [...animation.timing.begin, ...animation.timing.end].some((time) => time.type === "event"),
+      )
+      .map((animation) => animation.stableId),
+  );
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const animation of document.animationProgram.animations) {
+      if (dynamic.has(animation.stableId) || !animation.dependencies.some((dependency) => dynamic.has(dependency)))
+        continue;
+      dynamic.add(animation.stableId);
+      changed = true;
+    }
+  }
+  return dynamic;
+}
+
+function animationEventTargets(document: RenderDocument): ReadonlyMap<string, readonly string[]> {
+  const targets = new Map<string, Set<string>>();
+  for (const animation of document.animationProgram.animations) {
+    if (animation.runtimeSupport !== "typed") continue;
+    for (const time of [...animation.timing.begin, ...animation.timing.end]) {
+      if (time.type !== "event") continue;
+      const targetId = time.targetId ?? animation.target?.source.id ?? animation.target?.key;
+      if (!targetId) continue;
+      const events = targets.get(targetId) ?? new Set<string>();
+      events.add(time.event.toLowerCase());
+      targets.set(targetId, events);
+    }
+  }
+  return new Map([...targets].map(([target, events]) => [target, [...events].sort()]));
 }
 
 function createOptions(
@@ -365,7 +414,7 @@ function addHelper(context: ViewBuildContext, name: string, lines: string[]): st
 
 function addAnimatedHelper(context: ViewBuildContext, name: string, lines: string[]): string {
   context.helpers.push({ name, lines, animated: true });
-  return `${name}(documentTime: documentTime)`;
+  return `${name}(documentTime: documentTime${context.dynamicTimingIds.size > 0 ? ", animationIntervals: animationIntervals" : ""})`;
 }
 
 function shapeHelperCall(helper: string): string {
@@ -415,6 +464,15 @@ function buildViewNodes(
             candidate.attributeName === attributeName,
         )
       : [];
+
+  const intervalLiteral = (animation: AnimationDefinition): string => {
+    if (context.dynamicTimingIds.has(animation.stableId))
+      return `animationIntervals[${swiftString(animation.stableId)}] ?? []`;
+    const intervals = context.animationIntervals.get(animation.stableId) ?? [];
+    return `[${intervals
+      .map((interval) => `(begin: ${swiftDuration(interval.begin)}, end: ${swiftDuration(interval.end)})`)
+      .join(", ")}]`;
+  };
 
   const ownedAnimationsFor = (node: RenderNode, attributeName: string) => {
     const direct = directAnimationsFor(node, attributeName);
@@ -521,10 +579,6 @@ function buildViewNodes(
         expression = `${context.rootName}.svgCSSAnimatedValue(documentTime: documentTime, duration: ${swiftDuration(css.duration)}, delay: ${swiftDuration(css.delay)}, iterationCount: ${iterationCount}, direction: .${css.direction.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase())}, fillMode: .${css.fillMode}, playState: .${css.playState}, values: [${authoredValues.map((value) => swiftAnimationValueLiteral(value, context.precision, `${context.rootName}.`)).join(", ")}], keyTimes: [${keyTimes}], timingFunctions: [${css.segmentTimingFunctions.map(cssTimingLiteral).join(", ")}], clamp: .${clampMode}, underlying: ${expression})`;
         continue;
       }
-      const intervals = context.animationIntervals.get(animation.stableId) ?? [];
-      const intervalLiteral = intervals
-        .map((interval) => `(begin: ${swiftDuration(interval.begin)}, end: ${swiftDuration(interval.end)})`)
-        .join(", ");
       const duration =
         animation.timing.duration.type === "seconds" ? animation.timing.duration.seconds : Number.POSITIVE_INFINITY;
       const repeatingDuration = computeSMILRepeatingDuration(animation.timing);
@@ -536,7 +590,7 @@ function buildViewNodes(
               `(x1: ${formatNumber(spline.x1)}, y1: ${formatNumber(spline.y1)}, x2: ${formatNumber(spline.x2)}, y2: ${formatNumber(spline.y2)})`,
           )
           .join(", ") ?? "";
-      expression = `${context.rootName}.svgAnimatedValue(documentTime: documentTime, intervals: [${intervalLiteral}], duration: ${swiftDuration(duration)}, repeatingDuration: ${swiftDuration(repeatingDuration)}, values: [${authoredValues.map((value) => swiftAnimationValueLiteral(value, context.precision, `${context.rootName}.`)).join(", ")}], form: .${form.replace(/-/g, "")}, calcMode: .${animation.kind === "set" ? "discrete" : animation.composition.calcMode}, keyTimes: [${keyTimes}], keySplines: [${keySplines}], additive: ${animation.composition.additive === "sum" || set.form === "by" ? "true" : "false"}, accumulate: ${animation.composition.accumulate === "sum" ? "true" : "false"}, clamp: .${clampMode}, underlying: ${expression}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"})`;
+      expression = `${context.rootName}.svgAnimatedValue(documentTime: documentTime, intervals: ${intervalLiteral(animation)}, duration: ${swiftDuration(duration)}, repeatingDuration: ${swiftDuration(repeatingDuration)}, values: [${authoredValues.map((value) => swiftAnimationValueLiteral(value, context.precision, `${context.rootName}.`)).join(", ")}], form: .${form.replace(/-/g, "")}, calcMode: .${animation.kind === "set" ? "discrete" : animation.composition.calcMode}, keyTimes: [${keyTimes}], keySplines: [${keySplines}], additive: ${animation.composition.additive === "sum" || set.form === "by" ? "true" : "false"}, accumulate: ${animation.composition.accumulate === "sum" ? "true" : "false"}, clamp: .${clampMode}, underlying: ${expression}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"})`;
     }
     return expression;
   };
@@ -554,10 +608,6 @@ function buildViewNodes(
     for (const animation of animations) {
       const motion = animation.motion;
       if (!motion) continue;
-      const intervals = context.animationIntervals.get(animation.stableId) ?? [];
-      const intervalLiteral = intervals
-        .map((interval) => `(begin: ${swiftDuration(interval.begin)}, end: ${swiftDuration(interval.end)})`)
-        .join(", ");
       const duration =
         animation.timing.duration.type === "seconds" ? animation.timing.duration.seconds : Number.POSITIVE_INFINITY;
       const repeatingDuration = computeSMILRepeatingDuration(animation.timing);
@@ -581,7 +631,7 @@ function buildViewNodes(
           .join(", ") ?? "";
       const rotateMode = motion.rotate.type === "auto" ? (motion.rotate.reverse ? "autoReverse" : "auto") : "angle";
       const angle = motion.rotate.type === "angle" ? motion.rotate.degrees : 0;
-      expression = `${context.rootName}.svgAnimatedMotion(documentTime: documentTime, intervals: [${intervalLiteral}], duration: ${swiftDuration(duration)}, repeatingDuration: ${swiftDuration(repeatingDuration)}, points: [${points}], length: ${formatNumber(motion.length)}, pathPoints: [${pathPoints}], rotate: .${rotateMode}, angle: ${formatNumber(angle)}, calcMode: .${animation.composition.calcMode}, keyTimes: [${keyTimes}], keyPoints: [${keyPoints}], keySplines: [${keySplines}], additive: ${animation.composition.additive === "sum" ? "true" : "false"}, accumulate: ${animation.composition.accumulate === "sum" ? "true" : "false"}, underlying: ${expression}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"})`;
+      expression = `${context.rootName}.svgAnimatedMotion(documentTime: documentTime, intervals: ${intervalLiteral(animation)}, duration: ${swiftDuration(duration)}, repeatingDuration: ${swiftDuration(repeatingDuration)}, points: [${points}], length: ${formatNumber(motion.length)}, pathPoints: [${pathPoints}], rotate: .${rotateMode}, angle: ${formatNumber(angle)}, calcMode: .${animation.composition.calcMode}, keyTimes: [${keyTimes}], keyPoints: [${keyPoints}], keySplines: [${keySplines}], additive: ${animation.composition.additive === "sum" ? "true" : "false"}, accumulate: ${animation.composition.accumulate === "sum" ? "true" : "false"}, underlying: ${expression}, freeze: ${animation.timing.fill === "freeze" ? "true" : "false"})`;
     }
     return expression === "CGAffineTransform.identity" ? undefined : expression;
   };
@@ -916,8 +966,35 @@ function buildViewNodes(
     const conditions = [
       ...(display ? [`${display} != "none"`] : []),
       ...(visibility ? [`${visibility} != "hidden" && ${visibility} != "collapse"`] : []),
+      ...context.document.animationProgram.animations
+        .filter(
+          (animation) =>
+            animation.kind === "discard" &&
+            animation.runtimeSupport === "typed" &&
+            animation.target?.key === node.animationTargetKey,
+        )
+        .map(
+          (animation) =>
+            `!${context.rootName}.svgIsDiscarded(documentTime: documentTime, intervals: ${intervalLiteral(animation)})`,
+        ),
     ];
     return conditions.length > 0 ? conditions.join(" && ") : undefined;
+  };
+
+  const interaction = (
+    node: RenderNode,
+  ): { targetId: string; events: readonly string[]; pointerEvents: string } | undefined => {
+    const identifiers = [node.source.id, node.animationTargetKey].filter((value): value is string => !!value);
+    for (const targetId of identifiers) {
+      const events = context.eventTargets.get(targetId);
+      if (events?.length)
+        return {
+          targetId,
+          events,
+          pointerEvents: String(node.style.presentation["pointer-events"] ?? "visiblePainted"),
+        };
+    }
+    return undefined;
   };
 
   const opacityExpression = (node: RenderNode): number | string =>
@@ -2135,6 +2212,7 @@ function buildViewNodes(
           ...(mask ? { mask } : {}),
           ...(filter ? { filter } : {}),
           ...(node.accessibility ? { accessibility: node.accessibility } : {}),
+          ...(interaction(node) ? { interaction: interaction(node) } : {}),
           ...(presentationCondition(node) ? { presentationCondition: presentationCondition(node) } : {}),
           ...(animationTransform ? { animationTransform } : {}),
         });
@@ -2293,6 +2371,7 @@ function buildViewNodes(
         ...(wordSpacing ? { wordSpacing } : {}),
         chunks: textChunks,
         animated: textAnimated,
+        ...(context.dynamicTimingIds.size > 0 ? { eventDriven: true } : {}),
       });
       const targetTransforms = [...ancestorTransforms, node.transform];
       const animationTransform = transformCorrectionExpression(node, ancestorTransforms);
@@ -2301,7 +2380,14 @@ function buildViewNodes(
       const filter = buildFilter(node.filter, targetTransforms, node);
       generated.push({
         type: "group",
-        children: [{ type: "text", helper: textAnimated ? `${name}(documentTime: documentTime)` : name }],
+        children: [
+          {
+            type: "text",
+            helper: textAnimated
+              ? `${name}(documentTime: documentTime${context.dynamicTimingIds.size > 0 ? ", animationIntervals: animationIntervals" : ""})`
+              : name,
+          },
+        ],
         opacity: opacityExpression(node),
         isolated:
           opacityExpression(node) !== 1 ||
@@ -2315,6 +2401,7 @@ function buildViewNodes(
         ...(mask ? { mask } : {}),
         ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
+        ...(interaction(node) ? { interaction: interaction(node) } : {}),
         ...(animationOffset(node, ["x", "dx"], [node.attributes.x ?? 0, node.attributes.dx ?? 0])
           ? { animationOffsetX: animationOffset(node, ["x", "dx"], [node.attributes.x ?? 0, node.attributes.dx ?? 0]) }
           : {}),
@@ -2390,6 +2477,7 @@ function buildViewNodes(
         ...(animatedSubdocument ? { subdocumentAnimated: true } : {}),
         ...(imageAnimated ? { animated: true } : {}),
         ...(transformExpression ? { transformExpression } : {}),
+        ...(context.dynamicTimingIds.size > 0 ? { eventDriven: true } : {}),
       });
       const targetTransforms = [...ancestorTransforms, node.transform];
       const animationTransform = transformCorrectionExpression(node, ancestorTransforms);
@@ -2398,7 +2486,14 @@ function buildViewNodes(
       const filter = buildFilter(node.filter, targetTransforms, node);
       generated.push({
         type: "group",
-        children: [{ type: "image", helper: imageAnimated ? `${name}(documentTime: documentTime)` : name }],
+        children: [
+          {
+            type: "image",
+            helper: imageAnimated
+              ? `${name}(documentTime: documentTime${context.dynamicTimingIds.size > 0 ? ", animationIntervals: animationIntervals" : ""})`
+              : name,
+          },
+        ],
         opacity: opacityExpression(node),
         isolated:
           opacityExpression(node) !== 1 ||
@@ -2412,6 +2507,7 @@ function buildViewNodes(
         ...(mask ? { mask } : {}),
         ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
+        ...(interaction(node) ? { interaction: interaction(node) } : {}),
         ...(presentationCondition(node) ? { presentationCondition: presentationCondition(node) } : {}),
         ...(animationTransform ? { animationTransform } : {}),
       });
@@ -2619,6 +2715,7 @@ function buildViewNodes(
         ...(mask ? { mask } : {}),
         ...(filter ? { filter } : {}),
         ...(node.accessibility ? { accessibility: node.accessibility } : {}),
+        ...(interaction(node) ? { interaction: interaction(node) } : {}),
         ...(presentationCondition(node) ? { presentationCondition: presentationCondition(node) } : {}),
         ...(animationTransform ? { animationTransform } : {}),
       });
@@ -2867,6 +2964,9 @@ function createTextHelper(
     "// CoreText glyph paths preserve SVG metrics; accessibility text is retained, but selection is unavailable.",
     `private struct ${helper.name}: View {`,
     ...(helper.animated ? [`${indentation}let documentTime: Double`, ""] : []),
+    ...(helper.animated && helper.eventDriven
+      ? [`${indentation}let animationIntervals: [String: [(begin: Double, end: Double)]]`, ""]
+      : []),
     `${indentation}var body: some View {`,
     `${i2}Canvas { context, size in`,
     `${i3}context.withCGContext { graphics in`,
@@ -3787,6 +3887,55 @@ function renderViewNode(node: GeneratedViewNode, level: number, indentation: str
   if (node.animationOffsetX) lines.push(`${prefix}.offset(x: ${node.animationOffsetX})`);
   if (node.animationOffsetY) lines.push(`${prefix}.offset(y: ${node.animationOffsetY})`);
   if (node.animationTransform) lines.push(`${prefix}.transformEffect(${node.animationTransform})`);
+  if (node.interaction) {
+    const { targetId, events, pointerEvents } = node.interaction;
+    const tap = events.filter((event) => event === "click" || event === "activate");
+    const hoverIn = events.filter((event) => event === "mouseover" || event === "mouseenter");
+    const hoverOut = events.filter((event) => event === "mouseout" || event === "mouseleave");
+    const focusIn = events.filter((event) => event === "focus" || event === "focusin");
+    const focusOut = events.filter((event) => event === "blur" || event === "focusout");
+    const pointerDown = events.filter((event) => event === "mousedown" || event === "pointerdown");
+    const pointerUp = events.filter((event) => event === "mouseup" || event === "pointerup");
+    const record = (event: string, depth: number) =>
+      `${prefix}${indentation.repeat(depth)}recordAnimationEvent(name: ${swiftString(event)}, targetID: ${swiftString(targetId)}, documentTime: documentTime)`;
+    if (tap.length > 0) {
+      lines.push(`${prefix}.onTapGesture {`);
+      for (const event of tap) lines.push(record(event, 1));
+      lines.push(`${prefix}}`);
+    }
+    if (hoverIn.length + hoverOut.length > 0) {
+      lines.push(`${prefix}.onHover { hovering in`, `${prefix}${indentation}if hovering {`);
+      for (const event of hoverIn) lines.push(record(event, 2));
+      lines.push(`${prefix}${indentation}} else {`);
+      for (const event of hoverOut) lines.push(record(event, 2));
+      lines.push(`${prefix}${indentation}}`, `${prefix}}`);
+    }
+    if (focusIn.length + focusOut.length > 0) {
+      lines.push(`${prefix}.modifier(SVGFocusEventModifier { focused in`, `${prefix}${indentation}if focused {`);
+      for (const event of focusIn) lines.push(record(event, 2));
+      lines.push(`${prefix}${indentation}} else {`);
+      for (const event of focusOut) lines.push(record(event, 2));
+      lines.push(`${prefix}${indentation}}`, `${prefix}})`);
+    }
+    if (pointerDown.length + pointerUp.length > 0) {
+      const down = `[${pointerDown.map(swiftString).join(", ")}]`;
+      const up = `[${pointerUp.map(swiftString).join(", ")}]`;
+      lines.push(
+        `${prefix}.simultaneousGesture(`,
+        `${prefix}${indentation}DragGesture(minimumDistance: 0)`,
+        `${prefix}${indentation}${indentation}.onChanged { _ in recordPointerTransition(targetID: ${swiftString(targetId)}, names: ${down}, active: true, documentTime: documentTime) }`,
+        `${prefix}${indentation}${indentation}.onEnded { _ in recordPointerTransition(targetID: ${swiftString(targetId)}, names: ${up}, active: false, documentTime: documentTime) }`,
+        `${prefix})`,
+      );
+    }
+    if (events.includes("activate")) {
+      lines.push(
+        `${prefix}.accessibilityAddTraits(.isButton)`,
+        `${prefix}.accessibilityAction(.default) { recordAnimationEvent(name: "activate", targetID: ${swiftString(targetId)}, documentTime: documentTime) }`,
+      );
+    }
+    if (pointerEvents.toLowerCase() === "none") lines.push(`${prefix}.allowsHitTesting(false)`);
+  }
   appendAccessibilityModifiers(lines, node.accessibility, prefix);
   return lines;
 }
@@ -5034,6 +5183,130 @@ function base64(bytes: Uint8Array): string {
   return result;
 }
 
+function eventTimingSupport(document: RenderDocument, indentationSize: number): string[] {
+  const dynamic = dynamicTimingIds(document);
+  if (dynamic.size === 0) return [];
+  const indentation = " ".repeat(indentationSize);
+  const staticIntervals = sampleSMILProgram(document.animationProgram, 0).intervals;
+  const definitions = new Map(document.animationProgram.animations.map((animation) => [animation.stableId, animation]));
+  const referencedDuration = (id: string): number => {
+    const duration = definitions.get(id)?.timing.duration;
+    return duration?.type === "seconds" ? duration.seconds : Number.POSITIVE_INFINITY;
+  };
+  const source = (time: AnimationTime, animation: AnimationDefinition): string => {
+    if (time.type === "offset") return `[${swiftDuration(time.seconds)}]`;
+    if (time.type === "syncbase")
+      return `svgSyncbaseTimes(animationIntervals[${swiftString(time.animationId)}] ?? [], useEnd: ${time.phase === "end"}, offset: ${swiftDuration(time.offsetSeconds)})`;
+    if (time.type === "repeat")
+      return `svgRepeatTimes(animationIntervals[${swiftString(time.animationId)}] ?? [], duration: ${swiftDuration(referencedDuration(time.animationId))}, iteration: ${time.iteration}, offset: ${swiftDuration(time.offsetSeconds)})`;
+    if (time.type === "repeatEvent")
+      return `svgRepeatEventTimes(animationIntervals[${swiftString(time.animationId)}] ?? [], duration: ${swiftDuration(referencedDuration(time.animationId))}, offset: ${swiftDuration(time.offsetSeconds)})`;
+    if (time.type === "event") {
+      const targetId = time.targetId ?? animation.target?.source.id ?? animation.target?.key;
+      return `svgEventTimes(events, name: ${swiftString(time.event.toLowerCase())}, targetID: ${targetId ? swiftString(targetId) : "nil"}, allowUntargeted: ${time.targetId === undefined}, offset: ${swiftDuration(time.offsetSeconds)})`;
+    }
+    return "[]";
+  };
+  const list = (times: readonly AnimationTime[], animation: AnimationDefinition) =>
+    times.length === 0 ? "[]" : times.map((time) => source(time, animation)).join(" + ");
+  const initial = document.animationProgram.animations
+    .filter((animation) => !dynamic.has(animation.stableId))
+    .map((animation) => {
+      const intervals = staticIntervals.get(animation.stableId) ?? [];
+      return `${indentation}${swiftString(animation.stableId)}: [${intervals
+        .map((interval) => `(begin: ${swiftDuration(interval.begin)}, end: ${swiftDuration(interval.end)})`)
+        .join(", ")}]`;
+    })
+    .join(`,\n`);
+  const assignments = document.animationProgram.evaluationOrder.flatMap((id) => {
+    if (!dynamic.has(id)) return [];
+    const animation = definitions.get(id);
+    if (!animation) return [];
+    return [
+      `${indentation}animationIntervals[${swiftString(id)}] = svgResolveIntervals(beginInstances: ${list(animation.timing.begin, animation)}, endInstances: ${list(animation.timing.end, animation)}, activeDuration: ${swiftDuration(computeSMILActiveDuration(animation.timing))}, restart: .${animation.timing.restart})`,
+    ];
+  });
+  return [
+    "struct SVGAnimationEvent: Hashable, Codable, Sendable {",
+    `${indentation}struct Payload: Hashable, Codable, Sendable {`,
+    `${indentation}${indentation}var x: Double?`,
+    `${indentation}${indentation}var y: Double?`,
+    `${indentation}${indentation}var button: Int?`,
+    `${indentation}${indentation}var key: String?`,
+    `${indentation}${indentation}init(x: Double? = nil, y: Double? = nil, button: Int? = nil, key: String? = nil) { self.x = x; self.y = y; self.button = button; self.key = key }`,
+    `${indentation}}`,
+    `${indentation}var time: Double`,
+    `${indentation}var name: String`,
+    `${indentation}var targetID: String?`,
+    `${indentation}var repeatIteration: Int?`,
+    `${indentation}var order: Int?`,
+    `${indentation}var payload: Payload?`,
+    `${indentation}init(time: Double, name: String, targetID: String? = nil, repeatIteration: Int? = nil, order: Int? = nil, payload: Payload? = nil) { self.time = time; self.name = name; self.targetID = targetID; self.repeatIteration = repeatIteration; self.order = order; self.payload = payload }`,
+    "}",
+    "",
+    "private struct SVGFocusEventModifier: ViewModifier {",
+    `${indentation}@FocusState private var focused: Bool`,
+    `${indentation}let changed: (Bool) -> Void`,
+    `${indentation}init(changed: @escaping (Bool) -> Void) { self.changed = changed }`,
+    `${indentation}func body(content: Content) -> some View {`,
+    `${indentation}${indentation}content.focusable().focused($focused).onChange(of: focused) { changed($0) }`,
+    `${indentation}}`,
+    "}",
+    "",
+    "private enum SVGAnimationRestart: Equatable { case always, whenNotActive, never }",
+    "",
+    "private static func svgAnimationIntervals(events: [SVGAnimationEvent]) -> [String: [(begin: Double, end: Double)]] {",
+    `${indentation}var animationIntervals: [String: [(begin: Double, end: Double)]] = ${initial ? `[\n${initial}\n]` : "[:]"}`,
+    ...assignments,
+    `${indentation}return animationIntervals`,
+    "}",
+    "",
+    "private static func svgEventTimes(_ events: [SVGAnimationEvent], name: String, targetID: String?, allowUntargeted: Bool, offset: Double) -> [Double] {",
+    `${indentation}events.enumerated()`,
+    `${indentation}${indentation}.filter { $0.element.time.isFinite && $0.element.name.lowercased() == name && ($0.element.targetID == targetID || (allowUntargeted && $0.element.targetID == nil)) }`,
+    `${indentation}${indentation}.sorted { left, right in left.element.time != right.element.time ? left.element.time < right.element.time : (left.element.order ?? left.offset) != (right.element.order ?? right.offset) ? (left.element.order ?? left.offset) < (right.element.order ?? right.offset) : left.offset < right.offset }`,
+    `${indentation}${indentation}.map { $0.element.time + offset }`,
+    "}",
+    "",
+    "private static func svgSyncbaseTimes(_ intervals: [(begin: Double, end: Double)], useEnd: Bool, offset: Double) -> [Double] {",
+    `${indentation}intervals.compactMap { let value = (useEnd ? $0.end : $0.begin) + offset; return value.isFinite ? value : nil }`,
+    "}",
+    "",
+    "private static func svgRepeatTimes(_ intervals: [(begin: Double, end: Double)], duration: Double, iteration: Int, offset: Double) -> [Double] {",
+    `${indentation}guard duration.isFinite && duration > 0 && iteration > 0 else { return [] }`,
+    `${indentation}return intervals.compactMap { let value = $0.begin + duration * Double(iteration); return value < $0.end - 0.000000000001 ? value + offset : nil }`,
+    "}",
+    "",
+    "private static func svgRepeatEventTimes(_ intervals: [(begin: Double, end: Double)], duration: Double, offset: Double) -> [Double] {",
+    `${indentation}guard duration.isFinite && duration > 0 else { return [] }`,
+    `${indentation}return intervals.flatMap { interval in`,
+    `${indentation}${indentation}var values: [Double] = []`,
+    `${indentation}${indentation}var iteration = 1`,
+    `${indentation}${indentation}while interval.begin + duration * Double(iteration) < interval.end - 0.000000000001 { values.append(interval.begin + duration * Double(iteration) + offset); iteration += 1 }`,
+    `${indentation}${indentation}return values`,
+    `${indentation}}`,
+    "}",
+    "",
+    "private static func svgResolveIntervals(beginInstances: [Double], endInstances: [Double], activeDuration: Double, restart: SVGAnimationRestart) -> [(begin: Double, end: Double)] {",
+    `${indentation}let begins = Array(Set(beginInstances.filter { $0.isFinite })).sorted()`,
+    `${indentation}let ends = Array(Set(endInstances.filter { $0.isFinite })).sorted()`,
+    `${indentation}var intervals: [(begin: Double, end: Double)] = []`,
+    `${indentation}for begin in begins {`,
+    `${indentation}${indentation}if let previous = intervals.last {`,
+    `${indentation}${indentation}${indentation}if restart == .never { continue }`,
+    `${indentation}${indentation}${indentation}let active = begin < previous.end - 0.000000000001`,
+    `${indentation}${indentation}${indentation}if active && restart == .whenNotActive { continue }`,
+    `${indentation}${indentation}${indentation}if active && restart == .always { intervals[intervals.count - 1].end = begin }`,
+    `${indentation}${indentation}}`,
+    `${indentation}${indentation}let naturalEnd = activeDuration.isFinite ? begin + activeDuration : .infinity`,
+    `${indentation}${indentation}let explicitEnd = ends.first { $0 >= begin - 0.000000000001 } ?? .infinity`,
+    `${indentation}${indentation}intervals.append((begin: begin, end: min(naturalEnd, explicitEnd)))`,
+    `${indentation}}`,
+    `${indentation}return intervals`,
+    "}",
+  ];
+}
+
 function createImageHelper(
   helper: ViewBuildContext["imageHelpers"][number],
   coordinateSpace: ViewBoxData,
@@ -5070,6 +5343,9 @@ function createImageHelper(
   const body: string[] = [
     `private struct ${helper.name}: View {`,
     ...(helper.animated ? [`${indentation}let documentTime: Double`, ""] : []),
+    ...(helper.animated && helper.eventDriven
+      ? [`${indentation}let animationIntervals: [String: [(begin: Double, end: Double)]]`, ""]
+      : []),
     `${indentation}var body: some View {`,
     `${i2}Canvas { context, size in`,
     `${i3}context.clip(to: Path(CGRect(x: ${formatNumber(node.viewport.x)}, y: ${formatNumber(node.viewport.y)}, width: ${formatNumber(node.viewport.width)}, height: ${formatNumber(node.viewport.height)})).applying(${runtimeTransform(helper.transform, coordinateSpace)}))`,
@@ -5311,11 +5587,15 @@ function createView(
   indentationSize: number,
 ): string[] {
   const indentation = " ".repeat(indentationSize);
+  const eventDriven = dynamicTimingIds(document).size > 0;
   const animated =
     document.animationProgram.animations.length > 0 ||
     imageHelpers.some((helper) => helper.animated) ||
     filterImageHelpers.some((helper) => helper.animated);
   const content = [
+    ...(eventDriven
+      ? [`${indentation}let animationIntervals = Self.svgAnimationIntervals(events: animationEvents)`]
+      : []),
     `${indentation}ZStack {`,
     ...nodes.flatMap((node) => renderViewNode(node, 2, indentation)),
     `${indentation}}`,
@@ -5324,28 +5604,41 @@ function createView(
     ? [
         "private let documentTime: Double?",
         "private let respectsReducedMotion: Bool",
+        ...(eventDriven ? ["private let suppliedAnimationEvents: [SVGAnimationEvent]"] : []),
         "@StateObject private var animationClock = AnimationClockState()",
+        ...(eventDriven
+          ? [
+              "@State private var interactionAnimationEvents: [SVGAnimationEvent] = []",
+              "@State private var nextAnimationEventOrder = 0",
+              "@State private var activePointerTargets: Set<String> = []",
+            ]
+          : []),
         "@Environment(\\.scenePhase) private var scenePhase",
         "@Environment(\\.accessibilityReduceMotion) private var reduceMotion",
         "",
-        "init(documentTime: Double? = nil, respectsReducedMotion: Bool = false) {",
+        eventDriven
+          ? "init(documentTime: Double? = nil, animationEvents: [SVGAnimationEvent] = [], respectsReducedMotion: Bool = false) {"
+          : "init(documentTime: Double? = nil, respectsReducedMotion: Bool = false) {",
         `${indentation}self.documentTime = documentTime`,
         `${indentation}self.respectsReducedMotion = respectsReducedMotion`,
+        ...(eventDriven ? [`${indentation}self.suppliedAnimationEvents = animationEvents`] : []),
         "}",
         "",
         "@ViewBuilder",
-        "private func content(at documentTime: Double) -> some View {",
+        eventDriven
+          ? "private func content(at documentTime: Double, animationEvents: [SVGAnimationEvent]) -> some View {"
+          : "private func content(at documentTime: Double) -> some View {",
         ...content,
         "}",
         "",
         "var body: some View {",
         `${indentation}if let documentTime {`,
-        `${indentation}${indentation}content(at: Self.sanitizedDocumentTime(documentTime))`,
+        `${indentation}${indentation}content(at: Self.sanitizedDocumentTime(documentTime)${eventDriven ? ", animationEvents: suppliedAnimationEvents + interactionAnimationEvents" : ""})`,
         `${indentation}} else if respectsReducedMotion && reduceMotion {`,
-        `${indentation}${indentation}content(at: 0)`,
+        `${indentation}${indentation}content(at: 0${eventDriven ? ", animationEvents: suppliedAnimationEvents + interactionAnimationEvents" : ""})`,
         `${indentation}} else {`,
         `${indentation}${indentation}TimelineView(.animation(paused: scenePhase != .active)) { timeline in`,
-        `${indentation}${indentation}${indentation}content(at: animationClock.sample(date: timeline.date, isActive: scenePhase == .active))`,
+        `${indentation}${indentation}${indentation}content(at: animationClock.sample(date: timeline.date, isActive: scenePhase == .active)${eventDriven ? ", animationEvents: suppliedAnimationEvents + interactionAnimationEvents" : ""})`,
         `${indentation}${indentation}}`,
         `${indentation}}`,
         "}",
@@ -5354,6 +5647,37 @@ function createView(
         `${indentation}value.isFinite ? value : 0`,
         "}",
         "",
+        ...(document.animationProgram.animations.some((animation) => animation.kind === "discard")
+          ? [
+              "private static func svgIsDiscarded(documentTime: Double, intervals: [(begin: Double, end: Double)]) -> Bool {",
+              `${indentation}let time = sanitizedDocumentTime(documentTime)`,
+              `${indentation}return intervals.contains { time >= $0.begin }`,
+              "}",
+              "",
+            ]
+          : []),
+        ...(eventDriven
+          ? [
+              "private func recordAnimationEvent(name: String, targetID: String, documentTime: Double) {",
+              `${indentation}let event = SVGAnimationEvent(time: Self.sanitizedDocumentTime(documentTime), name: name.lowercased(), targetID: targetID, order: nextAnimationEventOrder)`,
+              `${indentation}nextAnimationEventOrder += 1`,
+              `${indentation}interactionAnimationEvents.append(event)`,
+              `${indentation}if interactionAnimationEvents.count > 4096 { interactionAnimationEvents.removeFirst(interactionAnimationEvents.count - 4096) }`,
+              "}",
+              "",
+              "private func recordPointerTransition(targetID: String, names: [String], active: Bool, documentTime: Double) {",
+              `${indentation}if active {`,
+              `${indentation}${indentation}guard activePointerTargets.insert(targetID).inserted else { return }`,
+              `${indentation}} else {`,
+              `${indentation}${indentation}guard activePointerTargets.remove(targetID) != nil else { return }`,
+              `${indentation}}`,
+              `${indentation}for name in names { recordAnimationEvent(name: name, targetID: targetID, documentTime: documentTime) }`,
+              "}",
+              "",
+              ...eventTimingSupport(document, indentationSize),
+              "",
+            ]
+          : []),
         "private enum SVGTimingState: Equatable { case inactive, active, frozen, completed }",
         "",
         "private struct SVGTimingSample {",
@@ -5884,7 +6208,18 @@ function createView(
       name: helper.name,
       indent: indentationSize,
       returnType: "Shape",
-      body: helper.animated ? ["let documentTime: Double", "", ...pathFunction] : pathFunction,
+      body: helper.animated
+        ? [
+            "let documentTime: Double",
+            ...(document.animationProgram.animations.some((animation) =>
+              [...animation.timing.begin, ...animation.timing.end].some((time) => time.type === "event"),
+            )
+              ? ["let animationIntervals: [String: [(begin: Double, end: Double)]]"]
+              : []),
+            "",
+            ...pathFunction,
+          ]
+        : pathFunction,
     });
     layerStruct[0] = `private ${layerStruct[0]}`;
     body.push("", ...layerStruct);
@@ -5952,6 +6287,8 @@ export function generateView(
     rootName: config.structName ?? "SVGView",
     config,
     animationIntervals: sampleSMILProgram(document.animationProgram, 0).intervals,
+    dynamicTimingIds: dynamicTimingIds(document),
+    eventTargets: animationEventTargets(document),
   };
   const nodes = buildViewNodes(document.children, context);
   const imports = new Set<string>();

--- a/packages/svg-to-swiftui-core/src/renderTree/smilTiming.ts
+++ b/packages/svg-to-swiftui-core/src/renderTree/smilTiming.ts
@@ -15,6 +15,12 @@ export interface DeterministicTimingEvent {
   repeatIteration?: number;
   /** Stable order for events with the same timestamp. Input order is used by default. */
   order?: number;
+  payload?: {
+    x?: number;
+    y?: number;
+    button?: number;
+    key?: string;
+  };
 }
 
 export type SMILTimingState = "inactive" | "active" | "frozen" | "completed";
@@ -102,6 +108,26 @@ function sortedUnique(values: readonly number[]): number[] {
     .filter((value) => Number.isFinite(value))
     .sort((left, right) => left - right)
     .filter((value, index, array) => index === 0 || !equal(value, array[index - 1]!));
+}
+
+/** Canonical immutable trace order used by every evaluator and test frontend. */
+export function normalizeDeterministicTimingEvents(
+  events: readonly DeterministicTimingEvent[],
+): readonly DeterministicTimingEvent[] {
+  return events
+    .map((event, index) => ({ event, index }))
+    .filter(({ event }) => Number.isFinite(event.time) && event.name.trim().length > 0)
+    .sort(
+      (left, right) =>
+        left.event.time - right.event.time ||
+        (left.event.order ?? left.index) - (right.event.order ?? right.index) ||
+        left.index - right.index,
+    )
+    .map(({ event }) => ({
+      ...event,
+      name: event.name.trim().toLowerCase(),
+      ...(event.targetId === undefined ? {} : { targetId: event.targetId.trim() }),
+    }));
 }
 
 /** Build all deterministic intervals from already-resolved begin/end instance lists. */
@@ -249,11 +275,18 @@ export function sampleSMILTiming(
   };
 }
 
-function eventTimes(time: Extract<AnimationTime, { type: "event" }>, events: readonly DeterministicTimingEvent[]) {
+function eventTimes(
+  time: Extract<AnimationTime, { type: "event" }>,
+  definition: AnimationDefinition,
+  events: readonly DeterministicTimingEvent[],
+) {
+  const targetId = time.targetId ?? definition.target?.source.id ?? definition.target?.key;
   return events
     .map((event, index) => ({ event, index }))
     .filter(
-      ({ event }) => event.name === time.event && (time.targetId === undefined || event.targetId === time.targetId),
+      ({ event }) =>
+        event.name.toLowerCase() === time.event.toLowerCase() &&
+        (event.targetId === targetId || (time.targetId === undefined && event.targetId === undefined)),
     )
     .sort(
       (left, right) =>
@@ -267,6 +300,7 @@ function resolveTimes(
   intervals: ReadonlyMap<string, readonly SMILTimingInterval[]>,
   definitions: ReadonlyMap<string, AnimationDefinition>,
   events: readonly DeterministicTimingEvent[],
+  definition: AnimationDefinition,
 ): { times: number[]; unresolved: boolean } {
   const times: number[] = [];
   let unresolved = false;
@@ -292,8 +326,17 @@ function resolveTimes(
             times.push(repeatTime + value.offsetSeconds);
         }
       }
+    } else if (value.type === "repeatEvent") {
+      const referenced = intervals.get(value.animationId);
+      const referencedDefinition = definitions.get(value.animationId);
+      const duration = referencedDefinition ? simpleDuration(referencedDefinition.timing) : Number.POSITIVE_INFINITY;
+      if (!referenced || !Number.isFinite(duration) || duration <= 0) unresolved = true;
+      else
+        for (const interval of referenced)
+          for (let iteration = 1; interval.begin + duration * iteration < interval.end - EPSILON; iteration++)
+            times.push(interval.begin + duration * iteration + value.offsetSeconds);
     } else if (value.type === "event") {
-      const resolved = eventTimes(value, events);
+      const resolved = eventTimes(value, definition, events);
       if (resolved.length === 0) unresolved = true;
       times.push(...resolved);
     } else if (value.type !== "indefinite") unresolved = true;
@@ -307,6 +350,7 @@ export function sampleSMILProgram(
   documentTime: number,
   events: readonly DeterministicTimingEvent[] = [],
 ): SMILProgramSample {
+  const normalizedEvents = normalizeDeterministicTimingEvents(events);
   const definitions = new Map(program.animations.map((animation) => [animation.stableId, animation]));
   const intervals = new Map<string, readonly SMILTimingInterval[]>();
   const samples = new Map<string, SMILTimingSample>();
@@ -320,8 +364,8 @@ export function sampleSMILProgram(
       samples.set(id, sampleSMILTiming(animation.timing, documentTime, [], [], true));
       continue;
     }
-    const begins = resolveTimes(animation.timing.begin, intervals, definitions, events);
-    const ends = resolveTimes(animation.timing.end, intervals, definitions, events);
+    const begins = resolveTimes(animation.timing.begin, intervals, definitions, normalizedEvents, animation);
+    const ends = resolveTimes(animation.timing.end, intervals, definitions, normalizedEvents, animation);
     const resolved = resolveSMILIntervals(animation.timing, begins.times, ends.times);
     intervals.set(id, resolved);
     samples.set(
@@ -330,4 +374,20 @@ export function sampleSMILProgram(
     );
   }
   return { samples, intervals };
+}
+
+/** Pure timed-removal result used by generators and non-Swift frontends. */
+export function sampleDiscardedTargets(
+  program: AnimationProgram,
+  documentTime: number,
+  events: readonly DeterministicTimingEvent[] = [],
+): ReadonlySet<string> {
+  const sampled = sampleSMILProgram(program, documentTime, events);
+  const targets = new Set<string>();
+  for (const animation of program.animations) {
+    if (animation.kind !== "discard" || animation.runtimeSupport !== "typed" || !animation.target) continue;
+    const intervals = sampled.intervals.get(animation.stableId) ?? [];
+    if (intervals.some((interval) => documentTime >= interval.begin)) targets.add(animation.target.key);
+  }
+  return targets;
 }

--- a/packages/svg-to-swiftui-core/src/tests/smilTiming.test.ts
+++ b/packages/svg-to-swiftui-core/src/tests/smilTiming.test.ts
@@ -6,7 +6,9 @@ import {
   computeSMILActiveDuration,
   convert,
   convertWithDiagnostics,
+  normalizeDeterministicTimingEvents,
   resolveSMILIntervals,
+  sampleDiscardedTargets,
   sampleNumericAnimation,
   sampleSMILProgram,
   sampleSMILTiming,
@@ -83,6 +85,103 @@ describe("SMIL timing syntax and graph", () => {
     expect(result.intervals.get("d")?.[0]?.begin).toBeCloseTo(0.6);
     expect(result.samples.get("b")?.state).toBe("active");
     expect(result.intervals.get("c")).toHaveLength(1);
+  });
+
+  test("normalizes immutable traces and preserves explicit equal-time order", () => {
+    const original = [
+      { time: 1, name: " CLICK ", targetId: " trigger ", order: 2, payload: { button: 0 } },
+      { time: 0.5, name: "focus", targetId: "trigger" },
+      { time: 1, name: "click", targetId: "trigger", order: 1 },
+      { time: Number.NaN, name: "ignored" },
+    ] as const;
+    const normalized = normalizeDeterministicTimingEvents(original);
+
+    expect(normalized).toEqual([
+      { time: 0.5, name: "focus", targetId: "trigger" },
+      { time: 1, name: "click", targetId: "trigger", order: 1 },
+      { time: 1, name: "click", targetId: "trigger", order: 2, payload: { button: 0 } },
+    ]);
+    expect(original[0]!.name).toBe(" CLICK ");
+  });
+
+  test("supports beginEvent, endEvent, and repeatEvent lifecycle aliases", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20"><rect id="box" width="10" height="10"/>
+        <animate id="source" href="#box" attributeName="x" from="0" to="10" begin="click" dur="1s" repeatCount="3"/>
+        <animate id="onBegin" href="#box" attributeName="y" from="0" to="1" begin="source.beginEvent+100ms" dur="1s"/>
+        <animate id="onEnd" href="#box" attributeName="y" from="0" to="1" begin="source.endEvent" dur="1s"/>
+        <animate id="onRepeat" href="#box" attributeName="y" from="0" to="1" begin="source.repeatEvent+50ms" dur="100ms"/>
+      </svg>`);
+    const result = sampleSMILProgram(document.animationProgram, 4, [{ time: 0.25, name: "click" }]);
+
+    expect(result.intervals.get("onBegin")?.[0]?.begin).toBeCloseTo(0.35);
+    expect(result.intervals.get("onEnd")?.[0]?.begin).toBeCloseTo(3.25);
+    expect(result.intervals.get("onRepeat")?.map((interval) => interval.begin)).toEqual([1.3, 2.3]);
+  });
+
+  test("classifies unsupported and unresolved event sources", () => {
+    const source = `<svg viewBox="0 0 10 10"><rect id="box" width="5" height="5"><animate attributeName="x" from="0" to="1" begin="missing.click;box.wheel" dur="1s"/></rect></svg>`;
+    const permissive = convertWithDiagnostics(source);
+    expect(permissive.diagnostics.map((item) => item.code)).toEqual(
+      expect.arrayContaining(["missing-animation-event-target", "unsupported-animation-event"]),
+    );
+    expect(permissive.swift).not.toContain("SVGAnimationEvent");
+    expect(() => convert(source, { strict: true })).toThrow(
+      /(missing-animation-event-target|unsupported-animation-event)/,
+    );
+  });
+
+  test("removes discard targets at exact boundaries from pure event traces", () => {
+    const document = __testing.parseRenderDocument(`
+      <svg viewBox="0 0 20 20"><circle id="trigger" cx="1" cy="1" r="1"/><g id="card" transform="translate(2 2)"><rect width="10" height="10"/></g>
+        <discard id="remove" href="#card" begin="trigger.click+200ms"/>
+      </svg>`);
+    const targetKey = document.animationProgram.animations[0]!.target!.key;
+    const outOfOrderTrace = [
+      { time: 1, name: "click", targetId: "trigger", order: 2 },
+      { time: 0.5, name: "click", targetId: "trigger", order: 1 },
+    ];
+
+    const late = sampleDiscardedTargets(document.animationProgram, 100, outOfOrderTrace);
+    const early = sampleDiscardedTargets(document.animationProgram, 0.699999, outOfOrderTrace);
+    const boundary = sampleDiscardedTargets(document.animationProgram, 0.7, outOfOrderTrace);
+    expect(late).toContain(targetKey);
+    expect(early).not.toContain(targetKey);
+    expect(boundary).toContain(targetKey);
+  });
+
+  test("emits deterministic Swift event input, native adapters, discard, and hit-testing semantics", () => {
+    const swift = convert(`
+      <svg viewBox="0 0 40 20"><defs><clipPath id="clip"><rect width="20" height="20"/></clipPath></defs>
+        <g id="trigger" clip-path="url(#clip)" transform="translate(2 0)" tabindex="0" aria-label="Trigger" pointer-events="none">
+          <rect width="16" height="16"/>
+          <animate attributeName="opacity" from="0" to="1" begin="trigger.click;trigger.focus;trigger.pointerdown;trigger.mouseenter;trigger.activate" dur="1s"/>
+        </g>
+        <discard href="#trigger" begin="trigger.blur+1s"/>
+      </svg>`);
+
+    expect(swift).toContain("struct SVGAnimationEvent: Hashable, Codable, Sendable");
+    expect(swift).toContain("animationEvents: [SVGAnimationEvent] = []");
+    expect(swift).toContain("onTapGesture");
+    expect(swift).toContain("SVGFocusEventModifier");
+    expect(swift).toContain("DragGesture(minimumDistance: 0)");
+    expect(swift).toContain("accessibilityAction(.default)");
+    expect(swift).toContain("allowsHitTesting(false)");
+    expect(swift).toContain("svgIsDiscarded");
+    expect(swift).toContain("@Environment(\\.accessibilityReduceMotion) private var reduceMotion");
+    expect(swift).toContain("content(at: 0, animationEvents: suppliedAnimationEvents + interactionAnimationEvents)");
+    expect(swift).toContain('.accessibilityLabel("Trigger")');
+    expect(swift).not.toContain("evaluateJavaScript");
+  });
+
+  test("leaves eventless generated documents free of interaction state and adapters", () => {
+    const swift = convert(
+      `<svg viewBox="0 0 10 10"><rect width="5" height="5"><animate attributeName="x" from="0" to="5" dur="1s"/></rect></svg>`,
+    );
+    expect(swift).toContain("init(documentTime: Double? = nil, respectsReducedMotion: Bool = false)");
+    expect(swift).not.toContain("SVGAnimationEvent");
+    expect(swift).not.toContain("onTapGesture");
+    expect(swift).not.toContain("allowsHitTesting");
   });
 
   test("terminates dependency cycles as unresolved with stable diagnostics", () => {


### PR DESCRIPTION
Closes #104.

## What changed

- adds immutable, serializable deterministic event traces with stable ordering and supported payloads
- supports eventbase timing, `beginEvent`, `endEvent`, and `repeatEvent` dependencies
- generates native SwiftUI tap, pointer, hover, focus, and accessibility adapters only for event-driven documents
- implements pure timed `<discard>` removal across rendering, accessibility, and later interaction targeting
- diagnoses unsupported events and missing or ambiguous targets without executing authored JavaScript
- sends the same manifest event trace to WebKit and generated Swift in temporal evals
- adds an event/discard comparison fixture and full lifecycle, reduced-motion, accessibility, and boundary documentation

## Validation

- 411 unit tests passed
- lint, typecheck, package build, and manifest verification passed
- full temporal suite: 9 reference probes and 165/165 SwiftUI comparison frames passed
- new event/discard fixture: 10/10 exact frames passed
- repository build passed

The WebKit fixture includes an equivalent SMIL `display="none"` assertion because WebKit does not implement SVG2 `<discard>`; pure tests independently verify `<discard>` before, at, and after its exact boundary.
